### PR TITLE
Allow generated NativeMethods to use CallingConvention.StdCall via define symbol

### DIFF
--- a/tools/Generator/Generator.cs
+++ b/tools/Generator/Generator.cs
@@ -962,7 +962,7 @@ namespace VulkanSharp.Generator
 			if (csType.StartsWith ("PFN_"))
 				csType = "IntPtr";
 
-			IndentWriteLine ("[DllImport (VulkanLibrary, CallingConvention = VkCallingConvention)]");
+			IndentWriteLine ("[DllImport (VulkanLibrary, CallingConvention = CallingConvention.Cdecl)]");
 			IndentWrite ("internal static unsafe extern {0} {1} (", csType, function);
 			WriteUnmanagedCommandParameters (commandElement);
 			WriteLine (");");
@@ -978,18 +978,6 @@ namespace VulkanSharp.Generator
 			IndentWriteLine ("{");
 			IndentLevel++;
 			IndentWriteLine ("const string VulkanLibrary = \"vulkan\";\n");
-
-			IndentLevel--;
-			IndentWriteLine ("#if USE_STDCALL");
-			IndentLevel++;
-			IndentWriteLine ("const CallingConvention VkCallingConvention = CallingConvention.StdCall;");
-			IndentLevel--;
-			IndentWriteLine ("#else");
-			IndentLevel++;
-			IndentWriteLine ("const CallingConvention VkCallingConvention = CallingConvention.Cdecl;");
-			IndentLevel--;
-			IndentWriteLine ("#endif\n");
-			IndentLevel++;
 
 			bool written = false;
 			foreach (var command in specTree.Elements ("commands").Elements ("command")) {

--- a/tools/Generator/Generator.cs
+++ b/tools/Generator/Generator.cs
@@ -962,7 +962,7 @@ namespace VulkanSharp.Generator
 			if (csType.StartsWith ("PFN_"))
 				csType = "IntPtr";
 
-			IndentWriteLine ("[DllImport (VulkanLibrary, CallingConvention = CallingConvention.Cdecl)]");
+			IndentWriteLine ("[DllImport (VulkanLibrary, CallingConvention = CallingConvention.Winapi)]");
 			IndentWrite ("internal static unsafe extern {0} {1} (", csType, function);
 			WriteUnmanagedCommandParameters (commandElement);
 			WriteLine (");");

--- a/tools/Generator/Generator.cs
+++ b/tools/Generator/Generator.cs
@@ -962,7 +962,7 @@ namespace VulkanSharp.Generator
 			if (csType.StartsWith ("PFN_"))
 				csType = "IntPtr";
 
-			IndentWriteLine ("[DllImport (VulkanLibrary, CallingConvention = CallingConvention.Cdecl)]");
+			IndentWriteLine ("[DllImport (VulkanLibrary, CallingConvention = VkCallingConvention)]");
 			IndentWrite ("internal static unsafe extern {0} {1} (", csType, function);
 			WriteUnmanagedCommandParameters (commandElement);
 			WriteLine (");");
@@ -978,6 +978,18 @@ namespace VulkanSharp.Generator
 			IndentWriteLine ("{");
 			IndentLevel++;
 			IndentWriteLine ("const string VulkanLibrary = \"vulkan\";\n");
+
+			IndentLevel--;
+			IndentWriteLine ("#if USE_STDCALL");
+			IndentLevel++;
+			IndentWriteLine ("const CallingConvention VkCallingConvention = CallingConvention.StdCall;");
+			IndentLevel--;
+			IndentWriteLine ("#else");
+			IndentLevel++;
+			IndentWriteLine ("const CallingConvention VkCallingConvention = CallingConvention.Cdecl;");
+			IndentLevel--;
+			IndentWriteLine ("#endif\n");
+			IndentLevel++;
 
 			bool written = false;
 			foreach (var command in specTree.Elements ("commands").Elements ("command")) {


### PR DESCRIPTION
The Windows version of Vulkan LunarG SDK seems to use StdCall instead of
Cdecl

Compile project with USE_STDCALL as define symbol. 
