### PR TITLE
Null checks for optional parameters 

### DIFF
--- a/tools/Generator/Generator.cs
+++ b/tools/Generator/Generator.cs
@@ -691,6 +691,10 @@ namespace VulkanSharp.Generator
 				string name = param.Element ("name").Value;
 				string csType = GetTypeCsName (type);
 
+				var optional = param.Attribute ("optional");
+
+				bool isOptionalParam = (optional != null && optional.Value == "true");
+
 				bool isPointer = param.Value.Contains (type + "*");
 				bool isDoublePointer = param.Value.Contains (type + "**");
 				bool isConst = false;
@@ -728,7 +732,14 @@ namespace VulkanSharp.Generator
 					bool isFixed = fixedParams != null &&  fixedParams.ContainsKey (name);
 					string paramName = isFixed ? "ptr" + name : name;
 
-					Write ("{0}{1}{2}", (isPointer && !isStruct && !isFixed) ? "&" : "", keywords.Contains (paramName) ? "@" + paramName : paramName, (!isFixed && (isStruct || isHandle)) ? ".m" : "");
+					if (isOptionalParam && isPointer && !isOut)
+					{
+						Write ("{0} != null ? {0}{1} : null", keywords.Contains (paramName) ? "@" + paramName : paramName, (!isFixed && (isStruct || isHandle)) ? ".m" : "");
+					}
+					else
+					{
+						Write ("{0}{1}{2}", (isPointer && !isStruct && !isFixed) ? "&" : "", keywords.Contains (paramName) ? "@" + paramName : paramName, (!isFixed && (isStruct || isHandle)) ? ".m" : "");
+					}
 				} else
 					Write ("{0}{1} {2}", isOut ? "out " : "", csType, keywords.Contains (name) ? "@" + name : name);
 			}

--- a/tools/Generator/Generator.cs
+++ b/tools/Generator/Generator.cs
@@ -731,20 +731,27 @@ namespace VulkanSharp.Generator
 				if (passToNative) {
 					bool isFixed = fixedParams != null &&  fixedParams.ContainsKey (name);
 					string paramName = isFixed ? "ptr" + name : name;
+					bool useHandlePtr = !isFixed && (isStruct || isHandle);
 
 					if (isOptionalParam && isPointer && !isOut)
 					{
-						Write ("{0} != null ? {0}{1} : null", keywords.Contains (paramName) ? "@" + paramName : paramName, (!isFixed && (isStruct || isHandle)) ? ".m" : "");
+						Write ("{0} != null ? {0}{1} : null", GetSafeParameterName(paramName), useHandlePtr ? ".m" : "");
 					}
 					else
 					{
-						Write ("{0}{1}{2}", (isPointer && !isStruct && !isFixed) ? "&" : "", keywords.Contains (paramName) ? "@" + paramName : paramName, (!isFixed && (isStruct || isHandle)) ? ".m" : "");
+						Write ("{0}{1}{2}", (isPointer && !isStruct && !isFixed) ? "&" : "", GetSafeParameterName(paramName), useHandlePtr ? ".m" : "");
 					}
 				} else
 					Write ("{0}{1} {2}", isOut ? "out " : "", csType, keywords.Contains (name) ? "@" + name : name);
 			}
 
 			return outParams;
+		}
+		
+		string GetSafeParameterName(string paramName)
+		{
+			// if paramName is a reserved name
+			return keywords.Contains (paramName) ? "@" + paramName : paramName;
 		}
 
 		string GetManagedHandleType (string handleType)


### PR DESCRIPTION
Should be able to pass into NativeMethods calls AllocationCallbacks allocator as null

Out parameters should NOT be affected