### PR TITLE
Support (at least) the 1.1.111 spec.

### DIFF
--- a/src/Platforms/Android/Structs.cs
+++ b/src/Platforms/Android/Structs.cs
@@ -24,8 +24,8 @@ namespace Vulkan.Android
 			get { return m->Window; }
 			set { m->Window = value; }
 		}
-		internal Android.Interop.AndroidSurfaceCreateInfoKhr* m {
 
+		internal Android.Interop.AndroidSurfaceCreateInfoKhr* m {
 			get {
 				return (Android.Interop.AndroidSurfaceCreateInfoKhr*)native.Handle;
 			}

--- a/src/Platforms/Windows/Structs.cs
+++ b/src/Platforms/Windows/Structs.cs
@@ -29,8 +29,8 @@ namespace Vulkan.Windows
 			get { return m->Hwnd; }
 			set { m->Hwnd = value; }
 		}
-		internal Windows.Interop.Win32SurfaceCreateInfoKhr* m {
 
+		internal Windows.Interop.Win32SurfaceCreateInfoKhr* m {
 			get {
 				return (Windows.Interop.Win32SurfaceCreateInfoKhr*)native.Handle;
 			}
@@ -67,8 +67,8 @@ namespace Vulkan.Windows
 			get { return m->Handle; }
 			set { m->Handle = value; }
 		}
-		internal Windows.Interop.ImportMemoryWin32HandleInfoNv* m {
 
+		internal Windows.Interop.ImportMemoryWin32HandleInfoNv* m {
 			get {
 				return (Windows.Interop.ImportMemoryWin32HandleInfoNv*)native.Handle;
 			}
@@ -105,8 +105,8 @@ namespace Vulkan.Windows
 			get { return m->DwAccess; }
 			set { m->DwAccess = value; }
 		}
-		internal Windows.Interop.ExportMemoryWin32HandleInfoNv* m {
 
+		internal Windows.Interop.ExportMemoryWin32HandleInfoNv* m {
 			get {
 				return (Windows.Interop.ExportMemoryWin32HandleInfoNv*)native.Handle;
 			}
@@ -312,8 +312,8 @@ namespace Vulkan.Windows
 				}
 			}
 		}
-		internal Windows.Interop.Win32KeyedMutexAcquireReleaseInfoNv* m {
 
+		internal Windows.Interop.Win32KeyedMutexAcquireReleaseInfoNv* m {
 			get {
 				return (Windows.Interop.Win32KeyedMutexAcquireReleaseInfoNv*)native.Handle;
 			}

--- a/src/Platforms/iOS/Structs.cs
+++ b/src/Platforms/iOS/Structs.cs
@@ -24,8 +24,8 @@ namespace Vulkan.iOS
 			get { return m->View; }
 			set { m->View = value; }
 		}
-		internal iOS.Interop.IOSSurfaceCreateInfoMvk* m {
 
+		internal iOS.Interop.IOSSurfaceCreateInfoMvk* m {
 			get {
 				return (iOS.Interop.IOSSurfaceCreateInfoMvk*)native.Handle;
 			}

--- a/src/Vulkan/Commands.cs
+++ b/src/Vulkan/Commands.cs
@@ -16,6 +16,20 @@ namespace Vulkan
 {
 	public static partial class Commands
 	{
+		public static UInt32 EnumerateInstanceVersion ()
+		{
+			Result result;
+			UInt32 pApiVersion;
+			unsafe {
+				pApiVersion = new UInt32 ();
+				result = Interop.NativeMethods.vkEnumerateInstanceVersion (&pApiVersion);
+				if (result != Result.Success)
+					throw new ResultException (result);
+
+				return pApiVersion;
+			}
+		}
+
 		public static LayerProperties[] EnumerateInstanceLayerProperties ()
 		{
 			Result result;

--- a/src/Vulkan/Enums.cs
+++ b/src/Vulkan/Enums.cs
@@ -113,6 +113,18 @@ namespace Vulkan
 		IntOpaqueWhite = 5,
 	}
 
+	[Flags]
+	public enum RenderPassCreateFlags : int
+	{
+	}
+
+	[Flags]
+	public enum SamplerCreateFlags : int
+	{
+		SubsampledExt = 0x1,
+		SubsampledCoarseReconstructionExt = 0x2,
+	}
+
 	public enum PipelineCacheHeaderVersion : int
 	{
 		One = 1,
@@ -122,6 +134,13 @@ namespace Vulkan
 	public enum DescriptorSetLayoutCreateFlags : int
 	{
 		PushDescriptorKhr = 0x1,
+		UpdateAfterBindPoolExt = 0x2,
+	}
+
+	[Flags]
+	public enum DeviceQueueCreateFlags : int
+	{
+		Protected = 0x1,
 	}
 
 	[Flags]
@@ -130,6 +149,8 @@ namespace Vulkan
 		SparseBinding = 0x1,
 		SparseResidency = 0x2,
 		SparseAliased = 0x4,
+		DeviceAddressCaptureReplayExt = 0x10,
+		Protected = 0x8,
 	}
 
 	[Flags]
@@ -144,6 +165,11 @@ namespace Vulkan
 		IndexBuffer = 0x40,
 		VertexBuffer = 0x80,
 		IndirectBuffer = 0x100,
+		TransformFeedbackBufferExt = 0x800,
+		TransformFeedbackCounterBufferExt = 0x1000,
+		ConditionalRenderingExt = 0x200,
+		RayTracingNv = 0x400,
+		ShaderDeviceAddressExt = 0x20000,
 	}
 
 	[Flags]
@@ -171,6 +197,7 @@ namespace Vulkan
 	{
 		Transient = 0x1,
 		ResetCommandBuffer = 0x2,
+		Protected = 0x4,
 	}
 
 	[Flags]
@@ -233,6 +260,8 @@ namespace Vulkan
 		UniformBufferDynamic = 8,
 		StorageBufferDynamic = 9,
 		InputAttachment = 10,
+		InlineUniformBlockExt = 1000138000,
+		AccelerationStructureNv = 1000165000,
 	}
 
 	public enum DynamicState : int
@@ -249,6 +278,9 @@ namespace Vulkan
 		ViewportWScalingNv = 1000087000,
 		DiscardRectangleExt = 1000099000,
 		SampleLocationsExt = 1000143000,
+		ViewportShadingRatePaletteNv = 1000164004,
+		ViewportCoarseSampleOrderNv = 1000164006,
+		ExclusiveScissorNv = 1000205001,
 	}
 
 	[Flags]
@@ -424,34 +456,34 @@ namespace Vulkan
 		EacR11SnormBlock = 154,
 		EacR11G11UnormBlock = 155,
 		EacR11G11SnormBlock = 156,
-		Astc4X4UnormBlock = 157,
-		Astc4X4SrgbBlock = 158,
-		Astc5X4UnormBlock = 159,
-		Astc5X4SrgbBlock = 160,
-		Astc5X5UnormBlock = 161,
-		Astc5X5SrgbBlock = 162,
-		Astc6X5UnormBlock = 163,
-		Astc6X5SrgbBlock = 164,
-		Astc6X6UnormBlock = 165,
-		Astc6X6SrgbBlock = 166,
-		Astc8X5UnormBlock = 167,
-		Astc8X5SrgbBlock = 168,
-		Astc8X6UnormBlock = 169,
-		Astc8X6SrgbBlock = 170,
-		Astc8X8UnormBlock = 171,
-		Astc8X8SrgbBlock = 172,
-		Astc10X5UnormBlock = 173,
-		Astc10X5SrgbBlock = 174,
-		Astc10X6UnormBlock = 175,
-		Astc10X6SrgbBlock = 176,
-		Astc10X8UnormBlock = 177,
-		Astc10X8SrgbBlock = 178,
-		Astc10X10UnormBlock = 179,
-		Astc10X10SrgbBlock = 180,
-		Astc12X10UnormBlock = 181,
-		Astc12X10SrgbBlock = 182,
-		Astc12X12UnormBlock = 183,
-		Astc12X12SrgbBlock = 184,
+		ASTC4X4UnormBlock = 157,
+		ASTC4X4SrgbBlock = 158,
+		ASTC5X4UnormBlock = 159,
+		ASTC5X4SrgbBlock = 160,
+		ASTC5X5UnormBlock = 161,
+		ASTC5X5SrgbBlock = 162,
+		ASTC6X5UnormBlock = 163,
+		ASTC6X5SrgbBlock = 164,
+		ASTC6X6UnormBlock = 165,
+		ASTC6X6SrgbBlock = 166,
+		ASTC8X5UnormBlock = 167,
+		ASTC8X5SrgbBlock = 168,
+		ASTC8X6UnormBlock = 169,
+		ASTC8X6SrgbBlock = 170,
+		ASTC8X8UnormBlock = 171,
+		ASTC8X8SrgbBlock = 172,
+		ASTC10X5UnormBlock = 173,
+		ASTC10X5SrgbBlock = 174,
+		ASTC10X6UnormBlock = 175,
+		ASTC10X6SrgbBlock = 176,
+		ASTC10X8UnormBlock = 177,
+		ASTC10X8SrgbBlock = 178,
+		ASTC10X10UnormBlock = 179,
+		ASTC10X10SrgbBlock = 180,
+		ASTC12X10UnormBlock = 181,
+		ASTC12X10SrgbBlock = 182,
+		ASTC12X12UnormBlock = 183,
+		ASTC12X12SrgbBlock = 184,
 		Pvrtc12BppUnormBlockImg = 1000054000,
 		Pvrtc14BppUnormBlockImg = 1000054001,
 		Pvrtc22BppUnormBlockImg = 1000054002,
@@ -460,40 +492,74 @@ namespace Vulkan
 		Pvrtc14BppSrgbBlockImg = 1000054005,
 		Pvrtc22BppSrgbBlockImg = 1000054006,
 		Pvrtc24BppSrgbBlockImg = 1000054007,
-		G8B8G8R8422UnormKhr = 1000156000,
-		B8G8R8G8422UnormKhr = 1000156001,
-		G8B8R83Plane420UnormKhr = 1000156002,
-		G8B8R82Plane420UnormKhr = 1000156003,
-		G8B8R83Plane422UnormKhr = 1000156004,
-		G8B8R82Plane422UnormKhr = 1000156005,
-		G8B8R83Plane444UnormKhr = 1000156006,
-		R10X6UnormPack16Khr = 1000156007,
-		R10X6G10X6Unorm2Pack16Khr = 1000156008,
-		R10X6G10X6B10X6A10X6Unorm4Pack16Khr = 1000156009,
-		G10X6B10X6G10X6R10X6422Unorm4Pack16Khr = 1000156010,
-		B10X6G10X6R10X6G10X6422Unorm4Pack16Khr = 1000156011,
-		G10X6B10X6R10X63Plane420Unorm3Pack16Khr = 1000156012,
-		G10X6B10X6R10X62Plane420Unorm3Pack16Khr = 1000156013,
-		G10X6B10X6R10X63Plane422Unorm3Pack16Khr = 1000156014,
-		G10X6B10X6R10X62Plane422Unorm3Pack16Khr = 1000156015,
-		G10X6B10X6R10X63Plane444Unorm3Pack16Khr = 1000156016,
-		R12X4UnormPack16Khr = 1000156017,
-		R12X4G12X4Unorm2Pack16Khr = 1000156018,
-		R12X4G12X4B12X4A12X4Unorm4Pack16Khr = 1000156019,
-		G12X4B12X4G12X4R12X4422Unorm4Pack16Khr = 1000156020,
-		B12X4G12X4R12X4G12X4422Unorm4Pack16Khr = 1000156021,
-		G12X4B12X4R12X43Plane420Unorm3Pack16Khr = 1000156022,
-		G12X4B12X4R12X42Plane420Unorm3Pack16Khr = 1000156023,
-		G12X4B12X4R12X43Plane422Unorm3Pack16Khr = 1000156024,
-		G12X4B12X4R12X42Plane422Unorm3Pack16Khr = 1000156025,
-		G12X4B12X4R12X43Plane444Unorm3Pack16Khr = 1000156026,
-		G16B16G16R16422UnormKhr = 1000156027,
-		B16G16R16G16422UnormKhr = 1000156028,
-		G16B16R163Plane420UnormKhr = 1000156029,
-		G16B16R162Plane420UnormKhr = 1000156030,
-		G16B16R163Plane422UnormKhr = 1000156031,
-		G16B16R162Plane422UnormKhr = 1000156032,
-		G16B16R163Plane444UnormKhr = 1000156033,
+		G8B8G8R8422UnormKhr = G8B8G8R8422Unorm,
+		B8G8R8G8422UnormKhr = B8G8R8G8422Unorm,
+		G8B8R83Plane420UnormKhr = G8B8R83Plane420Unorm,
+		G8B8R82Plane420UnormKhr = G8B8R82Plane420Unorm,
+		G8B8R83Plane422UnormKhr = G8B8R83Plane422Unorm,
+		G8B8R82Plane422UnormKhr = G8B8R82Plane422Unorm,
+		G8B8R83Plane444UnormKhr = G8B8R83Plane444Unorm,
+		R10X6UnormPack16Khr = R10X6UnormPack16,
+		R10X6G10X6Unorm2Pack16Khr = R10X6G10X6Unorm2Pack16,
+		R10X6G10X6B10X6A10X6Unorm4Pack16Khr = R10X6G10X6B10X6A10X6Unorm4Pack16,
+		G10X6B10X6G10X6R10X6422Unorm4Pack16Khr = G10X6B10X6G10X6R10X6422Unorm4Pack16,
+		B10X6G10X6R10X6G10X6422Unorm4Pack16Khr = B10X6G10X6R10X6G10X6422Unorm4Pack16,
+		G10X6B10X6R10X63Plane420Unorm3Pack16Khr = G10X6B10X6R10X63Plane420Unorm3Pack16,
+		G10X6B10X6R10X62Plane420Unorm3Pack16Khr = G10X6B10X6R10X62Plane420Unorm3Pack16,
+		G10X6B10X6R10X63Plane422Unorm3Pack16Khr = G10X6B10X6R10X63Plane422Unorm3Pack16,
+		G10X6B10X6R10X62Plane422Unorm3Pack16Khr = G10X6B10X6R10X62Plane422Unorm3Pack16,
+		G10X6B10X6R10X63Plane444Unorm3Pack16Khr = G10X6B10X6R10X63Plane444Unorm3Pack16,
+		R12X4UnormPack16Khr = R12X4UnormPack16,
+		R12X4G12X4Unorm2Pack16Khr = R12X4G12X4Unorm2Pack16,
+		R12X4G12X4B12X4A12X4Unorm4Pack16Khr = R12X4G12X4B12X4A12X4Unorm4Pack16,
+		G12X4B12X4G12X4R12X4422Unorm4Pack16Khr = G12X4B12X4G12X4R12X4422Unorm4Pack16,
+		B12X4G12X4R12X4G12X4422Unorm4Pack16Khr = B12X4G12X4R12X4G12X4422Unorm4Pack16,
+		G12X4B12X4R12X43Plane420Unorm3Pack16Khr = G12X4B12X4R12X43Plane420Unorm3Pack16,
+		G12X4B12X4R12X42Plane420Unorm3Pack16Khr = G12X4B12X4R12X42Plane420Unorm3Pack16,
+		G12X4B12X4R12X43Plane422Unorm3Pack16Khr = G12X4B12X4R12X43Plane422Unorm3Pack16,
+		G12X4B12X4R12X42Plane422Unorm3Pack16Khr = G12X4B12X4R12X42Plane422Unorm3Pack16,
+		G12X4B12X4R12X43Plane444Unorm3Pack16Khr = G12X4B12X4R12X43Plane444Unorm3Pack16,
+		G16B16G16R16422UnormKhr = G16B16G16R16422Unorm,
+		B16G16R16G16422UnormKhr = B16G16R16G16422Unorm,
+		G16B16R163Plane420UnormKhr = G16B16R163Plane420Unorm,
+		G16B16R162Plane420UnormKhr = G16B16R162Plane420Unorm,
+		G16B16R163Plane422UnormKhr = G16B16R163Plane422Unorm,
+		G16B16R162Plane422UnormKhr = G16B16R162Plane422Unorm,
+		G16B16R163Plane444UnormKhr = G16B16R163Plane444Unorm,
+		G8B8G8R8422Unorm = 1000156000,
+		B8G8R8G8422Unorm = 1000156001,
+		G8B8R83Plane420Unorm = 1000156002,
+		G8B8R82Plane420Unorm = 1000156003,
+		G8B8R83Plane422Unorm = 1000156004,
+		G8B8R82Plane422Unorm = 1000156005,
+		G8B8R83Plane444Unorm = 1000156006,
+		R10X6UnormPack16 = 1000156007,
+		R10X6G10X6Unorm2Pack16 = 1000156008,
+		R10X6G10X6B10X6A10X6Unorm4Pack16 = 1000156009,
+		G10X6B10X6G10X6R10X6422Unorm4Pack16 = 1000156010,
+		B10X6G10X6R10X6G10X6422Unorm4Pack16 = 1000156011,
+		G10X6B10X6R10X63Plane420Unorm3Pack16 = 1000156012,
+		G10X6B10X6R10X62Plane420Unorm3Pack16 = 1000156013,
+		G10X6B10X6R10X63Plane422Unorm3Pack16 = 1000156014,
+		G10X6B10X6R10X62Plane422Unorm3Pack16 = 1000156015,
+		G10X6B10X6R10X63Plane444Unorm3Pack16 = 1000156016,
+		R12X4UnormPack16 = 1000156017,
+		R12X4G12X4Unorm2Pack16 = 1000156018,
+		R12X4G12X4B12X4A12X4Unorm4Pack16 = 1000156019,
+		G12X4B12X4G12X4R12X4422Unorm4Pack16 = 1000156020,
+		B12X4G12X4R12X4G12X4422Unorm4Pack16 = 1000156021,
+		G12X4B12X4R12X43Plane420Unorm3Pack16 = 1000156022,
+		G12X4B12X4R12X42Plane420Unorm3Pack16 = 1000156023,
+		G12X4B12X4R12X43Plane422Unorm3Pack16 = 1000156024,
+		G12X4B12X4R12X42Plane422Unorm3Pack16 = 1000156025,
+		G12X4B12X4R12X43Plane444Unorm3Pack16 = 1000156026,
+		G16B16G16R16422Unorm = 1000156027,
+		B16G16R16G16422Unorm = 1000156028,
+		G16B16R163Plane420Unorm = 1000156029,
+		G16B16R162Plane420Unorm = 1000156030,
+		G16B16R163Plane422Unorm = 1000156031,
+		G16B16R162Plane422Unorm = 1000156032,
+		G16B16R163Plane444Unorm = 1000156033,
 	}
 
 	[Flags]
@@ -513,16 +579,17 @@ namespace Vulkan
 		BlitDst = 0x800,
 		SampledImageFilterLinear = 0x1000,
 		SampledImageFilterCubicImg = 0x2000,
-		TransferSrcKhr = 0x4000,
-		TransferDstKhr = 0x8000,
 		SampledImageFilterMinmaxExt = 0x10000,
-		MidpointChromaSamplesKhr = 0x20000,
-		SampledImageYcbcrConversionLinearFilterKhr = 0x40000,
-		SampledImageYcbcrConversionSeparateReconstructionFilterKhr = 0x80000,
-		SampledImageYcbcrConversionChromaReconstructionExplicitKhr = 0x100000,
-		SampledImageYcbcrConversionChromaReconstructionExplicitForceableKhr = 0x200000,
-		DisjointKhr = 0x400000,
-		CositedChromaSamplesKhr = 0x800000,
+		FragmentDensityMapExt = 0x1000000,
+		TransferSrc = 0x4000,
+		TransferDst = 0x8000,
+		MidpointChromaSamples = 0x20000,
+		SampledImageYcbcrConversionLinearFilter = 0x40000,
+		SampledImageYcbcrConversionSeparateReconstructionFilter = 0x80000,
+		SampledImageYcbcrConversionChromaReconstructionExplicit = 0x100000,
+		SampledImageYcbcrConversionChromaReconstructionExplicitForceable = 0x200000,
+		Disjoint = 0x400000,
+		CositedChromaSamples = 0x800000,
 	}
 
 	public enum FrontFace : int
@@ -538,9 +605,13 @@ namespace Vulkan
 		Depth = 0x2,
 		Stencil = 0x4,
 		Metadata = 0x8,
-		Plane0Khr = 0x10,
-		Plane1Khr = 0x20,
-		Plane2Khr = 0x40,
+		MemoryPlane0Ext = 0x80,
+		MemoryPlane1Ext = 0x100,
+		MemoryPlane2Ext = 0x200,
+		MemoryPlane3Ext = 0x400,
+		Plane0 = 0x10,
+		Plane1 = 0x20,
+		Plane2 = 0x40,
 	}
 
 	[Flags]
@@ -551,13 +622,16 @@ namespace Vulkan
 		SparseAliased = 0x4,
 		MutableFormat = 0x8,
 		CubeCompatible = 0x10,
-		BindSfrKhx = 0x40,
-		Create2DArrayCompatibleKhr = 0x20,
-		BlockTexelViewCompatibleKhr = 0x80,
-		ExtendedUsageKhr = 0x100,
+		CornerSampledNv = 0x2000,
 		SampleLocationsCompatibleDepthExt = 0x1000,
-		DisjointKhr = 0x200,
-		AliasKhr = 0x400,
+		SubsampledExt = 0x4000,
+		Alias = 0x400,
+		SplitInstanceBindRegions = 0x40,
+		Create_2DArrayCompatible = 0x20,
+		BlockTexelViewCompatible = 0x80,
+		ExtendedUsage = 0x100,
+		Protected = 0x800,
+		Disjoint = 0x200,
 	}
 
 	public enum ImageLayout : int
@@ -573,21 +647,26 @@ namespace Vulkan
 		Preinitialized = 8,
 		PresentSrcKhr = 1000001002,
 		SharedPresentKhr = 1000111000,
-		DepthReadOnlyStencilAttachmentOptimalKhr = 1000117000,
-		DepthAttachmentStencilReadOnlyOptimalKhr = 1000117001,
+		DepthReadOnlyStencilAttachmentOptimalKhr = DepthReadOnlyStencilAttachmentOptimal,
+		DepthAttachmentStencilReadOnlyOptimalKhr = DepthAttachmentStencilReadOnlyOptimal,
+		ShadingRateOptimalNv = 1000164003,
+		FragmentDensityMapOptimalExt = 1000218000,
+		DepthReadOnlyStencilAttachmentOptimal = 1000117000,
+		DepthAttachmentStencilReadOnlyOptimal = 1000117001,
 	}
 
 	public enum ImageTiling : int
 	{
 		Optimal = 0,
 		Linear = 1,
+		DrmFormatModifierExt = 1000158000,
 	}
 
 	public enum ImageType : int
 	{
-		Image1D = 0,
-		Image2D = 1,
-		Image3D = 2,
+		Image_1D = 0,
+		Image_2D = 1,
+		Image_3D = 2,
 	}
 
 	[Flags]
@@ -601,16 +680,24 @@ namespace Vulkan
 		DepthStencilAttachment = 0x20,
 		TransientAttachment = 0x40,
 		InputAttachment = 0x80,
+		ShadingRateImageNv = 0x100,
+		FragmentDensityMapExt = 0x200,
+	}
+
+	[Flags]
+	public enum ImageViewCreateFlags : int
+	{
+		FragmentDensityMapDynamicExt = 0x1,
 	}
 
 	public enum ImageViewType : int
 	{
-		View1D = 0,
-		View2D = 1,
-		View3D = 2,
+		View_1D = 0,
+		View_2D = 1,
+		View_3D = 2,
 		Cube = 3,
-		View1DArray = 4,
-		View2DArray = 5,
+		View_1DArray = 4,
+		View_2DArray = 5,
 		CubeArray = 6,
 	}
 
@@ -624,6 +711,7 @@ namespace Vulkan
 	{
 		Uint16 = 0,
 		Uint32 = 1,
+		NoneNv = 1000165000,
 	}
 
 	public enum LogicOp : int
@@ -650,7 +738,7 @@ namespace Vulkan
 	public enum MemoryHeapFlags : int
 	{
 		DeviceLocal = 0x1,
-		MultiInstanceKhx = 0x2,
+		MultiInstance = 0x2,
 	}
 
 	[Flags]
@@ -673,9 +761,17 @@ namespace Vulkan
 		HostWrite = 0x4000,
 		MemoryRead = 0x8000,
 		MemoryWrite = 0x10000,
+		TransformFeedbackWriteExt = 0x2000000,
+		TransformFeedbackCounterReadExt = 0x4000000,
+		TransformFeedbackCounterWriteExt = 0x8000000,
+		ConditionalRenderingReadExt = 0x100000,
 		CommandProcessReadNvx = 0x20000,
 		CommandProcessWriteNvx = 0x40000,
 		ColorAttachmentReadNoncoherentExt = 0x80000,
+		ShadingRateImageReadNv = 0x800000,
+		AccelerationStructureReadNv = 0x200000,
+		AccelerationStructureWriteNv = 0x400000,
+		FragmentDensityMapReadExt = 0x1000000,
 	}
 
 	[Flags]
@@ -686,6 +782,7 @@ namespace Vulkan
 		HostCoherent = 0x4,
 		HostCached = 0x8,
 		LazilyAllocated = 0x10,
+		Protected = 0x20,
 	}
 
 	public enum PhysicalDeviceType : int
@@ -701,6 +798,7 @@ namespace Vulkan
 	{
 		Graphics = 0,
 		Compute = 1,
+		RayTracingNv = 1000165000,
 	}
 
 	[Flags]
@@ -709,8 +807,9 @@ namespace Vulkan
 		DisableOptimization = 0x1,
 		AllowDerivatives = 0x2,
 		Derivative = 0x4,
-		ViewIndexFromDeviceIndexKhx = 0x8,
-		DispatchBaseKhx = 0x10,
+		DeferCompileNv = 0x20,
+		ViewIndexFromDeviceIndex = 0x8,
+		DispatchBase = 0x10,
 	}
 
 	public enum PrimitiveTopology : int
@@ -753,7 +852,7 @@ namespace Vulkan
 	[Flags]
 	public enum QueryResultFlags : int
 	{
-		Result64 = 0x1,
+		Result_64 = 0x1,
 		Wait = 0x2,
 		WithAvailability = 0x4,
 		Partial = 0x8,
@@ -764,6 +863,9 @@ namespace Vulkan
 		Occlusion = 0,
 		PipelineStatistics = 1,
 		Timestamp = 2,
+		TransformFeedbackStreamExt = 1000028004,
+		AccelerationStructureCompactedSizeNv = 1000165000,
+		PerformanceQueryIntel = 1000210000,
 	}
 
 	[Flags]
@@ -773,6 +875,7 @@ namespace Vulkan
 		Compute = 0x2,
 		Transfer = 0x4,
 		SparseBinding = 0x8,
+		Protected = 0x10,
 	}
 
 	public enum SubpassContents : int
@@ -808,9 +911,15 @@ namespace Vulkan
 		ErrorIncompatibleDisplayKhr = -1000003001,
 		ErrorValidationFailedExt = -1000011001,
 		ErrorInvalidShaderNv = -1000012000,
-		ErrorOutOfPoolMemoryKhr = -1000069000,
-		ErrorInvalidExternalHandleKhr = -1000072003,
+		ErrorOutOfPoolMemoryKhr = ErrorOutOfPoolMemory,
+		ErrorInvalidExternalHandleKhr = ErrorInvalidExternalHandle,
+		ErrorInvalidDrmFormatModifierPlaneLayoutExt = -1000158000,
+		ErrorFragmentationExt = -1000161000,
 		ErrorNotPermittedExt = -1000174001,
+		ErrorInvalidDeviceAddressExt = -1000244000,
+		ErrorFullScreenExclusiveModeLostExt = -1000255000,
+		ErrorOutOfPoolMemory = -1000069000,
+		ErrorInvalidExternalHandle = -1000072003,
 	}
 
 	[Flags]
@@ -824,6 +933,14 @@ namespace Vulkan
 		Compute = 0x20,
 		AllGraphics = 0x0000001F,
 		All = 0x7FFFFFFF,
+		RaygenNv = 0x100,
+		AnyHitNv = 0x200,
+		ClosestHitNv = 0x400,
+		MissNv = 0x800,
+		IntersectionNv = 0x1000,
+		CallableNv = 0x2000,
+		TaskNv = 0x40,
+		MeshNv = 0x80,
 	}
 
 	[Flags]
@@ -905,16 +1022,22 @@ namespace Vulkan
 		LoaderDeviceCreateInfo = 48,
 		SwapchainCreateInfoKhr = 1000001000,
 		PresentInfoKhr = 1000001001,
+		DeviceGroupPresentCapabilitiesKhr = 1000060007,
+		ImageSwapchainCreateInfoKhr = 1000060008,
+		BindImageMemorySwapchainInfoKhr = 1000060009,
+		AcquireNextImageInfoKhr = 1000060010,
+		DeviceGroupPresentInfoKhr = 1000060011,
+		DeviceGroupSwapchainCreateInfoKhr = 1000060012,
 		DisplayModeCreateInfoKhr = 1000002000,
 		DisplaySurfaceCreateInfoKhr = 1000002001,
 		DisplayPresentInfoKhr = 1000003000,
 		XlibSurfaceCreateInfoKhr = 1000004000,
 		XcbSurfaceCreateInfoKhr = 1000005000,
 		WaylandSurfaceCreateInfoKhr = 1000006000,
-		MirSurfaceCreateInfoKhr = 1000007000,
 		AndroidSurfaceCreateInfoKhr = 1000008000,
 		Win32SurfaceCreateInfoKhr = 1000009000,
 		DebugReportCallbackCreateInfoExt = 1000011000,
+		DebugReportCreateInfoExt = DebugReportCallbackCreateInfoExt,
 		PipelineRasterizationStateRasterizationOrderAmd = 1000018000,
 		DebugMarkerObjectNameInfoExt = 1000022000,
 		DebugMarkerObjectTagInfoExt = 1000022001,
@@ -922,49 +1045,51 @@ namespace Vulkan
 		DedicatedAllocationImageCreateInfoNv = 1000026000,
 		DedicatedAllocationBufferCreateInfoNv = 1000026001,
 		DedicatedAllocationMemoryAllocateInfoNv = 1000026002,
+		PhysicalDeviceTransformFeedbackFeaturesExt = 1000028000,
+		PhysicalDeviceTransformFeedbackPropertiesExt = 1000028001,
+		PipelineRasterizationStateStreamCreateInfoExt = 1000028002,
+		ImageViewHandleInfoNvx = 1000030000,
 		TextureLODGatherFormatPropertiesAmd = 1000041000,
-		RenderPassMultiviewCreateInfoKhx = 1000053000,
-		PhysicalDeviceMultiviewFeaturesKhx = 1000053001,
-		PhysicalDeviceMultiviewPropertiesKhx = 1000053002,
+		StreamDescriptorSurfaceCreateInfoGGP = 1000049000,
+		PhysicalDeviceCornerSampledImageFeaturesNv = 1000050000,
+		RenderPassMultiviewCreateInfoKhr = RenderPassMultiviewCreateInfo,
+		PhysicalDeviceMultiviewFeaturesKhr = PhysicalDeviceMultiviewFeatures,
+		PhysicalDeviceMultiviewPropertiesKhr = PhysicalDeviceMultiviewProperties,
 		ExternalMemoryImageCreateInfoNv = 1000056000,
 		ExportMemoryAllocateInfoNv = 1000056001,
 		ImportMemoryWin32HandleInfoNv = 1000057000,
 		ExportMemoryWin32HandleInfoNv = 1000057001,
 		Win32KeyedMutexAcquireReleaseInfoNv = 1000058000,
-		PhysicalDeviceFeatures2Khr = 1000059000,
-		PhysicalDeviceProperties2Khr = 1000059001,
-		FormatProperties2Khr = 1000059002,
-		ImageFormatProperties2Khr = 1000059003,
-		PhysicalDeviceImageFormatInfo2Khr = 1000059004,
-		QueueFamilyProperties2Khr = 1000059005,
-		PhysicalDeviceMemoryProperties2Khr = 1000059006,
-		SparseImageFormatProperties2Khr = 1000059007,
-		PhysicalDeviceSparseImageFormatInfo2Khr = 1000059008,
-		MemoryAllocateFlagsInfoKhx = 1000060000,
-		DeviceGroupRenderPassBeginInfoKhx = 1000060003,
-		DeviceGroupCommandBufferBeginInfoKhx = 1000060004,
-		DeviceGroupSubmitInfoKhx = 1000060005,
-		DeviceGroupBindSparseInfoKhx = 1000060006,
-		AcquireNextImageInfoKhx = 1000060010,
-		BindBufferMemoryDeviceGroupInfoKhx = 1000060013,
-		BindImageMemoryDeviceGroupInfoKhx = 1000060014,
-		DeviceGroupPresentCapabilitiesKhx = 1000060007,
-		ImageSwapchainCreateInfoKhx = 1000060008,
-		BindImageMemorySwapchainInfoKhx = 1000060009,
-		DeviceGroupPresentInfoKhx = 1000060011,
-		DeviceGroupSwapchainCreateInfoKhx = 1000060012,
+		PhysicalDeviceFeatures2Khr = PhysicalDeviceFeatures2,
+		PhysicalDeviceProperties2Khr = PhysicalDeviceProperties2,
+		FormatProperties2Khr = FormatProperties2,
+		ImageFormatProperties2Khr = ImageFormatProperties2,
+		PhysicalDeviceImageFormatInfo2Khr = PhysicalDeviceImageFormatInfo2,
+		QueueFamilyProperties2Khr = QueueFamilyProperties2,
+		PhysicalDeviceMemoryProperties2Khr = PhysicalDeviceMemoryProperties2,
+		SparseImageFormatProperties2Khr = SparseImageFormatProperties2,
+		PhysicalDeviceSparseImageFormatInfo2Khr = PhysicalDeviceSparseImageFormatInfo2,
+		MemoryAllocateFlagsInfoKhr = MemoryAllocateFlagsInfo,
+		DeviceGroupRenderPassBeginInfoKhr = DeviceGroupRenderPassBeginInfo,
+		DeviceGroupCommandBufferBeginInfoKhr = DeviceGroupCommandBufferBeginInfo,
+		DeviceGroupSubmitInfoKhr = DeviceGroupSubmitInfo,
+		DeviceGroupBindSparseInfoKhr = DeviceGroupBindSparseInfo,
+		BindBufferMemoryDeviceGroupInfoKhr = BindBufferMemoryDeviceGroupInfo,
+		BindImageMemoryDeviceGroupInfoKhr = BindImageMemoryDeviceGroupInfo,
 		ValidationFlagsExt = 1000061000,
 		ViSurfaceCreateInfoNn = 1000062000,
-		PhysicalDeviceGroupPropertiesKhx = 1000070000,
-		DeviceGroupDeviceCreateInfoKhx = 1000070001,
-		PhysicalDeviceExternalImageFormatInfoKhr = 1000071000,
-		ExternalImageFormatPropertiesKhr = 1000071001,
-		PhysicalDeviceExternalBufferInfoKhr = 1000071002,
-		ExternalBufferPropertiesKhr = 1000071003,
-		PhysicalDeviceIDPropertiesKhr = 1000071004,
-		ExternalMemoryBufferCreateInfoKhr = 1000072000,
-		ExternalMemoryImageCreateInfoKhr = 1000072001,
-		ExportMemoryAllocateInfoKhr = 1000072002,
+		ImageViewASTCDecodeModeExt = 1000067000,
+		PhysicalDeviceASTCDecodeFeaturesExt = 1000067001,
+		PhysicalDeviceGroupPropertiesKhr = PhysicalDeviceGroupProperties,
+		DeviceGroupDeviceCreateInfoKhr = DeviceGroupDeviceCreateInfo,
+		PhysicalDeviceExternalImageFormatInfoKhr = PhysicalDeviceExternalImageFormatInfo,
+		ExternalImageFormatPropertiesKhr = ExternalImageFormatProperties,
+		PhysicalDeviceExternalBufferInfoKhr = PhysicalDeviceExternalBufferInfo,
+		ExternalBufferPropertiesKhr = ExternalBufferProperties,
+		PhysicalDeviceIDPropertiesKhr = PhysicalDeviceIDProperties,
+		ExternalMemoryBufferCreateInfoKhr = ExternalMemoryBufferCreateInfo,
+		ExternalMemoryImageCreateInfoKhr = ExternalMemoryImageCreateInfo,
+		ExportMemoryAllocateInfoKhr = ExportMemoryAllocateInfo,
 		ImportMemoryWin32HandleInfoKhr = 1000073000,
 		ExportMemoryWin32HandleInfoKhr = 1000073001,
 		MemoryWin32HandlePropertiesKhr = 1000073002,
@@ -973,9 +1098,9 @@ namespace Vulkan
 		MemoryFdPropertiesKhr = 1000074001,
 		MemoryGetFdInfoKhr = 1000074002,
 		Win32KeyedMutexAcquireReleaseInfoKhr = 1000075000,
-		PhysicalDeviceExternalSemaphoreInfoKhr = 1000076000,
-		ExternalSemaphorePropertiesKhr = 1000076001,
-		ExportSemaphoreCreateInfoKhr = 1000077000,
+		PhysicalDeviceExternalSemaphoreInfoKhr = PhysicalDeviceExternalSemaphoreInfo,
+		ExternalSemaphorePropertiesKhr = ExternalSemaphoreProperties,
+		ExportSemaphoreCreateInfoKhr = ExportSemaphoreCreateInfo,
 		ImportSemaphoreWin32HandleInfoKhr = 1000078000,
 		ExportSemaphoreWin32HandleInfoKhr = 1000078001,
 		D3D12FenceSubmitInfoKhr = 1000078002,
@@ -983,9 +1108,13 @@ namespace Vulkan
 		ImportSemaphoreFdInfoKhr = 1000079000,
 		SemaphoreGetFdInfoKhr = 1000079001,
 		PhysicalDevicePushDescriptorPropertiesKhr = 1000080000,
-		PhysicalDevice16BitStorageFeaturesKhr = 1000083000,
+		CommandBufferInheritanceConditionalRenderingInfoExt = 1000081000,
+		PhysicalDeviceConditionalRenderingFeaturesExt = 1000081001,
+		ConditionalRenderingBeginInfoExt = 1000081002,
+		PhysicalDeviceFloat16Int8FeaturesKhr = 1000082000,
+		PhysicalDevice16BitStorageFeaturesKhr = PhysicalDevice16BitStorageFeatures,
 		PresentRegionsKhr = 1000084000,
-		DescriptorUpdateTemplateCreateInfoKhr = 1000085000,
+		DescriptorUpdateTemplateCreateInfoKhr = DescriptorUpdateTemplateCreateInfo,
 		ObjectTableCreateInfoNvx = 1000086000,
 		IndirectCommandsLayoutCreateInfoNvx = 1000086001,
 		CmdProcessCommandsInfoNvx = 1000086002,
@@ -1005,60 +1134,256 @@ namespace Vulkan
 		PipelineDiscardRectangleStateCreateInfoExt = 1000099001,
 		PhysicalDeviceConservativeRasterizationPropertiesExt = 1000101000,
 		PipelineRasterizationConservativeStateCreateInfoExt = 1000101001,
+		PhysicalDeviceDepthClipEnableFeaturesExt = 1000102000,
+		PipelineRasterizationDepthClipStateCreateInfoExt = 1000102001,
 		HdrMetadataExt = 1000105000,
+		AttachmentDescription2Khr = 1000109000,
+		AttachmentReference2Khr = 1000109001,
+		SubpassDescription2Khr = 1000109002,
+		SubpassDependency2Khr = 1000109003,
+		RenderPassCreateInfo2Khr = 1000109004,
+		SubpassBeginInfoKhr = 1000109005,
+		SubpassEndInfoKhr = 1000109006,
 		SharedPresentSurfaceCapabilitiesKhr = 1000111000,
-		PhysicalDeviceExternalFenceInfoKhr = 1000112000,
-		ExternalFencePropertiesKhr = 1000112001,
-		ExportFenceCreateInfoKhr = 1000113000,
+		PhysicalDeviceExternalFenceInfoKhr = PhysicalDeviceExternalFenceInfo,
+		ExternalFencePropertiesKhr = ExternalFenceProperties,
+		ExportFenceCreateInfoKhr = ExportFenceCreateInfo,
 		ImportFenceWin32HandleInfoKhr = 1000114000,
 		ExportFenceWin32HandleInfoKhr = 1000114001,
 		FenceGetWin32HandleInfoKhr = 1000114002,
 		ImportFenceFdInfoKhr = 1000115000,
 		FenceGetFdInfoKhr = 1000115001,
-		PhysicalDevicePointClippingPropertiesKhr = 1000117000,
-		RenderPassInputAttachmentAspectCreateInfoKhr = 1000117001,
-		ImageViewUsageCreateInfoKhr = 1000117002,
-		PipelineTessellationDomainOriginStateCreateInfoKhr = 1000117003,
+		PhysicalDevicePointClippingPropertiesKhr = PhysicalDevicePointClippingProperties,
+		RenderPassInputAttachmentAspectCreateInfoKhr = RenderPassInputAttachmentAspectCreateInfo,
+		ImageViewUsageCreateInfoKhr = ImageViewUsageCreateInfo,
+		PipelineTessellationDomainOriginStateCreateInfoKhr = PipelineTessellationDomainOriginStateCreateInfo,
 		PhysicalDeviceSurfaceInfo2Khr = 1000119000,
 		SurfaceCapabilities2Khr = 1000119001,
 		SurfaceFormat2Khr = 1000119002,
-		PhysicalDeviceVariablePointerFeaturesKhr = 1000120000,
+		PhysicalDeviceVariablePointerFeaturesKhr = PhysicalDeviceVariablePointerFeatures,
+		PhysicalDeviceVariablePointersFeaturesKhr = PhysicalDeviceVariablePointerFeatures,
+		DisplayProperties2Khr = 1000121000,
+		DisplayPlaneProperties2Khr = 1000121001,
+		DisplayModeProperties2Khr = 1000121002,
+		DisplayPlaneInfo2Khr = 1000121003,
+		DisplayPlaneCapabilities2Khr = 1000121004,
 		IOSSurfaceCreateInfoMvk = 1000122000,
 		MacOSSurfaceCreateInfoMvk = 1000123000,
-		MemoryDedicatedRequirementsKhr = 1000127000,
-		MemoryDedicatedAllocateInfoKhr = 1000127001,
+		MemoryDedicatedRequirementsKhr = MemoryDedicatedRequirements,
+		MemoryDedicatedAllocateInfoKhr = MemoryDedicatedAllocateInfo,
+		DebugUtilsObjectNameInfoExt = 1000128000,
+		DebugUtilsObjectTagInfoExt = 1000128001,
+		DebugUtilsLabelExt = 1000128002,
+		DebugUtilsMessengerCallbackDataExt = 1000128003,
+		DebugUtilsMessengerCreateInfoExt = 1000128004,
+		AndroidHardwareBufferUsageAndroid = 1000129000,
+		AndroidHardwareBufferPropertiesAndroid = 1000129001,
+		AndroidHardwareBufferFormatPropertiesAndroid = 1000129002,
+		ImportAndroidHardwareBufferInfoAndroid = 1000129003,
+		MemoryGetAndroidHardwareBufferInfoAndroid = 1000129004,
+		ExternalFormatAndroid = 1000129005,
 		PhysicalDeviceSamplerFilterMinmaxPropertiesExt = 1000130000,
 		SamplerReductionModeCreateInfoExt = 1000130001,
+		PhysicalDeviceInlineUniformBlockFeaturesExt = 1000138000,
+		PhysicalDeviceInlineUniformBlockPropertiesExt = 1000138001,
+		WriteDescriptorSetInlineUniformBlockExt = 1000138002,
+		DescriptorPoolInlineUniformBlockCreateInfoExt = 1000138003,
 		SampleLocationsInfoExt = 1000143000,
 		RenderPassSampleLocationsBeginInfoExt = 1000143001,
 		PipelineSampleLocationsStateCreateInfoExt = 1000143002,
 		PhysicalDeviceSampleLocationsPropertiesExt = 1000143003,
 		MultisamplePropertiesExt = 1000143004,
-		BufferMemoryRequirementsInfo2Khr = 1000146000,
-		ImageMemoryRequirementsInfo2Khr = 1000146001,
-		ImageSparseMemoryRequirementsInfo2Khr = 1000146002,
-		MemoryRequirements2Khr = 1000146003,
-		SparseImageMemoryRequirements2Khr = 1000146004,
+		BufferMemoryRequirementsInfo2Khr = BufferMemoryRequirementsInfo2,
+		ImageMemoryRequirementsInfo2Khr = ImageMemoryRequirementsInfo2,
+		ImageSparseMemoryRequirementsInfo2Khr = ImageSparseMemoryRequirementsInfo2,
+		MemoryRequirements2Khr = MemoryRequirements2,
+		SparseImageMemoryRequirements2Khr = SparseImageMemoryRequirements2,
 		ImageFormatListCreateInfoKhr = 1000147000,
 		PhysicalDeviceBlendOperationAdvancedFeaturesExt = 1000148000,
 		PhysicalDeviceBlendOperationAdvancedPropertiesExt = 1000148001,
 		PipelineColorBlendAdvancedStateCreateInfoExt = 1000148002,
 		PipelineCoverageToColorStateCreateInfoNv = 1000149000,
 		PipelineCoverageModulationStateCreateInfoNv = 1000152000,
-		SamplerYcbcrConversionCreateInfoKhr = 1000156000,
-		SamplerYcbcrConversionInfoKhr = 1000156001,
-		BindImagePlaneMemoryInfoKhr = 1000156002,
-		ImagePlaneMemoryRequirementsInfoKhr = 1000156003,
-		PhysicalDeviceSamplerYcbcrConversionFeaturesKhr = 1000156004,
-		SamplerYcbcrConversionImageFormatPropertiesKhr = 1000156005,
-		BindBufferMemoryInfoKhr = 1000157000,
-		BindImageMemoryInfoKhr = 1000157001,
+		PhysicalDeviceShaderSMBuiltinsFeaturesNv = 1000154000,
+		PhysicalDeviceShaderSMBuiltinsPropertiesNv = 1000154001,
+		SamplerYcbcrConversionCreateInfoKhr = SamplerYcbcrConversionCreateInfo,
+		SamplerYcbcrConversionInfoKhr = SamplerYcbcrConversionInfo,
+		BindImagePlaneMemoryInfoKhr = BindImagePlaneMemoryInfo,
+		ImagePlaneMemoryRequirementsInfoKhr = ImagePlaneMemoryRequirementsInfo,
+		PhysicalDeviceSamplerYcbcrConversionFeaturesKhr = PhysicalDeviceSamplerYcbcrConversionFeatures,
+		SamplerYcbcrConversionImageFormatPropertiesKhr = SamplerYcbcrConversionImageFormatProperties,
+		BindBufferMemoryInfoKhr = BindBufferMemoryInfo,
+		BindImageMemoryInfoKhr = BindImageMemoryInfo,
+		DrmFormatModifierPropertiesListExt = 1000158000,
+		DrmFormatModifierPropertiesExt = 1000158001,
+		PhysicalDeviceImageDrmFormatModifierInfoExt = 1000158002,
+		ImageDrmFormatModifierListCreateInfoExt = 1000158003,
+		ImageDrmFormatModifierExplicitCreateInfoExt = 1000158004,
+		ImageDrmFormatModifierPropertiesExt = 1000158005,
 		ValidationCacheCreateInfoExt = 1000160000,
 		ShaderModuleValidationCacheCreateInfoExt = 1000160001,
+		DescriptorSetLayoutBindingFlagsCreateInfoExt = 1000161000,
+		PhysicalDeviceDescriptorIndexingFeaturesExt = 1000161001,
+		PhysicalDeviceDescriptorIndexingPropertiesExt = 1000161002,
+		DescriptorSetVariableDescriptorCountAllocateInfoExt = 1000161003,
+		DescriptorSetVariableDescriptorCountLayoutSupportExt = 1000161004,
+		PipelineViewportShadingRateImageStateCreateInfoNv = 1000164000,
+		PhysicalDeviceShadingRateImageFeaturesNv = 1000164001,
+		PhysicalDeviceShadingRateImagePropertiesNv = 1000164002,
+		PipelineViewportCoarseSampleOrderStateCreateInfoNv = 1000164005,
+		RayTracingPipelineCreateInfoNv = 1000165000,
+		AccelerationStructureCreateInfoNv = 1000165001,
+		GeometryNv = 1000165003,
+		GeometryTrianglesNv = 1000165004,
+		GeometryAABBNv = 1000165005,
+		BindAccelerationStructureMemoryInfoNv = 1000165006,
+		WriteDescriptorSetAccelerationStructureNv = 1000165007,
+		AccelerationStructureMemoryRequirementsInfoNv = 1000165008,
+		PhysicalDeviceRayTracingPropertiesNv = 1000165009,
+		RayTracingShaderGroupCreateInfoNv = 1000165011,
+		AccelerationStructureInfoNv = 1000165012,
+		PhysicalDeviceRepresentativeFragmentTestFeaturesNv = 1000166000,
+		PipelineRepresentativeFragmentTestStateCreateInfoNv = 1000166001,
+		PhysicalDeviceMaintenance3PropertiesKhr = PhysicalDeviceMaintenance3Properties,
+		DescriptorSetLayoutSupportKhr = DescriptorSetLayoutSupport,
+		PhysicalDeviceImageViewImageFormatInfoExt = 1000170000,
+		FilterCubicImageViewImageFormatPropertiesExt = 1000170001,
 		DeviceQueueGlobalPriorityCreateInfoExt = 1000174000,
+		PhysicalDevice8BitStorageFeaturesKhr = 1000177000,
 		ImportMemoryHostPointerInfoExt = 1000178000,
 		MemoryHostPointerPropertiesExt = 1000178001,
 		PhysicalDeviceExternalMemoryHostPropertiesExt = 1000178002,
+		PhysicalDeviceShaderAtomicInt64FeaturesKhr = 1000180000,
+		CalibratedTimestampInfoExt = 1000184000,
+		PhysicalDeviceShaderCorePropertiesAmd = 1000185000,
+		DeviceMemoryOverallocationCreateInfoAmd = 1000189000,
+		PhysicalDeviceVertexAttributeDivisorPropertiesExt = 1000190000,
+		PipelineVertexInputDivisorStateCreateInfoExt = 1000190001,
+		PhysicalDeviceVertexAttributeDivisorFeaturesExt = 1000190002,
+		PresentFrameTokenGGP = 1000191000,
+		PipelineCreationFeedbackCreateInfoExt = 1000192000,
+		PhysicalDeviceDriverPropertiesKhr = 1000196000,
+		PhysicalDeviceFloatControlsPropertiesKhr = 1000197000,
+		PhysicalDeviceDepthStencilResolvePropertiesKhr = 1000199000,
+		SubpassDescriptionDepthStencilResolveKhr = 1000199001,
+		PhysicalDeviceComputeShaderDerivativesFeaturesNv = 1000201000,
+		PhysicalDeviceMeshShaderFeaturesNv = 1000202000,
+		PhysicalDeviceMeshShaderPropertiesNv = 1000202001,
+		PhysicalDeviceFragmentShaderBarycentricFeaturesNv = 1000203000,
+		PhysicalDeviceShaderImageFootprintFeaturesNv = 1000204000,
+		PipelineViewportExclusiveScissorStateCreateInfoNv = 1000205000,
+		PhysicalDeviceExclusiveScissorFeaturesNv = 1000205002,
+		CheckpointDataNv = 1000206000,
+		QueueFamilyCheckpointPropertiesNv = 1000206001,
+		PhysicalDeviceShaderIntegerFunctions2FeaturesIntel = 1000209000,
+		QueryPoolCreateInfoIntel = 1000210000,
+		InitializePerformanceApiInfoIntel = 1000210001,
+		PerformanceMarkerInfoIntel = 1000210002,
+		PerformanceStreamMarkerInfoIntel = 1000210003,
+		PerformanceOverrideInfoIntel = 1000210004,
+		PerformanceConfigurationAcquireInfoIntel = 1000210005,
+		PhysicalDeviceVulkanMemoryModelFeaturesKhr = 1000211000,
+		PhysicalDevicePCIBusInfoPropertiesExt = 1000212000,
+		DisplayNativeHdrSurfaceCapabilitiesAmd = 1000213000,
+		SwapchainDisplayNativeHdrCreateInfoAmd = 1000213001,
+		ImagepipeSurfaceCreateInfoFuchsia = 1000214000,
+		MetalSurfaceCreateInfoExt = 1000217000,
+		PhysicalDeviceFragmentDensityMapFeaturesExt = 1000218000,
+		PhysicalDeviceFragmentDensityMapPropertiesExt = 1000218001,
+		RenderPassFragmentDensityMapCreateInfoExt = 1000218002,
+		PhysicalDeviceScalarBlockLayoutFeaturesExt = 1000221000,
+		PhysicalDeviceMemoryBudgetPropertiesExt = 1000237000,
+		PhysicalDeviceMemoryPriorityFeaturesExt = 1000238000,
+		MemoryPriorityAllocateInfoExt = 1000238001,
+		SurfaceProtectedCapabilitiesKhr = 1000239000,
+		PhysicalDeviceDedicatedAllocationImageAliasingFeaturesNv = 1000240000,
+		PhysicalDeviceBufferDeviceAddressFeaturesExt = 1000244000,
+		PhysicalDeviceBufferAddressFeaturesExt = PhysicalDeviceBufferDeviceAddressFeaturesExt,
+		BufferDeviceAddressInfoExt = 1000244001,
+		BufferDeviceAddressCreateInfoExt = 1000244002,
+		ImageStencilUsageCreateInfoExt = 1000246000,
+		ValidationFeaturesExt = 1000247000,
+		PhysicalDeviceCooperativeMatrixFeaturesNv = 1000249000,
+		CooperativeMatrixPropertiesNv = 1000249001,
+		PhysicalDeviceCooperativeMatrixPropertiesNv = 1000249002,
+		PhysicalDeviceCoverageReductionModeFeaturesNv = 1000250000,
+		PipelineCoverageReductionStateCreateInfoNv = 1000250001,
+		FramebufferMixedSamplesCombinationNv = 1000250002,
+		PhysicalDeviceFragmentShaderInterlockFeaturesExt = 1000251000,
+		PhysicalDeviceYcbcrImageArraysFeaturesExt = 1000252000,
+		PhysicalDeviceUniformBufferStandardLayoutFeaturesKhr = 1000253000,
+		SurfaceFullScreenExclusiveInfoExt = 1000255000,
+		SurfaceCapabilitiesFullScreenExclusiveExt = 1000255002,
+		SurfaceFullScreenExclusiveWin32InfoExt = 1000255001,
+		HeadlessSurfaceCreateInfoExt = 1000256000,
+		PhysicalDeviceHostQueryResetFeaturesExt = 1000261000,
+		PhysicalDeviceSubgroupProperties = 1000094000,
+		BindBufferMemoryInfo = 1000157000,
+		BindImageMemoryInfo = 1000157001,
+		PhysicalDevice16BitStorageFeatures = 1000083000,
+		MemoryDedicatedRequirements = 1000127000,
+		MemoryDedicatedAllocateInfo = 1000127001,
+		MemoryAllocateFlagsInfo = 1000060000,
+		DeviceGroupRenderPassBeginInfo = 1000060003,
+		DeviceGroupCommandBufferBeginInfo = 1000060004,
+		DeviceGroupSubmitInfo = 1000060005,
+		DeviceGroupBindSparseInfo = 1000060006,
+		BindBufferMemoryDeviceGroupInfo = 1000060013,
+		BindImageMemoryDeviceGroupInfo = 1000060014,
+		PhysicalDeviceGroupProperties = 1000070000,
+		DeviceGroupDeviceCreateInfo = 1000070001,
+		BufferMemoryRequirementsInfo2 = 1000146000,
+		ImageMemoryRequirementsInfo2 = 1000146001,
+		ImageSparseMemoryRequirementsInfo2 = 1000146002,
+		MemoryRequirements2 = 1000146003,
+		SparseImageMemoryRequirements2 = 1000146004,
+		PhysicalDeviceFeatures2 = 1000059000,
+		PhysicalDeviceProperties2 = 1000059001,
+		FormatProperties2 = 1000059002,
+		ImageFormatProperties2 = 1000059003,
+		PhysicalDeviceImageFormatInfo2 = 1000059004,
+		QueueFamilyProperties2 = 1000059005,
+		PhysicalDeviceMemoryProperties2 = 1000059006,
+		SparseImageFormatProperties2 = 1000059007,
+		PhysicalDeviceSparseImageFormatInfo2 = 1000059008,
+		PhysicalDevicePointClippingProperties = 1000117000,
+		RenderPassInputAttachmentAspectCreateInfo = 1000117001,
+		ImageViewUsageCreateInfo = 1000117002,
+		PipelineTessellationDomainOriginStateCreateInfo = 1000117003,
+		RenderPassMultiviewCreateInfo = 1000053000,
+		PhysicalDeviceMultiviewFeatures = 1000053001,
+		PhysicalDeviceMultiviewProperties = 1000053002,
+		PhysicalDeviceVariablePointersFeatures = 1000120000,
+		PhysicalDeviceVariablePointerFeatures = PhysicalDeviceVariablePointersFeatures,
+		ProtectedSubmitInfo = 1000145000,
+		PhysicalDeviceProtectedMemoryFeatures = 1000145001,
+		PhysicalDeviceProtectedMemoryProperties = 1000145002,
+		DeviceQueueInfo2 = 1000145003,
+		SamplerYcbcrConversionCreateInfo = 1000156000,
+		SamplerYcbcrConversionInfo = 1000156001,
+		BindImagePlaneMemoryInfo = 1000156002,
+		ImagePlaneMemoryRequirementsInfo = 1000156003,
+		PhysicalDeviceSamplerYcbcrConversionFeatures = 1000156004,
+		SamplerYcbcrConversionImageFormatProperties = 1000156005,
+		DescriptorUpdateTemplateCreateInfo = 1000085000,
+		PhysicalDeviceExternalImageFormatInfo = 1000071000,
+		ExternalImageFormatProperties = 1000071001,
+		PhysicalDeviceExternalBufferInfo = 1000071002,
+		ExternalBufferProperties = 1000071003,
+		PhysicalDeviceIDProperties = 1000071004,
+		ExternalMemoryBufferCreateInfo = 1000072000,
+		ExternalMemoryImageCreateInfo = 1000072001,
+		ExportMemoryAllocateInfo = 1000072002,
+		PhysicalDeviceExternalFenceInfo = 1000112000,
+		ExternalFenceProperties = 1000112001,
+		ExportFenceCreateInfo = 1000113000,
+		ExportSemaphoreCreateInfo = 1000077000,
+		PhysicalDeviceExternalSemaphoreInfo = 1000076000,
+		ExternalSemaphoreProperties = 1000076001,
+		PhysicalDeviceMaintenance3Properties = 1000168000,
+		DescriptorSetLayoutSupport = 1000168001,
+		PhysicalDeviceShaderDrawParametersFeatures = 1000063000,
+		PhysicalDeviceShaderDrawParameterFeatures = PhysicalDeviceShaderDrawParametersFeatures,
 	}
 
 	public enum SystemAllocationScope : int
@@ -1089,6 +1414,7 @@ namespace Vulkan
 		Nearest = 0,
 		Linear = 1,
 		CubicImg = 1000015000,
+		CubicExt = CubicImg,
 	}
 
 	public enum SamplerMipmapMode : int
@@ -1123,7 +1449,15 @@ namespace Vulkan
 		Host = 0x4000,
 		AllGraphics = 0x8000,
 		AllCommands = 0x10000,
+		TransformFeedbackExt = 0x1000000,
+		ConditionalRenderingExt = 0x40000,
 		CommandProcessNvx = 0x20000,
+		ShadingRateImageNv = 0x400000,
+		RayTracingShaderNv = 0x200000,
+		AccelerationStructureBuildNv = 0x2000000,
+		TaskShaderNv = 0x80000,
+		MeshShaderNv = 0x100000,
+		FragmentDensityProcessExt = 0x800000,
 	}
 
 	[Flags]
@@ -1137,13 +1471,13 @@ namespace Vulkan
 	[Flags]
 	public enum SampleCountFlags : int
 	{
-		Count1 = 0x1,
-		Count2 = 0x2,
-		Count4 = 0x4,
-		Count8 = 0x8,
-		Count16 = 0x10,
-		Count32 = 0x20,
-		Count64 = 0x40,
+		Count_1 = 0x1,
+		Count_2 = 0x2,
+		Count_4 = 0x4,
+		Count_8 = 0x8,
+		Count_16 = 0x10,
+		Count_32 = 0x20,
+		Count_64 = 0x40,
 	}
 
 	[Flags]
@@ -1156,14 +1490,15 @@ namespace Vulkan
 	public enum DescriptorPoolCreateFlags : int
 	{
 		FreeDescriptorSet = 0x1,
+		UpdateAfterBindExt = 0x2,
 	}
 
 	[Flags]
 	public enum DependencyFlags : int
 	{
 		ByRegion = 0x1,
-		ViewLocalKhx = 0x2,
-		DeviceGroupKhx = 0x4,
+		DeviceGroup = 0x4,
+		ViewLocal = 0x2,
 	}
 
 	public enum ObjectType : int
@@ -1199,11 +1534,31 @@ namespace Vulkan
 		DisplayKhr = 1000002000,
 		DisplayModeKhr = 1000002001,
 		DebugReportCallbackExt = 1000011000,
-		DescriptorUpdateTemplateKhr = 1000085000,
+		DescriptorUpdateTemplateKhr = DescriptorUpdateTemplate,
 		ObjectTableNvx = 1000086000,
 		IndirectCommandsLayoutNvx = 1000086001,
-		SamplerYcbcrConversionKhr = 1000156000,
+		DebugUtilsMessengerExt = 1000128000,
+		SamplerYcbcrConversionKhr = SamplerYcbcrConversion,
 		ValidationCacheExt = 1000160000,
+		AccelerationStructureNv = 1000165000,
+		PerformanceConfigurationIntel = 1000210000,
+		SamplerYcbcrConversion = 1000156000,
+		DescriptorUpdateTemplate = 1000085000,
+	}
+
+	[Flags]
+	public enum DescriptorBindingFlagsExt : int
+	{
+		UpdateAfterBind = 0x1,
+		UpdateUnusedWhilePending = 0x2,
+		PartiallyBound = 0x4,
+		VariableDescriptorCount = 0x8,
+	}
+
+	[Flags]
+	public enum ConditionalRenderingFlagsExt : int
+	{
+		Inverted = 0x1,
 	}
 
 	[Flags]
@@ -1243,10 +1598,11 @@ namespace Vulkan
 		PushConstant = 4,
 	}
 
-	public enum DescriptorUpdateTemplateTypeKhr : int
+	public enum DescriptorUpdateTemplateType : int
 	{
 		DescriptorSet = 0,
-		PushDescriptors = 1,
+		PushDescriptorsKhr = 1,
+		DescriptorSetKhr = DescriptorSet,
 	}
 
 	public enum ViewportCoordinateSwizzleNv : int
@@ -1274,10 +1630,12 @@ namespace Vulkan
 		PerViewPositionXOnlyNvx = 0x2,
 	}
 
-	public enum PointClippingBehaviorKhr : int
+	public enum PointClippingBehavior : int
 	{
 		AllClipPlanes = 0,
 		UserClipPlanesOnly = 1,
+		AllClipPlanesKhr = AllClipPlanes,
+		UserClipPlanesOnlyKhr = UserClipPlanesOnly,
 	}
 
 	public enum CoverageModulationModeNv : int
@@ -1286,6 +1644,12 @@ namespace Vulkan
 		Rgb = 1,
 		Alpha = 2,
 		Rgba = 3,
+	}
+
+	public enum CoverageReductionModeNv : int
+	{
+		Merge = 0,
+		Truncate = 1,
 	}
 
 	public enum ValidationCacheHeaderVersionExt : int
@@ -1308,6 +1672,14 @@ namespace Vulkan
 		Realtime = 1024,
 	}
 
+	public enum TimeDomainExt : int
+	{
+		Device = 0,
+		ClockMonotonic = 1,
+		ClockMonotonicRaw = 2,
+		QueryPerformanceCounter = 3,
+	}
+
 	public enum ConservativeRasterizationModeExt : int
 	{
 		Disabled = 0,
@@ -1315,12 +1687,149 @@ namespace Vulkan
 		Underestimate = 2,
 	}
 
+	[Flags]
+	public enum ResolveModeFlagsKhr : int
+	{
+		NoneKhr = 0,
+		SampleZero = 0x1,
+		Average = 0x2,
+		Min = 0x4,
+		Max = 0x8,
+	}
+
+	[Flags]
+	public enum GeometryFlagsNv : int
+	{
+		Opaque = 0x1,
+		NoDuplicateAnyHitInvocation = 0x2,
+	}
+
+	[Flags]
+	public enum GeometryInstanceFlagsNv : int
+	{
+		TriangleCullDisable = 0x1,
+		TriangleFrontCounterclockwise = 0x2,
+		ForceOpaque = 0x4,
+		ForceNoOpaque = 0x8,
+	}
+
+	[Flags]
+	public enum BuildAccelerationStructureFlagsNv : int
+	{
+		AllowUpdate = 0x1,
+		AllowCompaction = 0x2,
+		PreferFastTrace = 0x4,
+		PreferFastBuild = 0x8,
+		LowMemory = 0x10,
+	}
+
+	public enum CopyAccelerationStructureModeNv : int
+	{
+		Clone = 0,
+		Compact = 1,
+	}
+
+	public enum AccelerationStructureTypeNv : int
+	{
+		TopLevel = 0,
+		BottomLevel = 1,
+	}
+
+	public enum GeometryTypeNv : int
+	{
+		Triangles = 0,
+		Aabbs = 1,
+	}
+
+	public enum RayTracingShaderGroupTypeNv : int
+	{
+		General = 0,
+		TrianglesHitGroup = 1,
+		ProceduralHitGroup = 2,
+	}
+
+	public enum AccelerationStructureMemoryRequirementsTypeNv : int
+	{
+		Object = 0,
+		BuildScratch = 1,
+		UpdateScratch = 2,
+	}
+
+	public enum MemoryOverallocationBehaviorAmd : int
+	{
+		Default = 0,
+		Allowed = 1,
+		Disallowed = 2,
+	}
+
+	public enum ScopeNv : int
+	{
+		Device = 1,
+		Workgroup = 2,
+		Subgroup = 3,
+		QueueFamily = 5,
+	}
+
+	public enum ComponentTypeNv : int
+	{
+		Float16 = 0,
+		Float32 = 1,
+		Float64 = 2,
+		Sint8 = 3,
+		Sint16 = 4,
+		Sint32 = 5,
+		Sint64 = 6,
+		Uint8 = 7,
+		Uint16 = 8,
+		Uint32 = 9,
+		Uint64 = 10,
+	}
+
+	[Flags]
+	public enum PipelineCreationFeedbackFlagsExt : int
+	{
+		Valid = 0x1,
+		ApplicationPipelineCacheHit = 0x2,
+		BasePipelineAcceleration = 0x4,
+	}
+
+	public enum PerformanceConfigurationTypeIntel : int
+	{
+		CommandQueueMetricsDiscoveryActivated = 0,
+	}
+
+	public enum QueryPoolSamplingModeIntel : int
+	{
+		Manual = 0,
+	}
+
+	public enum PerformanceOverrideTypeIntel : int
+	{
+		NullHardware = 0,
+		FlushGpuCaches = 1,
+	}
+
+	public enum PerformanceParameterTypeIntel : int
+	{
+		HwCountersSupported = 0,
+		StreamMarkerValidBits = 1,
+	}
+
+	public enum PerformanceValueTypeIntel : int
+	{
+		Uint32 = 0,
+		Uint64 = 1,
+		Float = 2,
+		Bool = 3,
+		String = 4,
+	}
+
 	public enum ColorSpaceKhr : int
 	{
 		SrgbNonlinear = 0,
 		DisplayP3NonlinearExt = 1000104001,
 		ExtendedSrgbLinearExt = 1000104002,
-		DciP3LinearExt = 1000104003,
+		DisplayP3LinearExt = 1000104003,
 		DciP3NonlinearExt = 1000104004,
 		Bt709LinearExt = 1000104005,
 		Bt709NonlinearExt = 1000104006,
@@ -1332,6 +1841,8 @@ namespace Vulkan
 		AdobergbNonlinearExt = 1000104012,
 		PassThroughExt = 1000104013,
 		ExtendedSrgbNonlinearExt = 1000104014,
+		DciP3LinearExt = DisplayP3LinearExt,
+		DisplayNativeAmd = 1000213000,
 	}
 
 	[Flags]
@@ -1417,13 +1928,18 @@ namespace Vulkan
 		SurfaceKhr = 26,
 		SwapchainKhr = 27,
 		DebugReportCallbackExt = 28,
+		DebugReport = DebugReportCallbackExt,
 		DisplayKhr = 29,
 		DisplayModeKhr = 30,
 		ObjectTableNvx = 31,
 		IndirectCommandsLayoutNvx = 32,
 		ValidationCacheExt = 33,
-		DescriptorUpdateTemplateKhr = 1000085000,
-		SamplerYcbcrConversionKhr = 1000156000,
+		ValidationCache = ValidationCacheExt,
+		SamplerYcbcrConversion = 1000156000,
+		DescriptorUpdateTemplate = 1000085000,
+		DescriptorUpdateTemplateKhr = DescriptorUpdateTemplate,
+		SamplerYcbcrConversionKhr = SamplerYcbcrConversion,
+		AccelerationStructureNv = 1000165000,
 	}
 
 	public enum RasterizationOrderAmd : int
@@ -1455,8 +1971,25 @@ namespace Vulkan
 		Shaders = 1,
 	}
 
+	public enum ValidationFeatureEnableExt : int
+	{
+		GpuAssisted = 0,
+		GpuAssistedReserveBindingSlot = 1,
+	}
+
+	public enum ValidationFeatureDisableExt : int
+	{
+		All = 0,
+		Shaders = 1,
+		ThreadSafety = 2,
+		ApiParameters = 3,
+		ObjectLifetimes = 4,
+		CoreChecks = 5,
+		UniqueHandles = 6,
+	}
+
 	[Flags]
-	public enum ExternalMemoryHandleTypeFlagsKhr : int
+	public enum ExternalMemoryHandleTypeFlags : int
 	{
 		OpaqueFd = 0x1,
 		OpaqueWin32 = 0x2,
@@ -1465,13 +1998,14 @@ namespace Vulkan
 		D3D11TextureKmt = 0x10,
 		D3D12Heap = 0x20,
 		D3D12Resource = 0x40,
-		DmaBufBitExt = 0x200,
-		HostAllocationBitExt = 0x80,
-		HostMappedForeignMemoryBitExt = 0x100,
+		DmaBufExt = 0x200,
+		AndroidHardwareBufferAndroid = 0x400,
+		HostAllocationExt = 0x80,
+		HostMappedForeignMemoryExt = 0x100,
 	}
 
 	[Flags]
-	public enum ExternalMemoryFeatureFlagsKhr : int
+	public enum ExternalMemoryFeatureFlags : int
 	{
 		DedicatedOnly = 0x1,
 		Exportable = 0x2,
@@ -1479,7 +2013,7 @@ namespace Vulkan
 	}
 
 	[Flags]
-	public enum ExternalSemaphoreHandleTypeFlagsKhr : int
+	public enum ExternalSemaphoreHandleTypeFlags : int
 	{
 		OpaqueFd = 0x1,
 		OpaqueWin32 = 0x2,
@@ -1489,20 +2023,20 @@ namespace Vulkan
 	}
 
 	[Flags]
-	public enum ExternalSemaphoreFeatureFlagsKhr : int
+	public enum ExternalSemaphoreFeatureFlags : int
 	{
 		Exportable = 0x1,
 		Importable = 0x2,
 	}
 
 	[Flags]
-	public enum SemaphoreImportFlagsKhr : int
+	public enum SemaphoreImportFlags : int
 	{
 		Temporary = 0x1,
 	}
 
 	[Flags]
-	public enum ExternalFenceHandleTypeFlagsKhr : int
+	public enum ExternalFenceHandleTypeFlags : int
 	{
 		OpaqueFd = 0x1,
 		OpaqueWin32 = 0x2,
@@ -1511,14 +2045,14 @@ namespace Vulkan
 	}
 
 	[Flags]
-	public enum ExternalFenceFeatureFlagsKhr : int
+	public enum ExternalFenceFeatureFlags : int
 	{
 		Exportable = 0x1,
 		Importable = 0x2,
 	}
 
 	[Flags]
-	public enum FenceImportFlagsKhr : int
+	public enum FenceImportFlags : int
 	{
 		Temporary = 0x1,
 	}
@@ -1547,7 +2081,7 @@ namespace Vulkan
 	}
 
 	[Flags]
-	public enum PeerMemoryFeatureFlagsKhx : int
+	public enum PeerMemoryFeatureFlags : int
 	{
 		CopySrc = 0x1,
 		CopyDst = 0x2,
@@ -1556,13 +2090,13 @@ namespace Vulkan
 	}
 
 	[Flags]
-	public enum MemoryAllocateFlagsKhx : int
+	public enum MemoryAllocateFlags : int
 	{
 		DeviceMask = 0x1,
 	}
 
 	[Flags]
-	public enum DeviceGroupPresentModeFlagsKhx : int
+	public enum DeviceGroupPresentModeFlagsKhr : int
 	{
 		Local = 0x1,
 		Remote = 0x2,
@@ -1573,34 +2107,61 @@ namespace Vulkan
 	[Flags]
 	public enum SwapchainCreateFlagsKhr : int
 	{
-		BindSfrBitKhx = 0x1,
+		SplitInstanceBindRegions = 0x1,
+		Protected = 0x2,
+		MutableFormat = 0x4,
 	}
 
-	public enum TessellationDomainOriginKhr : int
+	[Flags]
+	public enum SubgroupFeatureFlags : int
+	{
+		Basic = 0x1,
+		Vote = 0x2,
+		Arithmetic = 0x4,
+		Ballot = 0x8,
+		Shuffle = 0x10,
+		ShuffleRelative = 0x20,
+		Clustered = 0x40,
+		Quad = 0x80,
+		PartitionedNv = 0x100,
+	}
+
+	public enum TessellationDomainOrigin : int
 	{
 		UpperLeft = 0,
 		LowerLeft = 1,
+		UpperLeftKhr = UpperLeft,
+		LowerLeftKhr = LowerLeft,
 	}
 
-	public enum SamplerYcbcrModelConversionKhr : int
+	public enum SamplerYcbcrModelConversion : int
 	{
 		RgbIdentity = 0,
 		YcbcrIdentity = 1,
 		Ycbcr709 = 2,
 		Ycbcr601 = 3,
 		Ycbcr2020 = 4,
+		RgbIdentityKhr = RgbIdentity,
+		YcbcrIdentityKhr = YcbcrIdentity,
+		Ycbcr709Khr = Ycbcr709,
+		Ycbcr601Khr = Ycbcr601,
+		Ycbcr2020Khr = Ycbcr2020,
 	}
 
-	public enum SamplerYcbcrRangeKhr : int
+	public enum SamplerYcbcrRange : int
 	{
 		ItuFull = 0,
 		ItuNarrow = 1,
+		ItuFullKhr = ItuFull,
+		ItuNarrowKhr = ItuNarrow,
 	}
 
-	public enum ChromaLocationKhr : int
+	public enum ChromaLocation : int
 	{
 		CositedEven = 0,
 		Midpoint = 1,
+		CositedEvenKhr = CositedEven,
+		MidpointKhr = Midpoint,
 	}
 
 	public enum SamplerReductionModeExt : int
@@ -1615,5 +2176,76 @@ namespace Vulkan
 		Uncorrelated = 0,
 		Disjoint = 1,
 		Conjoint = 2,
+	}
+
+	[Flags]
+	public enum DebugUtilsMessageSeverityFlagsExt : int
+	{
+		Verbose = 0x1,
+		Info = 0x10,
+		Warning = 0x100,
+		Error = 0x1000,
+	}
+
+	[Flags]
+	public enum DebugUtilsMessageTypeFlagsExt : int
+	{
+		General = 0x1,
+		Validation = 0x2,
+		Performance = 0x4,
+	}
+
+	public enum FullScreenExclusiveExt : int
+	{
+		Default = 0,
+		Allowed = 1,
+		Disallowed = 2,
+		ApplicationControlled = 3,
+	}
+
+	public enum VendorId : int
+	{
+		Viv = 0x10001,
+		Vsi = 0x10002,
+		Kazan = 0x10003,
+	}
+
+	public enum DriverIdKhr : int
+	{
+		AmdProprietary = 1,
+		AmdOpenSource = 2,
+		MesaRadv = 3,
+		NvidiaProprietary = 4,
+		IntelProprietaryWindows = 5,
+		IntelOpenSourceMesa = 6,
+		ImaginationProprietary = 7,
+		QualcommProprietary = 8,
+		ArmProprietary = 9,
+		GoogleSwiftshader = 10,
+		GGPProprietary = 11,
+	}
+
+	public enum ShadingRatePaletteEntryNv : int
+	{
+		NoInvocations = 0,
+		_16InvocationsPerPixel = 1,
+		_8InvocationsPerPixel = 2,
+		_4InvocationsPerPixel = 3,
+		_2InvocationsPerPixel = 4,
+		_1InvocationPerPixel = 5,
+		_1InvocationPer2X1Pixels = 6,
+		_1InvocationPer1X2Pixels = 7,
+		_1InvocationPer2X2Pixels = 8,
+		_1InvocationPer4X2Pixels = 9,
+		_1InvocationPer2X4Pixels = 10,
+		_1InvocationPer4X4Pixels = 11,
+	}
+
+	public enum CoarseSampleOrderTypeNv : int
+	{
+		Default = 0,
+		Custom = 1,
+		PixelMajor = 2,
+		SampleMajor = 3,
 	}
 }

--- a/src/Vulkan/Handles.cs
+++ b/src/Vulkan/Handles.cs
@@ -109,6 +109,40 @@ namespace Vulkan
 			}
 		}
 
+		public SurfaceKhr CreateImagePipeSurfaceFUCHSIA (ImagePipeSurfaceCreateInfoFUCHSIA pCreateInfo, AllocationCallbacks pAllocator = null)
+		{
+			Result result;
+			SurfaceKhr pSurface;
+			unsafe {
+				pSurface = new SurfaceKhr ();
+
+				fixed (UInt64* ptrpSurface = &pSurface.m) {
+					result = Interop.NativeMethods.vkCreateImagePipeSurfaceFUCHSIA (this.m, pCreateInfo != null ? pCreateInfo.m : (Interop.ImagePipeSurfaceCreateInfoFUCHSIA*)default(IntPtr), pAllocator != null ? pAllocator.m : null, ptrpSurface);
+				}
+				if (result != Result.Success)
+					throw new ResultException (result);
+
+				return pSurface;
+			}
+		}
+
+		public SurfaceKhr CreateStreamDescriptorSurfaceGGP (StreamDescriptorSurfaceCreateInfoGGP pCreateInfo, AllocationCallbacks pAllocator = null)
+		{
+			Result result;
+			SurfaceKhr pSurface;
+			unsafe {
+				pSurface = new SurfaceKhr ();
+
+				fixed (UInt64* ptrpSurface = &pSurface.m) {
+					result = Interop.NativeMethods.vkCreateStreamDescriptorSurfaceGGP (this.m, pCreateInfo != null ? pCreateInfo.m : (Interop.StreamDescriptorSurfaceCreateInfoGGP*)default(IntPtr), pAllocator != null ? pAllocator.m : null, ptrpSurface);
+				}
+				if (result != Result.Success)
+					throw new ResultException (result);
+
+				return pSurface;
+			}
+		}
+
 		public DebugReportCallbackExt CreateDebugReportCallbackEXT (DebugReportCallbackCreateInfoExt pCreateInfo, AllocationCallbacks pAllocator = null)
 		{
 			Result result;
@@ -140,23 +174,6 @@ namespace Vulkan
 			}
 		}
 
-		public SurfaceKhr CreateIOSSurfaceMVK (IOSSurfaceCreateInfoMvk pCreateInfo, AllocationCallbacks pAllocator = null)
-		{
-			Result result;
-			SurfaceKhr pSurface;
-			unsafe {
-				pSurface = new SurfaceKhr ();
-
-				fixed (UInt64* ptrpSurface = &pSurface.m) {
-					result = Interop.NativeMethods.vkCreateIOSSurfaceMVK (this.m, pCreateInfo != null ? pCreateInfo.m : (Interop.IOSSurfaceCreateInfoMvk*)default(IntPtr), pAllocator != null ? pAllocator.m : null, ptrpSurface);
-				}
-				if (result != Result.Success)
-					throw new ResultException (result);
-
-				return pSurface;
-			}
-		}
-
 		public SurfaceKhr CreateMacOSSurfaceMVK (MacOSSurfaceCreateInfoMvk pCreateInfo, AllocationCallbacks pAllocator = null)
 		{
 			Result result;
@@ -166,6 +183,54 @@ namespace Vulkan
 
 				fixed (UInt64* ptrpSurface = &pSurface.m) {
 					result = Interop.NativeMethods.vkCreateMacOSSurfaceMVK (this.m, pCreateInfo != null ? pCreateInfo.m : (Interop.MacOSSurfaceCreateInfoMvk*)default(IntPtr), pAllocator != null ? pAllocator.m : null, ptrpSurface);
+				}
+				if (result != Result.Success)
+					throw new ResultException (result);
+
+				return pSurface;
+			}
+		}
+
+		public DebugUtilsMessengerExt CreateDebugUtilsMessengerEXT (DebugUtilsMessengerCreateInfoExt pCreateInfo, AllocationCallbacks pAllocator = null)
+		{
+			Result result;
+			DebugUtilsMessengerExt pMessenger;
+			unsafe {
+				pMessenger = new DebugUtilsMessengerExt ();
+
+				fixed (UInt64* ptrpMessenger = &pMessenger.m) {
+					result = Interop.NativeMethods.vkCreateDebugUtilsMessengerEXT (this.m, pCreateInfo != null ? pCreateInfo.m : (Interop.DebugUtilsMessengerCreateInfoExt*)default(IntPtr), pAllocator != null ? pAllocator.m : null, ptrpMessenger);
+				}
+				if (result != Result.Success)
+					throw new ResultException (result);
+
+				return pMessenger;
+			}
+		}
+
+		public void DestroyDebugUtilsMessengerEXT (DebugUtilsMessengerExt messenger, AllocationCallbacks pAllocator = null)
+		{
+			unsafe {
+				Interop.NativeMethods.vkDestroyDebugUtilsMessengerEXT (this.m, messenger != null ? messenger.m : default(UInt64), pAllocator != null ? pAllocator.m : null);
+			}
+		}
+
+		public void SubmitDebugUtilsMessageEXT (DebugUtilsMessageSeverityFlagsExt messageSeverity, DebugUtilsMessageTypeFlagsExt messageTypes, DebugUtilsMessengerCallbackDataExt pCallbackData)
+		{
+			unsafe {
+				Interop.NativeMethods.vkSubmitDebugUtilsMessageEXT (this.m, messageSeverity, messageTypes, pCallbackData != null ? pCallbackData.m : (Interop.DebugUtilsMessengerCallbackDataExt*)default(IntPtr));
+			}
+		}
+
+		public SurfaceKhr CreateHeadlessSurfaceEXT (HeadlessSurfaceCreateInfoExt pCreateInfo, AllocationCallbacks pAllocator = null)
+		{
+			Result result;
+			SurfaceKhr pSurface;
+			unsafe {
+				pSurface = new SurfaceKhr ();
+
+				fixed (UInt64* ptrpSurface = &pSurface.m) {
+					result = Interop.NativeMethods.vkCreateHeadlessSurfaceEXT (this.m, pCreateInfo != null ? pCreateInfo.m : (Interop.HeadlessSurfaceCreateInfoExt*)default(IntPtr), pAllocator != null ? pAllocator.m : null, ptrpSurface);
 				}
 				if (result != Result.Success)
 					throw new ResultException (result);
@@ -626,46 +691,82 @@ namespace Vulkan
 			}
 		}
 
-		public PhysicalDeviceFeatures2Khr GetFeatures2KHR ()
+		public PhysicalDeviceFeatures2 GetFeatures2 ()
 		{
-			PhysicalDeviceFeatures2Khr pFeatures;
+			PhysicalDeviceFeatures2 pFeatures;
 			unsafe {
-				pFeatures = new PhysicalDeviceFeatures2Khr ();
-				Interop.NativeMethods.vkGetPhysicalDeviceFeatures2KHR (this.m, pFeatures != null ? pFeatures.m : (Interop.PhysicalDeviceFeatures2Khr*)default(IntPtr));
+				pFeatures = new PhysicalDeviceFeatures2 ();
+				Interop.NativeMethods.vkGetPhysicalDeviceFeatures2 (this.m, pFeatures != null ? pFeatures.m : (Interop.PhysicalDeviceFeatures2*)default(IntPtr));
 
 				return pFeatures;
 			}
 		}
 
-		public PhysicalDeviceProperties2Khr GetProperties2KHR ()
+		[Obsolete ("GetFeatures2KHR is deprecated, please use GetFeatures2 instead.")]
+		public PhysicalDeviceFeatures2 GetFeatures2KHR ()
 		{
-			PhysicalDeviceProperties2Khr pProperties;
+			PhysicalDeviceFeatures2 pFeatures;
 			unsafe {
-				pProperties = new PhysicalDeviceProperties2Khr ();
-				Interop.NativeMethods.vkGetPhysicalDeviceProperties2KHR (this.m, pProperties != null ? pProperties.m : (Interop.PhysicalDeviceProperties2Khr*)default(IntPtr));
+				pFeatures = new PhysicalDeviceFeatures2 ();
+				Interop.NativeMethods.vkGetPhysicalDeviceFeatures2KHR (this.m, pFeatures != null ? pFeatures.m : (Interop.PhysicalDeviceFeatures2*)default(IntPtr));
+
+				return pFeatures;
+			}
+		}
+
+		public PhysicalDeviceProperties2 GetProperties2 ()
+		{
+			PhysicalDeviceProperties2 pProperties;
+			unsafe {
+				pProperties = new PhysicalDeviceProperties2 ();
+				Interop.NativeMethods.vkGetPhysicalDeviceProperties2 (this.m, pProperties != null ? pProperties.m : (Interop.PhysicalDeviceProperties2*)default(IntPtr));
 
 				return pProperties;
 			}
 		}
 
-		public FormatProperties2Khr GetFormatProperties2KHR (Format format)
+		[Obsolete ("GetProperties2KHR is deprecated, please use GetProperties2 instead.")]
+		public PhysicalDeviceProperties2 GetProperties2KHR ()
 		{
-			FormatProperties2Khr pFormatProperties;
+			PhysicalDeviceProperties2 pProperties;
 			unsafe {
-				pFormatProperties = new FormatProperties2Khr ();
-				Interop.NativeMethods.vkGetPhysicalDeviceFormatProperties2KHR (this.m, format, pFormatProperties != null ? pFormatProperties.m : (Interop.FormatProperties2Khr*)default(IntPtr));
+				pProperties = new PhysicalDeviceProperties2 ();
+				Interop.NativeMethods.vkGetPhysicalDeviceProperties2KHR (this.m, pProperties != null ? pProperties.m : (Interop.PhysicalDeviceProperties2*)default(IntPtr));
+
+				return pProperties;
+			}
+		}
+
+		public FormatProperties2 GetFormatProperties2 (Format format)
+		{
+			FormatProperties2 pFormatProperties;
+			unsafe {
+				pFormatProperties = new FormatProperties2 ();
+				Interop.NativeMethods.vkGetPhysicalDeviceFormatProperties2 (this.m, format, pFormatProperties != null ? pFormatProperties.m : (Interop.FormatProperties2*)default(IntPtr));
 
 				return pFormatProperties;
 			}
 		}
 
-		public ImageFormatProperties2Khr GetImageFormatProperties2KHR (PhysicalDeviceImageFormatInfo2Khr pImageFormatInfo)
+		[Obsolete ("GetFormatProperties2KHR is deprecated, please use GetFormatProperties2 instead.")]
+		public FormatProperties2 GetFormatProperties2KHR (Format format)
+		{
+			FormatProperties2 pFormatProperties;
+			unsafe {
+				pFormatProperties = new FormatProperties2 ();
+				Interop.NativeMethods.vkGetPhysicalDeviceFormatProperties2KHR (this.m, format, pFormatProperties != null ? pFormatProperties.m : (Interop.FormatProperties2*)default(IntPtr));
+
+				return pFormatProperties;
+			}
+		}
+
+		public ImageFormatProperties2 GetImageFormatProperties2 (PhysicalDeviceImageFormatInfo2 pImageFormatInfo)
 		{
 			Result result;
-			ImageFormatProperties2Khr pImageFormatProperties;
+			ImageFormatProperties2 pImageFormatProperties;
 			unsafe {
-				pImageFormatProperties = new ImageFormatProperties2Khr ();
-				result = Interop.NativeMethods.vkGetPhysicalDeviceImageFormatProperties2KHR (this.m, pImageFormatInfo != null ? pImageFormatInfo.m : (Interop.PhysicalDeviceImageFormatInfo2Khr*)default(IntPtr), pImageFormatProperties != null ? pImageFormatProperties.m : (Interop.ImageFormatProperties2Khr*)default(IntPtr));
+				pImageFormatProperties = new ImageFormatProperties2 ();
+				result = Interop.NativeMethods.vkGetPhysicalDeviceImageFormatProperties2 (this.m, pImageFormatInfo != null ? pImageFormatInfo.m : (Interop.PhysicalDeviceImageFormatInfo2*)default(IntPtr), pImageFormatProperties != null ? pImageFormatProperties.m : (Interop.ImageFormatProperties2*)default(IntPtr));
 				if (result != Result.Success)
 					throw new ResultException (result);
 
@@ -673,7 +774,47 @@ namespace Vulkan
 			}
 		}
 
-		public QueueFamilyProperties2Khr[] GetQueueFamilyProperties2KHR ()
+		[Obsolete ("GetImageFormatProperties2KHR is deprecated, please use GetImageFormatProperties2 instead.")]
+		public ImageFormatProperties2 GetImageFormatProperties2KHR (PhysicalDeviceImageFormatInfo2 pImageFormatInfo)
+		{
+			Result result;
+			ImageFormatProperties2 pImageFormatProperties;
+			unsafe {
+				pImageFormatProperties = new ImageFormatProperties2 ();
+				result = Interop.NativeMethods.vkGetPhysicalDeviceImageFormatProperties2KHR (this.m, pImageFormatInfo != null ? pImageFormatInfo.m : (Interop.PhysicalDeviceImageFormatInfo2*)default(IntPtr), pImageFormatProperties != null ? pImageFormatProperties.m : (Interop.ImageFormatProperties2*)default(IntPtr));
+				if (result != Result.Success)
+					throw new ResultException (result);
+
+				return pImageFormatProperties;
+			}
+		}
+
+		public QueueFamilyProperties2[] GetQueueFamilyProperties2 ()
+		{
+			unsafe {
+				UInt32 pQueueFamilyPropertyCount;
+				Interop.NativeMethods.vkGetPhysicalDeviceQueueFamilyProperties2 (this.m, &pQueueFamilyPropertyCount, null);
+				if (pQueueFamilyPropertyCount <= 0)
+					return null;
+
+				int size = Marshal.SizeOf (typeof (Interop.QueueFamilyProperties2));
+				var refpQueueFamilyProperties = new NativeReference ((int)(size * pQueueFamilyPropertyCount));
+				var ptrpQueueFamilyProperties = refpQueueFamilyProperties.Handle;
+				Interop.NativeMethods.vkGetPhysicalDeviceQueueFamilyProperties2 (this.m, &pQueueFamilyPropertyCount, (Interop.QueueFamilyProperties2*)ptrpQueueFamilyProperties);
+
+				if (pQueueFamilyPropertyCount <= 0)
+					return null;
+				var arr = new QueueFamilyProperties2 [pQueueFamilyPropertyCount];
+				for (int i = 0; i < pQueueFamilyPropertyCount; i++) {
+					arr [i] = new QueueFamilyProperties2 (new NativePointer (refpQueueFamilyProperties, (IntPtr)(&((Interop.QueueFamilyProperties2*)ptrpQueueFamilyProperties) [i])));
+				}
+
+				return arr;
+			}
+		}
+
+		[Obsolete ("GetQueueFamilyProperties2KHR is deprecated, please use GetQueueFamilyProperties2 instead.")]
+		public QueueFamilyProperties2[] GetQueueFamilyProperties2KHR ()
 		{
 			unsafe {
 				UInt32 pQueueFamilyPropertyCount;
@@ -681,85 +822,158 @@ namespace Vulkan
 				if (pQueueFamilyPropertyCount <= 0)
 					return null;
 
-				int size = Marshal.SizeOf (typeof (Interop.QueueFamilyProperties2Khr));
+				int size = Marshal.SizeOf (typeof (Interop.QueueFamilyProperties2));
 				var refpQueueFamilyProperties = new NativeReference ((int)(size * pQueueFamilyPropertyCount));
 				var ptrpQueueFamilyProperties = refpQueueFamilyProperties.Handle;
-				Interop.NativeMethods.vkGetPhysicalDeviceQueueFamilyProperties2KHR (this.m, &pQueueFamilyPropertyCount, (Interop.QueueFamilyProperties2Khr*)ptrpQueueFamilyProperties);
+				Interop.NativeMethods.vkGetPhysicalDeviceQueueFamilyProperties2KHR (this.m, &pQueueFamilyPropertyCount, (Interop.QueueFamilyProperties2*)ptrpQueueFamilyProperties);
 
 				if (pQueueFamilyPropertyCount <= 0)
 					return null;
-				var arr = new QueueFamilyProperties2Khr [pQueueFamilyPropertyCount];
+				var arr = new QueueFamilyProperties2 [pQueueFamilyPropertyCount];
 				for (int i = 0; i < pQueueFamilyPropertyCount; i++) {
-					arr [i] = new QueueFamilyProperties2Khr (new NativePointer (refpQueueFamilyProperties, (IntPtr)(&((Interop.QueueFamilyProperties2Khr*)ptrpQueueFamilyProperties) [i])));
+					arr [i] = new QueueFamilyProperties2 (new NativePointer (refpQueueFamilyProperties, (IntPtr)(&((Interop.QueueFamilyProperties2*)ptrpQueueFamilyProperties) [i])));
 				}
 
 				return arr;
 			}
 		}
 
-		public PhysicalDeviceMemoryProperties2Khr GetMemoryProperties2KHR ()
+		public PhysicalDeviceMemoryProperties2 GetMemoryProperties2 ()
 		{
-			PhysicalDeviceMemoryProperties2Khr pMemoryProperties;
+			PhysicalDeviceMemoryProperties2 pMemoryProperties;
 			unsafe {
-				pMemoryProperties = new PhysicalDeviceMemoryProperties2Khr ();
-				Interop.NativeMethods.vkGetPhysicalDeviceMemoryProperties2KHR (this.m, pMemoryProperties != null ? pMemoryProperties.m : (Interop.PhysicalDeviceMemoryProperties2Khr*)default(IntPtr));
+				pMemoryProperties = new PhysicalDeviceMemoryProperties2 ();
+				Interop.NativeMethods.vkGetPhysicalDeviceMemoryProperties2 (this.m, pMemoryProperties != null ? pMemoryProperties.m : (Interop.PhysicalDeviceMemoryProperties2*)default(IntPtr));
 
 				return pMemoryProperties;
 			}
 		}
 
-		public SparseImageFormatProperties2Khr[] GetSparseImageFormatProperties2KHR (PhysicalDeviceSparseImageFormatInfo2Khr pFormatInfo)
+		[Obsolete ("GetMemoryProperties2KHR is deprecated, please use GetMemoryProperties2 instead.")]
+		public PhysicalDeviceMemoryProperties2 GetMemoryProperties2KHR ()
+		{
+			PhysicalDeviceMemoryProperties2 pMemoryProperties;
+			unsafe {
+				pMemoryProperties = new PhysicalDeviceMemoryProperties2 ();
+				Interop.NativeMethods.vkGetPhysicalDeviceMemoryProperties2KHR (this.m, pMemoryProperties != null ? pMemoryProperties.m : (Interop.PhysicalDeviceMemoryProperties2*)default(IntPtr));
+
+				return pMemoryProperties;
+			}
+		}
+
+		public SparseImageFormatProperties2[] GetSparseImageFormatProperties2 (PhysicalDeviceSparseImageFormatInfo2 pFormatInfo)
 		{
 			unsafe {
 				UInt32 pPropertyCount;
-				Interop.NativeMethods.vkGetPhysicalDeviceSparseImageFormatProperties2KHR (this.m, pFormatInfo != null ? pFormatInfo.m : (Interop.PhysicalDeviceSparseImageFormatInfo2Khr*)default(IntPtr), &pPropertyCount, null);
+				Interop.NativeMethods.vkGetPhysicalDeviceSparseImageFormatProperties2 (this.m, pFormatInfo != null ? pFormatInfo.m : (Interop.PhysicalDeviceSparseImageFormatInfo2*)default(IntPtr), &pPropertyCount, null);
 				if (pPropertyCount <= 0)
 					return null;
 
-				int size = Marshal.SizeOf (typeof (Interop.SparseImageFormatProperties2Khr));
+				int size = Marshal.SizeOf (typeof (Interop.SparseImageFormatProperties2));
 				var refpProperties = new NativeReference ((int)(size * pPropertyCount));
 				var ptrpProperties = refpProperties.Handle;
-				Interop.NativeMethods.vkGetPhysicalDeviceSparseImageFormatProperties2KHR (this.m, pFormatInfo != null ? pFormatInfo.m : (Interop.PhysicalDeviceSparseImageFormatInfo2Khr*)default(IntPtr), &pPropertyCount, (Interop.SparseImageFormatProperties2Khr*)ptrpProperties);
+				Interop.NativeMethods.vkGetPhysicalDeviceSparseImageFormatProperties2 (this.m, pFormatInfo != null ? pFormatInfo.m : (Interop.PhysicalDeviceSparseImageFormatInfo2*)default(IntPtr), &pPropertyCount, (Interop.SparseImageFormatProperties2*)ptrpProperties);
 
 				if (pPropertyCount <= 0)
 					return null;
-				var arr = new SparseImageFormatProperties2Khr [pPropertyCount];
+				var arr = new SparseImageFormatProperties2 [pPropertyCount];
 				for (int i = 0; i < pPropertyCount; i++) {
-					arr [i] = new SparseImageFormatProperties2Khr (new NativePointer (refpProperties, (IntPtr)(&((Interop.SparseImageFormatProperties2Khr*)ptrpProperties) [i])));
+					arr [i] = new SparseImageFormatProperties2 (new NativePointer (refpProperties, (IntPtr)(&((Interop.SparseImageFormatProperties2*)ptrpProperties) [i])));
 				}
 
 				return arr;
 			}
 		}
 
-		public ExternalBufferPropertiesKhr GetExternalBufferPropertiesKHR (PhysicalDeviceExternalBufferInfoKhr pExternalBufferInfo)
+		[Obsolete ("GetSparseImageFormatProperties2KHR is deprecated, please use GetSparseImageFormatProperties2 instead.")]
+		public SparseImageFormatProperties2[] GetSparseImageFormatProperties2KHR (PhysicalDeviceSparseImageFormatInfo2 pFormatInfo)
 		{
-			ExternalBufferPropertiesKhr pExternalBufferProperties;
 			unsafe {
-				pExternalBufferProperties = new ExternalBufferPropertiesKhr ();
-				Interop.NativeMethods.vkGetPhysicalDeviceExternalBufferPropertiesKHR (this.m, pExternalBufferInfo != null ? pExternalBufferInfo.m : (Interop.PhysicalDeviceExternalBufferInfoKhr*)default(IntPtr), pExternalBufferProperties != null ? pExternalBufferProperties.m : (Interop.ExternalBufferPropertiesKhr*)default(IntPtr));
+				UInt32 pPropertyCount;
+				Interop.NativeMethods.vkGetPhysicalDeviceSparseImageFormatProperties2KHR (this.m, pFormatInfo != null ? pFormatInfo.m : (Interop.PhysicalDeviceSparseImageFormatInfo2*)default(IntPtr), &pPropertyCount, null);
+				if (pPropertyCount <= 0)
+					return null;
+
+				int size = Marshal.SizeOf (typeof (Interop.SparseImageFormatProperties2));
+				var refpProperties = new NativeReference ((int)(size * pPropertyCount));
+				var ptrpProperties = refpProperties.Handle;
+				Interop.NativeMethods.vkGetPhysicalDeviceSparseImageFormatProperties2KHR (this.m, pFormatInfo != null ? pFormatInfo.m : (Interop.PhysicalDeviceSparseImageFormatInfo2*)default(IntPtr), &pPropertyCount, (Interop.SparseImageFormatProperties2*)ptrpProperties);
+
+				if (pPropertyCount <= 0)
+					return null;
+				var arr = new SparseImageFormatProperties2 [pPropertyCount];
+				for (int i = 0; i < pPropertyCount; i++) {
+					arr [i] = new SparseImageFormatProperties2 (new NativePointer (refpProperties, (IntPtr)(&((Interop.SparseImageFormatProperties2*)ptrpProperties) [i])));
+				}
+
+				return arr;
+			}
+		}
+
+		public ExternalBufferProperties GetExternalBufferProperties (PhysicalDeviceExternalBufferInfo pExternalBufferInfo)
+		{
+			ExternalBufferProperties pExternalBufferProperties;
+			unsafe {
+				pExternalBufferProperties = new ExternalBufferProperties ();
+				Interop.NativeMethods.vkGetPhysicalDeviceExternalBufferProperties (this.m, pExternalBufferInfo != null ? pExternalBufferInfo.m : (Interop.PhysicalDeviceExternalBufferInfo*)default(IntPtr), pExternalBufferProperties != null ? pExternalBufferProperties.m : (Interop.ExternalBufferProperties*)default(IntPtr));
 
 				return pExternalBufferProperties;
 			}
 		}
 
-		public ExternalSemaphorePropertiesKhr GetExternalSemaphorePropertiesKHR (PhysicalDeviceExternalSemaphoreInfoKhr pExternalSemaphoreInfo)
+		[Obsolete ("GetExternalBufferPropertiesKHR is deprecated, please use GetExternalBufferProperties instead.")]
+		public ExternalBufferProperties GetExternalBufferPropertiesKHR (PhysicalDeviceExternalBufferInfo pExternalBufferInfo)
 		{
-			ExternalSemaphorePropertiesKhr pExternalSemaphoreProperties;
+			ExternalBufferProperties pExternalBufferProperties;
 			unsafe {
-				pExternalSemaphoreProperties = new ExternalSemaphorePropertiesKhr ();
-				Interop.NativeMethods.vkGetPhysicalDeviceExternalSemaphorePropertiesKHR (this.m, pExternalSemaphoreInfo != null ? pExternalSemaphoreInfo.m : (Interop.PhysicalDeviceExternalSemaphoreInfoKhr*)default(IntPtr), pExternalSemaphoreProperties != null ? pExternalSemaphoreProperties.m : (Interop.ExternalSemaphorePropertiesKhr*)default(IntPtr));
+				pExternalBufferProperties = new ExternalBufferProperties ();
+				Interop.NativeMethods.vkGetPhysicalDeviceExternalBufferPropertiesKHR (this.m, pExternalBufferInfo != null ? pExternalBufferInfo.m : (Interop.PhysicalDeviceExternalBufferInfo*)default(IntPtr), pExternalBufferProperties != null ? pExternalBufferProperties.m : (Interop.ExternalBufferProperties*)default(IntPtr));
+
+				return pExternalBufferProperties;
+			}
+		}
+
+		public ExternalSemaphoreProperties GetExternalSemaphoreProperties (PhysicalDeviceExternalSemaphoreInfo pExternalSemaphoreInfo)
+		{
+			ExternalSemaphoreProperties pExternalSemaphoreProperties;
+			unsafe {
+				pExternalSemaphoreProperties = new ExternalSemaphoreProperties ();
+				Interop.NativeMethods.vkGetPhysicalDeviceExternalSemaphoreProperties (this.m, pExternalSemaphoreInfo != null ? pExternalSemaphoreInfo.m : (Interop.PhysicalDeviceExternalSemaphoreInfo*)default(IntPtr), pExternalSemaphoreProperties != null ? pExternalSemaphoreProperties.m : (Interop.ExternalSemaphoreProperties*)default(IntPtr));
 
 				return pExternalSemaphoreProperties;
 			}
 		}
 
-		public ExternalFencePropertiesKhr GetExternalFencePropertiesKHR (PhysicalDeviceExternalFenceInfoKhr pExternalFenceInfo)
+		[Obsolete ("GetExternalSemaphorePropertiesKHR is deprecated, please use GetExternalSemaphoreProperties instead.")]
+		public ExternalSemaphoreProperties GetExternalSemaphorePropertiesKHR (PhysicalDeviceExternalSemaphoreInfo pExternalSemaphoreInfo)
 		{
-			ExternalFencePropertiesKhr pExternalFenceProperties;
+			ExternalSemaphoreProperties pExternalSemaphoreProperties;
 			unsafe {
-				pExternalFenceProperties = new ExternalFencePropertiesKhr ();
-				Interop.NativeMethods.vkGetPhysicalDeviceExternalFencePropertiesKHR (this.m, pExternalFenceInfo != null ? pExternalFenceInfo.m : (Interop.PhysicalDeviceExternalFenceInfoKhr*)default(IntPtr), pExternalFenceProperties != null ? pExternalFenceProperties.m : (Interop.ExternalFencePropertiesKhr*)default(IntPtr));
+				pExternalSemaphoreProperties = new ExternalSemaphoreProperties ();
+				Interop.NativeMethods.vkGetPhysicalDeviceExternalSemaphorePropertiesKHR (this.m, pExternalSemaphoreInfo != null ? pExternalSemaphoreInfo.m : (Interop.PhysicalDeviceExternalSemaphoreInfo*)default(IntPtr), pExternalSemaphoreProperties != null ? pExternalSemaphoreProperties.m : (Interop.ExternalSemaphoreProperties*)default(IntPtr));
+
+				return pExternalSemaphoreProperties;
+			}
+		}
+
+		public ExternalFenceProperties GetExternalFenceProperties (PhysicalDeviceExternalFenceInfo pExternalFenceInfo)
+		{
+			ExternalFenceProperties pExternalFenceProperties;
+			unsafe {
+				pExternalFenceProperties = new ExternalFenceProperties ();
+				Interop.NativeMethods.vkGetPhysicalDeviceExternalFenceProperties (this.m, pExternalFenceInfo != null ? pExternalFenceInfo.m : (Interop.PhysicalDeviceExternalFenceInfo*)default(IntPtr), pExternalFenceProperties != null ? pExternalFenceProperties.m : (Interop.ExternalFenceProperties*)default(IntPtr));
+
+				return pExternalFenceProperties;
+			}
+		}
+
+		[Obsolete ("GetExternalFencePropertiesKHR is deprecated, please use GetExternalFenceProperties instead.")]
+		public ExternalFenceProperties GetExternalFencePropertiesKHR (PhysicalDeviceExternalFenceInfo pExternalFenceInfo)
+		{
+			ExternalFenceProperties pExternalFenceProperties;
+			unsafe {
+				pExternalFenceProperties = new ExternalFenceProperties ();
+				Interop.NativeMethods.vkGetPhysicalDeviceExternalFencePropertiesKHR (this.m, pExternalFenceInfo != null ? pExternalFenceInfo.m : (Interop.PhysicalDeviceExternalFenceInfo*)default(IntPtr), pExternalFenceProperties != null ? pExternalFenceProperties.m : (Interop.ExternalFenceProperties*)default(IntPtr));
 
 				return pExternalFenceProperties;
 			}
@@ -819,12 +1033,12 @@ namespace Vulkan
 			}
 		}
 
-		public Rect2D[] GetPresentRectanglesKHX (SurfaceKhr surface)
+		public Rect2D[] GetPresentRectanglesKHR (SurfaceKhr surface)
 		{
 			Result result;
 			unsafe {
 				UInt32 pRectCount;
-				result = Interop.NativeMethods.vkGetPhysicalDevicePresentRectanglesKHX (this.m, surface != null ? surface.m : default(UInt64), &pRectCount, null);
+				result = Interop.NativeMethods.vkGetPhysicalDevicePresentRectanglesKHR (this.m, surface != null ? surface.m : default(UInt64), &pRectCount, null);
 				if (result != Result.Success)
 					throw new ResultException (result);
 				if (pRectCount <= 0)
@@ -833,7 +1047,7 @@ namespace Vulkan
 				int size = Marshal.SizeOf (typeof (Rect2D));
 				var refpRects = new NativeReference ((int)(size * pRectCount));
 				var ptrpRects = refpRects.Handle;
-				result = Interop.NativeMethods.vkGetPhysicalDevicePresentRectanglesKHX (this.m, surface != null ? surface.m : default(UInt64), &pRectCount, (Rect2D*)ptrpRects);
+				result = Interop.NativeMethods.vkGetPhysicalDevicePresentRectanglesKHR (this.m, surface != null ? surface.m : default(UInt64), &pRectCount, (Rect2D*)ptrpRects);
 				if (result != Result.Success)
 					throw new ResultException (result);
 
@@ -896,6 +1110,225 @@ namespace Vulkan
 				var arr = new SurfaceFormat2Khr [pSurfaceFormatCount];
 				for (int i = 0; i < pSurfaceFormatCount; i++) {
 					arr [i] = new SurfaceFormat2Khr (new NativePointer (refpSurfaceFormats, (IntPtr)(&((Interop.SurfaceFormat2Khr*)ptrpSurfaceFormats) [i])));
+				}
+
+				return arr;
+			}
+		}
+
+		public DisplayProperties2Khr[] GetDisplayProperties2KHR ()
+		{
+			Result result;
+			unsafe {
+				UInt32 pPropertyCount;
+				result = Interop.NativeMethods.vkGetPhysicalDeviceDisplayProperties2KHR (this.m, &pPropertyCount, null);
+				if (result != Result.Success)
+					throw new ResultException (result);
+				if (pPropertyCount <= 0)
+					return null;
+
+				int size = Marshal.SizeOf (typeof (Interop.DisplayProperties2Khr));
+				var refpProperties = new NativeReference ((int)(size * pPropertyCount));
+				var ptrpProperties = refpProperties.Handle;
+				result = Interop.NativeMethods.vkGetPhysicalDeviceDisplayProperties2KHR (this.m, &pPropertyCount, (Interop.DisplayProperties2Khr*)ptrpProperties);
+				if (result != Result.Success)
+					throw new ResultException (result);
+
+				if (pPropertyCount <= 0)
+					return null;
+				var arr = new DisplayProperties2Khr [pPropertyCount];
+				for (int i = 0; i < pPropertyCount; i++) {
+					arr [i] = new DisplayProperties2Khr (new NativePointer (refpProperties, (IntPtr)(&((Interop.DisplayProperties2Khr*)ptrpProperties) [i])));
+				}
+
+				return arr;
+			}
+		}
+
+		public DisplayPlaneProperties2Khr[] GetDisplayPlaneProperties2KHR ()
+		{
+			Result result;
+			unsafe {
+				UInt32 pPropertyCount;
+				result = Interop.NativeMethods.vkGetPhysicalDeviceDisplayPlaneProperties2KHR (this.m, &pPropertyCount, null);
+				if (result != Result.Success)
+					throw new ResultException (result);
+				if (pPropertyCount <= 0)
+					return null;
+
+				int size = Marshal.SizeOf (typeof (Interop.DisplayPlaneProperties2Khr));
+				var refpProperties = new NativeReference ((int)(size * pPropertyCount));
+				var ptrpProperties = refpProperties.Handle;
+				result = Interop.NativeMethods.vkGetPhysicalDeviceDisplayPlaneProperties2KHR (this.m, &pPropertyCount, (Interop.DisplayPlaneProperties2Khr*)ptrpProperties);
+				if (result != Result.Success)
+					throw new ResultException (result);
+
+				if (pPropertyCount <= 0)
+					return null;
+				var arr = new DisplayPlaneProperties2Khr [pPropertyCount];
+				for (int i = 0; i < pPropertyCount; i++) {
+					arr [i] = new DisplayPlaneProperties2Khr (new NativePointer (refpProperties, (IntPtr)(&((Interop.DisplayPlaneProperties2Khr*)ptrpProperties) [i])));
+				}
+
+				return arr;
+			}
+		}
+
+		public DisplayModeProperties2Khr[] GetDisplayModeProperties2KHR (DisplayKhr display)
+		{
+			Result result;
+			unsafe {
+				UInt32 pPropertyCount;
+				result = Interop.NativeMethods.vkGetDisplayModeProperties2KHR (this.m, display != null ? display.m : default(UInt64), &pPropertyCount, null);
+				if (result != Result.Success)
+					throw new ResultException (result);
+				if (pPropertyCount <= 0)
+					return null;
+
+				int size = Marshal.SizeOf (typeof (Interop.DisplayModeProperties2Khr));
+				var refpProperties = new NativeReference ((int)(size * pPropertyCount));
+				var ptrpProperties = refpProperties.Handle;
+				result = Interop.NativeMethods.vkGetDisplayModeProperties2KHR (this.m, display != null ? display.m : default(UInt64), &pPropertyCount, (Interop.DisplayModeProperties2Khr*)ptrpProperties);
+				if (result != Result.Success)
+					throw new ResultException (result);
+
+				if (pPropertyCount <= 0)
+					return null;
+				var arr = new DisplayModeProperties2Khr [pPropertyCount];
+				for (int i = 0; i < pPropertyCount; i++) {
+					arr [i] = new DisplayModeProperties2Khr (new NativePointer (refpProperties, (IntPtr)(&((Interop.DisplayModeProperties2Khr*)ptrpProperties) [i])));
+				}
+
+				return arr;
+			}
+		}
+
+		public DisplayPlaneCapabilities2Khr GetDisplayPlaneCapabilities2KHR (DisplayPlaneInfo2Khr pDisplayPlaneInfo)
+		{
+			Result result;
+			DisplayPlaneCapabilities2Khr pCapabilities;
+			unsafe {
+				pCapabilities = new DisplayPlaneCapabilities2Khr ();
+				result = Interop.NativeMethods.vkGetDisplayPlaneCapabilities2KHR (this.m, pDisplayPlaneInfo != null ? pDisplayPlaneInfo.m : (Interop.DisplayPlaneInfo2Khr*)default(IntPtr), pCapabilities != null ? pCapabilities.m : (Interop.DisplayPlaneCapabilities2Khr*)default(IntPtr));
+				if (result != Result.Success)
+					throw new ResultException (result);
+
+				return pCapabilities;
+			}
+		}
+
+		public TimeDomainExt[] GetCalibrateableTimeDomainsEXT ()
+		{
+			Result result;
+			unsafe {
+				UInt32 pTimeDomainCount;
+				result = Interop.NativeMethods.vkGetPhysicalDeviceCalibrateableTimeDomainsEXT (this.m, &pTimeDomainCount, null);
+				if (result != Result.Success)
+					throw new ResultException (result);
+				if (pTimeDomainCount <= 0)
+					return null;
+
+				int size = 4;
+				var refpTimeDomains = new NativeReference ((int)(size * pTimeDomainCount));
+				var ptrpTimeDomains = refpTimeDomains.Handle;
+				result = Interop.NativeMethods.vkGetPhysicalDeviceCalibrateableTimeDomainsEXT (this.m, &pTimeDomainCount, (TimeDomainExt*)ptrpTimeDomains);
+				if (result != Result.Success)
+					throw new ResultException (result);
+
+				if (pTimeDomainCount <= 0)
+					return null;
+				var arr = new TimeDomainExt [pTimeDomainCount];
+				for (int i = 0; i < pTimeDomainCount; i++) {
+					arr [i] = new TimeDomainExt ();
+					arr [i] = ((TimeDomainExt*)ptrpTimeDomains) [i];
+				}
+
+				return arr;
+			}
+		}
+
+		public CooperativeMatrixPropertiesNv[] GetCooperativeMatrixPropertiesNV ()
+		{
+			Result result;
+			unsafe {
+				UInt32 pPropertyCount;
+				result = Interop.NativeMethods.vkGetPhysicalDeviceCooperativeMatrixPropertiesNV (this.m, &pPropertyCount, null);
+				if (result != Result.Success)
+					throw new ResultException (result);
+				if (pPropertyCount <= 0)
+					return null;
+
+				int size = Marshal.SizeOf (typeof (Interop.CooperativeMatrixPropertiesNv));
+				var refpProperties = new NativeReference ((int)(size * pPropertyCount));
+				var ptrpProperties = refpProperties.Handle;
+				result = Interop.NativeMethods.vkGetPhysicalDeviceCooperativeMatrixPropertiesNV (this.m, &pPropertyCount, (Interop.CooperativeMatrixPropertiesNv*)ptrpProperties);
+				if (result != Result.Success)
+					throw new ResultException (result);
+
+				if (pPropertyCount <= 0)
+					return null;
+				var arr = new CooperativeMatrixPropertiesNv [pPropertyCount];
+				for (int i = 0; i < pPropertyCount; i++) {
+					arr [i] = new CooperativeMatrixPropertiesNv (new NativePointer (refpProperties, (IntPtr)(&((Interop.CooperativeMatrixPropertiesNv*)ptrpProperties) [i])));
+				}
+
+				return arr;
+			}
+		}
+
+		public PresentModeKhr[] GetSurfacePresentModes2EXT (PhysicalDeviceSurfaceInfo2Khr pSurfaceInfo)
+		{
+			Result result;
+			unsafe {
+				UInt32 pPresentModeCount;
+				result = Interop.NativeMethods.vkGetPhysicalDeviceSurfacePresentModes2EXT (this.m, pSurfaceInfo != null ? pSurfaceInfo.m : (Interop.PhysicalDeviceSurfaceInfo2Khr*)default(IntPtr), &pPresentModeCount, null);
+				if (result != Result.Success)
+					throw new ResultException (result);
+				if (pPresentModeCount <= 0)
+					return null;
+
+				int size = 4;
+				var refpPresentModes = new NativeReference ((int)(size * pPresentModeCount));
+				var ptrpPresentModes = refpPresentModes.Handle;
+				result = Interop.NativeMethods.vkGetPhysicalDeviceSurfacePresentModes2EXT (this.m, pSurfaceInfo != null ? pSurfaceInfo.m : (Interop.PhysicalDeviceSurfaceInfo2Khr*)default(IntPtr), &pPresentModeCount, (PresentModeKhr*)ptrpPresentModes);
+				if (result != Result.Success)
+					throw new ResultException (result);
+
+				if (pPresentModeCount <= 0)
+					return null;
+				var arr = new PresentModeKhr [pPresentModeCount];
+				for (int i = 0; i < pPresentModeCount; i++) {
+					arr [i] = new PresentModeKhr ();
+					arr [i] = ((PresentModeKhr*)ptrpPresentModes) [i];
+				}
+
+				return arr;
+			}
+		}
+
+		public FramebufferMixedSamplesCombinationNv[] GetSupportedFramebufferMixedSamplesCombinationsNV ()
+		{
+			Result result;
+			unsafe {
+				UInt32 pCombinationCount;
+				result = Interop.NativeMethods.vkGetPhysicalDeviceSupportedFramebufferMixedSamplesCombinationsNV (this.m, &pCombinationCount, null);
+				if (result != Result.Success)
+					throw new ResultException (result);
+				if (pCombinationCount <= 0)
+					return null;
+
+				int size = Marshal.SizeOf (typeof (Interop.FramebufferMixedSamplesCombinationNv));
+				var refpCombinations = new NativeReference ((int)(size * pCombinationCount));
+				var ptrpCombinations = refpCombinations.Handle;
+				result = Interop.NativeMethods.vkGetPhysicalDeviceSupportedFramebufferMixedSamplesCombinationsNV (this.m, &pCombinationCount, (Interop.FramebufferMixedSamplesCombinationNv*)ptrpCombinations);
+				if (result != Result.Success)
+					throw new ResultException (result);
+
+				if (pCombinationCount <= 0)
+					return null;
+				var arr = new FramebufferMixedSamplesCombinationNv [pCombinationCount];
+				for (int i = 0; i < pCombinationCount; i++) {
+					arr [i] = new FramebufferMixedSamplesCombinationNv (new NativePointer (refpCombinations, (IntPtr)(&((Interop.FramebufferMixedSamplesCombinationNv*)ptrpCombinations) [i])));
 				}
 
 				return arr;
@@ -1330,6 +1763,13 @@ namespace Vulkan
 					throw new ResultException (result);
 
 				return pData;
+			}
+		}
+
+		public void ResetQueryPoolEXT (QueryPool queryPool, UInt32 firstQuery, UInt32 queryCount)
+		{
+			unsafe {
+				Interop.NativeMethods.vkResetQueryPoolEXT (this.m, queryPool != null ? queryPool.m : default(UInt64), firstQuery, queryCount);
 			}
 		}
 
@@ -2164,6 +2604,14 @@ namespace Vulkan
 			}
 		}
 
+		public void TrimCommandPool (CommandPool commandPool, UInt32 flags = 0)
+		{
+			unsafe {
+				Interop.NativeMethods.vkTrimCommandPool (this.m, commandPool != null ? commandPool.m : default(UInt64), flags);
+			}
+		}
+
+		[Obsolete ("TrimCommandPoolKHR is deprecated, please use TrimCommandPool instead.")]
 		public void TrimCommandPoolKHR (CommandPool commandPool, UInt32 flags = 0)
 		{
 			unsafe {
@@ -2185,7 +2633,7 @@ namespace Vulkan
 			}
 		}
 
-		public MemoryWin32HandlePropertiesKhr GetMemoryWin32HandlePropertiesKHR (ExternalMemoryHandleTypeFlagsKhr handleType, IntPtr handle)
+		public MemoryWin32HandlePropertiesKhr GetMemoryWin32HandlePropertiesKHR (ExternalMemoryHandleTypeFlags handleType, IntPtr handle)
 		{
 			Result result;
 			MemoryWin32HandlePropertiesKhr pMemoryWin32HandleProperties;
@@ -2213,7 +2661,7 @@ namespace Vulkan
 			}
 		}
 
-		public MemoryFdPropertiesKhr GetMemoryFdPropertiesKHR (ExternalMemoryHandleTypeFlagsKhr handleType, int fd)
+		public MemoryFdPropertiesKhr GetMemoryFdPropertiesKHR (ExternalMemoryHandleTypeFlags handleType, int fd)
 		{
 			Result result;
 			MemoryFdPropertiesKhr pMemoryFdProperties;
@@ -2361,76 +2809,144 @@ namespace Vulkan
 			}
 		}
 
-		public PeerMemoryFeatureFlagsKhx GetGroupPeerMemoryFeaturesKHX (UInt32 heapIndex, UInt32 localDeviceIndex, UInt32 remoteDeviceIndex)
+		public PeerMemoryFeatureFlags GetGroupPeerMemoryFeatures (UInt32 heapIndex, UInt32 localDeviceIndex, UInt32 remoteDeviceIndex)
 		{
-			PeerMemoryFeatureFlagsKhx pPeerMemoryFeatures;
+			PeerMemoryFeatureFlags pPeerMemoryFeatures;
 			unsafe {
-				pPeerMemoryFeatures = new PeerMemoryFeatureFlagsKhx ();
-				Interop.NativeMethods.vkGetDeviceGroupPeerMemoryFeaturesKHX (this.m, heapIndex, localDeviceIndex, remoteDeviceIndex, &pPeerMemoryFeatures);
+				pPeerMemoryFeatures = new PeerMemoryFeatureFlags ();
+				Interop.NativeMethods.vkGetDeviceGroupPeerMemoryFeatures (this.m, heapIndex, localDeviceIndex, remoteDeviceIndex, &pPeerMemoryFeatures);
 
 				return pPeerMemoryFeatures;
 			}
 		}
 
-		public void BindBufferMemory2KHR (BindBufferMemoryInfoKhr[] pBindInfos)
+		[Obsolete ("GetGroupPeerMemoryFeaturesKHR is deprecated, please use GetGroupPeerMemoryFeatures instead.")]
+		public PeerMemoryFeatureFlags GetGroupPeerMemoryFeaturesKHR (UInt32 heapIndex, UInt32 localDeviceIndex, UInt32 remoteDeviceIndex)
+		{
+			PeerMemoryFeatureFlags pPeerMemoryFeatures;
+			unsafe {
+				pPeerMemoryFeatures = new PeerMemoryFeatureFlags ();
+				Interop.NativeMethods.vkGetDeviceGroupPeerMemoryFeaturesKHR (this.m, heapIndex, localDeviceIndex, remoteDeviceIndex, &pPeerMemoryFeatures);
+
+				return pPeerMemoryFeatures;
+			}
+		}
+
+		public void BindBufferMemory2 (BindBufferMemoryInfo[] pBindInfos)
 		{
 			Result result;
 			unsafe {
-				var arraypBindInfos = pBindInfos == null ? IntPtr.Zero : Marshal.AllocHGlobal (pBindInfos.Length*sizeof (Interop.BindBufferMemoryInfoKhr));
+				var arraypBindInfos = pBindInfos == null ? IntPtr.Zero : Marshal.AllocHGlobal (pBindInfos.Length*sizeof (Interop.BindBufferMemoryInfo));
 				var lenpBindInfos = pBindInfos == null ? 0 : pBindInfos.Length;
 				if (pBindInfos != null)
 					for (int i = 0; i < pBindInfos.Length; i++)
-						((Interop.BindBufferMemoryInfoKhr*)arraypBindInfos) [i] = *(pBindInfos [i].m);
-				result = Interop.NativeMethods.vkBindBufferMemory2KHR (this.m, (uint)lenpBindInfos, (Interop.BindBufferMemoryInfoKhr*)arraypBindInfos);
+						((Interop.BindBufferMemoryInfo*)arraypBindInfos) [i] = *(pBindInfos [i].m);
+				result = Interop.NativeMethods.vkBindBufferMemory2 (this.m, (uint)lenpBindInfos, (Interop.BindBufferMemoryInfo*)arraypBindInfos);
 				Marshal.FreeHGlobal (arraypBindInfos);
 				if (result != Result.Success)
 					throw new ResultException (result);
 			}
 		}
 
-		public void BindBufferMemory2KHR (BindBufferMemoryInfoKhr pBindInfo)
+		public void BindBufferMemory2 (BindBufferMemoryInfo pBindInfo)
 		{
 			Result result;
 			unsafe {
-				result = Interop.NativeMethods.vkBindBufferMemory2KHR (this.m, (UInt32)(pBindInfo != null ? 1 : 0), pBindInfo != null ? pBindInfo.m : (Interop.BindBufferMemoryInfoKhr*)default(IntPtr));
+				result = Interop.NativeMethods.vkBindBufferMemory2 (this.m, (UInt32)(pBindInfo != null ? 1 : 0), pBindInfo != null ? pBindInfo.m : (Interop.BindBufferMemoryInfo*)default(IntPtr));
 				if (result != Result.Success)
 					throw new ResultException (result);
 			}
 		}
 
-		public void BindImageMemory2KHR (BindImageMemoryInfoKhr[] pBindInfos)
+		[Obsolete ("BindBufferMemory2KHR is deprecated, please use BindBufferMemory2 instead.")]
+		public void BindBufferMemory2KHR (BindBufferMemoryInfo[] pBindInfos)
 		{
 			Result result;
 			unsafe {
-				var arraypBindInfos = pBindInfos == null ? IntPtr.Zero : Marshal.AllocHGlobal (pBindInfos.Length*sizeof (Interop.BindImageMemoryInfoKhr));
+				var arraypBindInfos = pBindInfos == null ? IntPtr.Zero : Marshal.AllocHGlobal (pBindInfos.Length*sizeof (Interop.BindBufferMemoryInfo));
 				var lenpBindInfos = pBindInfos == null ? 0 : pBindInfos.Length;
 				if (pBindInfos != null)
 					for (int i = 0; i < pBindInfos.Length; i++)
-						((Interop.BindImageMemoryInfoKhr*)arraypBindInfos) [i] = *(pBindInfos [i].m);
-				result = Interop.NativeMethods.vkBindImageMemory2KHR (this.m, (uint)lenpBindInfos, (Interop.BindImageMemoryInfoKhr*)arraypBindInfos);
+						((Interop.BindBufferMemoryInfo*)arraypBindInfos) [i] = *(pBindInfos [i].m);
+				result = Interop.NativeMethods.vkBindBufferMemory2KHR (this.m, (uint)lenpBindInfos, (Interop.BindBufferMemoryInfo*)arraypBindInfos);
 				Marshal.FreeHGlobal (arraypBindInfos);
 				if (result != Result.Success)
 					throw new ResultException (result);
 			}
 		}
 
-		public void BindImageMemory2KHR (BindImageMemoryInfoKhr pBindInfo)
+		[Obsolete ("BindBufferMemory2KHR is deprecated, please use BindBufferMemory2 instead.")]
+		public void BindBufferMemory2KHR (BindBufferMemoryInfo pBindInfo)
 		{
 			Result result;
 			unsafe {
-				result = Interop.NativeMethods.vkBindImageMemory2KHR (this.m, (UInt32)(pBindInfo != null ? 1 : 0), pBindInfo != null ? pBindInfo.m : (Interop.BindImageMemoryInfoKhr*)default(IntPtr));
+				result = Interop.NativeMethods.vkBindBufferMemory2KHR (this.m, (UInt32)(pBindInfo != null ? 1 : 0), pBindInfo != null ? pBindInfo.m : (Interop.BindBufferMemoryInfo*)default(IntPtr));
 				if (result != Result.Success)
 					throw new ResultException (result);
 			}
 		}
 
-		public DeviceGroupPresentCapabilitiesKhx GetGroupPresentCapabilitiesKHX ()
+		public void BindImageMemory2 (BindImageMemoryInfo[] pBindInfos)
 		{
 			Result result;
-			DeviceGroupPresentCapabilitiesKhx pDeviceGroupPresentCapabilities;
 			unsafe {
-				pDeviceGroupPresentCapabilities = new DeviceGroupPresentCapabilitiesKhx ();
-				result = Interop.NativeMethods.vkGetDeviceGroupPresentCapabilitiesKHX (this.m, pDeviceGroupPresentCapabilities != null ? pDeviceGroupPresentCapabilities.m : (Interop.DeviceGroupPresentCapabilitiesKhx*)default(IntPtr));
+				var arraypBindInfos = pBindInfos == null ? IntPtr.Zero : Marshal.AllocHGlobal (pBindInfos.Length*sizeof (Interop.BindImageMemoryInfo));
+				var lenpBindInfos = pBindInfos == null ? 0 : pBindInfos.Length;
+				if (pBindInfos != null)
+					for (int i = 0; i < pBindInfos.Length; i++)
+						((Interop.BindImageMemoryInfo*)arraypBindInfos) [i] = *(pBindInfos [i].m);
+				result = Interop.NativeMethods.vkBindImageMemory2 (this.m, (uint)lenpBindInfos, (Interop.BindImageMemoryInfo*)arraypBindInfos);
+				Marshal.FreeHGlobal (arraypBindInfos);
+				if (result != Result.Success)
+					throw new ResultException (result);
+			}
+		}
+
+		public void BindImageMemory2 (BindImageMemoryInfo pBindInfo)
+		{
+			Result result;
+			unsafe {
+				result = Interop.NativeMethods.vkBindImageMemory2 (this.m, (UInt32)(pBindInfo != null ? 1 : 0), pBindInfo != null ? pBindInfo.m : (Interop.BindImageMemoryInfo*)default(IntPtr));
+				if (result != Result.Success)
+					throw new ResultException (result);
+			}
+		}
+
+		[Obsolete ("BindImageMemory2KHR is deprecated, please use BindImageMemory2 instead.")]
+		public void BindImageMemory2KHR (BindImageMemoryInfo[] pBindInfos)
+		{
+			Result result;
+			unsafe {
+				var arraypBindInfos = pBindInfos == null ? IntPtr.Zero : Marshal.AllocHGlobal (pBindInfos.Length*sizeof (Interop.BindImageMemoryInfo));
+				var lenpBindInfos = pBindInfos == null ? 0 : pBindInfos.Length;
+				if (pBindInfos != null)
+					for (int i = 0; i < pBindInfos.Length; i++)
+						((Interop.BindImageMemoryInfo*)arraypBindInfos) [i] = *(pBindInfos [i].m);
+				result = Interop.NativeMethods.vkBindImageMemory2KHR (this.m, (uint)lenpBindInfos, (Interop.BindImageMemoryInfo*)arraypBindInfos);
+				Marshal.FreeHGlobal (arraypBindInfos);
+				if (result != Result.Success)
+					throw new ResultException (result);
+			}
+		}
+
+		[Obsolete ("BindImageMemory2KHR is deprecated, please use BindImageMemory2 instead.")]
+		public void BindImageMemory2KHR (BindImageMemoryInfo pBindInfo)
+		{
+			Result result;
+			unsafe {
+				result = Interop.NativeMethods.vkBindImageMemory2KHR (this.m, (UInt32)(pBindInfo != null ? 1 : 0), pBindInfo != null ? pBindInfo.m : (Interop.BindImageMemoryInfo*)default(IntPtr));
+				if (result != Result.Success)
+					throw new ResultException (result);
+			}
+		}
+
+		public DeviceGroupPresentCapabilitiesKhr GetGroupPresentCapabilitiesKHR ()
+		{
+			Result result;
+			DeviceGroupPresentCapabilitiesKhr pDeviceGroupPresentCapabilities;
+			unsafe {
+				pDeviceGroupPresentCapabilities = new DeviceGroupPresentCapabilitiesKhr ();
+				result = Interop.NativeMethods.vkGetDeviceGroupPresentCapabilitiesKHR (this.m, pDeviceGroupPresentCapabilities != null ? pDeviceGroupPresentCapabilities.m : (Interop.DeviceGroupPresentCapabilitiesKhr*)default(IntPtr));
 				if (result != Result.Success)
 					throw new ResultException (result);
 
@@ -2438,13 +2954,13 @@ namespace Vulkan
 			}
 		}
 
-		public DeviceGroupPresentModeFlagsKhx GetGroupSurfacePresentModesKHX (SurfaceKhr surface)
+		public DeviceGroupPresentModeFlagsKhr GetGroupSurfacePresentModesKHR (SurfaceKhr surface)
 		{
 			Result result;
-			DeviceGroupPresentModeFlagsKhx pModes;
+			DeviceGroupPresentModeFlagsKhr pModes;
 			unsafe {
-				pModes = new DeviceGroupPresentModeFlagsKhx ();
-				result = Interop.NativeMethods.vkGetDeviceGroupSurfacePresentModesKHX (this.m, surface != null ? surface.m : default(UInt64), &pModes);
+				pModes = new DeviceGroupPresentModeFlagsKhr ();
+				result = Interop.NativeMethods.vkGetDeviceGroupSurfacePresentModesKHR (this.m, surface != null ? surface.m : default(UInt64), &pModes);
 				if (result != Result.Success)
 					throw new ResultException (result);
 
@@ -2452,13 +2968,13 @@ namespace Vulkan
 			}
 		}
 
-		public UInt32 AcquireNextImage2KHX (AcquireNextImageInfoKhx pAcquireInfo)
+		public UInt32 AcquireNextImage2KHR (AcquireNextImageInfoKhr pAcquireInfo)
 		{
 			Result result;
 			UInt32 pImageIndex;
 			unsafe {
 				pImageIndex = new UInt32 ();
-				result = Interop.NativeMethods.vkAcquireNextImage2KHX (this.m, pAcquireInfo != null ? pAcquireInfo.m : (Interop.AcquireNextImageInfoKhx*)default(IntPtr), &pImageIndex);
+				result = Interop.NativeMethods.vkAcquireNextImage2KHR (this.m, pAcquireInfo != null ? pAcquireInfo.m : (Interop.AcquireNextImageInfoKhr*)default(IntPtr), &pImageIndex);
 				if (result != Result.Success)
 					throw new ResultException (result);
 
@@ -2466,15 +2982,15 @@ namespace Vulkan
 			}
 		}
 
-		public DescriptorUpdateTemplateKhr CreateDescriptorUpdateTemplateKHR (DescriptorUpdateTemplateCreateInfoKhr pCreateInfo, AllocationCallbacks pAllocator = null)
+		public DescriptorUpdateTemplate CreateDescriptorUpdateTemplate (DescriptorUpdateTemplateCreateInfo pCreateInfo, AllocationCallbacks pAllocator = null)
 		{
 			Result result;
-			DescriptorUpdateTemplateKhr pDescriptorUpdateTemplate;
+			DescriptorUpdateTemplate pDescriptorUpdateTemplate;
 			unsafe {
-				pDescriptorUpdateTemplate = new DescriptorUpdateTemplateKhr ();
+				pDescriptorUpdateTemplate = new DescriptorUpdateTemplate ();
 
 				fixed (UInt64* ptrpDescriptorUpdateTemplate = &pDescriptorUpdateTemplate.m) {
-					result = Interop.NativeMethods.vkCreateDescriptorUpdateTemplateKHR (this.m, pCreateInfo != null ? pCreateInfo.m : (Interop.DescriptorUpdateTemplateCreateInfoKhr*)default(IntPtr), pAllocator != null ? pAllocator.m : null, ptrpDescriptorUpdateTemplate);
+					result = Interop.NativeMethods.vkCreateDescriptorUpdateTemplate (this.m, pCreateInfo != null ? pCreateInfo.m : (Interop.DescriptorUpdateTemplateCreateInfo*)default(IntPtr), pAllocator != null ? pAllocator.m : null, ptrpDescriptorUpdateTemplate);
 				}
 				if (result != Result.Success)
 					throw new ResultException (result);
@@ -2483,14 +2999,48 @@ namespace Vulkan
 			}
 		}
 
-		public void DestroyDescriptorUpdateTemplateKHR (DescriptorUpdateTemplateKhr descriptorUpdateTemplate = null, AllocationCallbacks pAllocator = null)
+		[Obsolete ("CreateDescriptorUpdateTemplateKHR is deprecated, please use CreateDescriptorUpdateTemplate instead.")]
+		public DescriptorUpdateTemplate CreateDescriptorUpdateTemplateKHR (DescriptorUpdateTemplateCreateInfo pCreateInfo, AllocationCallbacks pAllocator = null)
+		{
+			Result result;
+			DescriptorUpdateTemplate pDescriptorUpdateTemplate;
+			unsafe {
+				pDescriptorUpdateTemplate = new DescriptorUpdateTemplate ();
+
+				fixed (UInt64* ptrpDescriptorUpdateTemplate = &pDescriptorUpdateTemplate.m) {
+					result = Interop.NativeMethods.vkCreateDescriptorUpdateTemplateKHR (this.m, pCreateInfo != null ? pCreateInfo.m : (Interop.DescriptorUpdateTemplateCreateInfo*)default(IntPtr), pAllocator != null ? pAllocator.m : null, ptrpDescriptorUpdateTemplate);
+				}
+				if (result != Result.Success)
+					throw new ResultException (result);
+
+				return pDescriptorUpdateTemplate;
+			}
+		}
+
+		public void DestroyDescriptorUpdateTemplate (DescriptorUpdateTemplate descriptorUpdateTemplate = null, AllocationCallbacks pAllocator = null)
+		{
+			unsafe {
+				Interop.NativeMethods.vkDestroyDescriptorUpdateTemplate (this.m, descriptorUpdateTemplate != null ? descriptorUpdateTemplate.m : default(UInt64), pAllocator != null ? pAllocator.m : null);
+			}
+		}
+
+		[Obsolete ("DestroyDescriptorUpdateTemplateKHR is deprecated, please use DestroyDescriptorUpdateTemplate instead.")]
+		public void DestroyDescriptorUpdateTemplateKHR (DescriptorUpdateTemplate descriptorUpdateTemplate = null, AllocationCallbacks pAllocator = null)
 		{
 			unsafe {
 				Interop.NativeMethods.vkDestroyDescriptorUpdateTemplateKHR (this.m, descriptorUpdateTemplate != null ? descriptorUpdateTemplate.m : default(UInt64), pAllocator != null ? pAllocator.m : null);
 			}
 		}
 
-		public void UpdateDescriptorSetWithTemplateKHR (DescriptorSet descriptorSet, DescriptorUpdateTemplateKhr descriptorUpdateTemplate, IntPtr pData)
+		public void UpdateDescriptorSetWithTemplate (DescriptorSet descriptorSet, DescriptorUpdateTemplate descriptorUpdateTemplate, IntPtr pData)
+		{
+			unsafe {
+				Interop.NativeMethods.vkUpdateDescriptorSetWithTemplate (this.m, descriptorSet != null ? descriptorSet.m : default(UInt64), descriptorUpdateTemplate != null ? descriptorUpdateTemplate.m : default(UInt64), pData);
+			}
+		}
+
+		[Obsolete ("UpdateDescriptorSetWithTemplateKHR is deprecated, please use UpdateDescriptorSetWithTemplate instead.")]
+		public void UpdateDescriptorSetWithTemplateKHR (DescriptorSet descriptorSet, DescriptorUpdateTemplate descriptorUpdateTemplate, IntPtr pData)
 		{
 			unsafe {
 				Interop.NativeMethods.vkUpdateDescriptorSetWithTemplateKHR (this.m, descriptorSet != null ? descriptorSet.m : default(UInt64), descriptorUpdateTemplate != null ? descriptorUpdateTemplate.m : default(UInt64), pData);
@@ -2578,61 +3128,110 @@ namespace Vulkan
 			}
 		}
 
-		public MemoryRequirements2Khr GetBufferMemoryRequirements2KHR (BufferMemoryRequirementsInfo2Khr pInfo)
+		public MemoryRequirements2 GetBufferMemoryRequirements2 (BufferMemoryRequirementsInfo2 pInfo)
 		{
-			MemoryRequirements2Khr pMemoryRequirements;
+			MemoryRequirements2 pMemoryRequirements;
 			unsafe {
-				pMemoryRequirements = new MemoryRequirements2Khr ();
-				Interop.NativeMethods.vkGetBufferMemoryRequirements2KHR (this.m, pInfo != null ? pInfo.m : (Interop.BufferMemoryRequirementsInfo2Khr*)default(IntPtr), pMemoryRequirements != null ? pMemoryRequirements.m : (Interop.MemoryRequirements2Khr*)default(IntPtr));
+				pMemoryRequirements = new MemoryRequirements2 ();
+				Interop.NativeMethods.vkGetBufferMemoryRequirements2 (this.m, pInfo != null ? pInfo.m : (Interop.BufferMemoryRequirementsInfo2*)default(IntPtr), pMemoryRequirements != null ? pMemoryRequirements.m : (Interop.MemoryRequirements2*)default(IntPtr));
 
 				return pMemoryRequirements;
 			}
 		}
 
-		public MemoryRequirements2Khr GetImageMemoryRequirements2KHR (ImageMemoryRequirementsInfo2Khr pInfo)
+		[Obsolete ("GetBufferMemoryRequirements2KHR is deprecated, please use GetBufferMemoryRequirements2 instead.")]
+		public MemoryRequirements2 GetBufferMemoryRequirements2KHR (BufferMemoryRequirementsInfo2 pInfo)
 		{
-			MemoryRequirements2Khr pMemoryRequirements;
+			MemoryRequirements2 pMemoryRequirements;
 			unsafe {
-				pMemoryRequirements = new MemoryRequirements2Khr ();
-				Interop.NativeMethods.vkGetImageMemoryRequirements2KHR (this.m, pInfo != null ? pInfo.m : (Interop.ImageMemoryRequirementsInfo2Khr*)default(IntPtr), pMemoryRequirements != null ? pMemoryRequirements.m : (Interop.MemoryRequirements2Khr*)default(IntPtr));
+				pMemoryRequirements = new MemoryRequirements2 ();
+				Interop.NativeMethods.vkGetBufferMemoryRequirements2KHR (this.m, pInfo != null ? pInfo.m : (Interop.BufferMemoryRequirementsInfo2*)default(IntPtr), pMemoryRequirements != null ? pMemoryRequirements.m : (Interop.MemoryRequirements2*)default(IntPtr));
 
 				return pMemoryRequirements;
 			}
 		}
 
-		public SparseImageMemoryRequirements2Khr[] GetImageSparseMemoryRequirements2KHR (ImageSparseMemoryRequirementsInfo2Khr pInfo)
+		public MemoryRequirements2 GetImageMemoryRequirements2 (ImageMemoryRequirementsInfo2 pInfo)
+		{
+			MemoryRequirements2 pMemoryRequirements;
+			unsafe {
+				pMemoryRequirements = new MemoryRequirements2 ();
+				Interop.NativeMethods.vkGetImageMemoryRequirements2 (this.m, pInfo != null ? pInfo.m : (Interop.ImageMemoryRequirementsInfo2*)default(IntPtr), pMemoryRequirements != null ? pMemoryRequirements.m : (Interop.MemoryRequirements2*)default(IntPtr));
+
+				return pMemoryRequirements;
+			}
+		}
+
+		[Obsolete ("GetImageMemoryRequirements2KHR is deprecated, please use GetImageMemoryRequirements2 instead.")]
+		public MemoryRequirements2 GetImageMemoryRequirements2KHR (ImageMemoryRequirementsInfo2 pInfo)
+		{
+			MemoryRequirements2 pMemoryRequirements;
+			unsafe {
+				pMemoryRequirements = new MemoryRequirements2 ();
+				Interop.NativeMethods.vkGetImageMemoryRequirements2KHR (this.m, pInfo != null ? pInfo.m : (Interop.ImageMemoryRequirementsInfo2*)default(IntPtr), pMemoryRequirements != null ? pMemoryRequirements.m : (Interop.MemoryRequirements2*)default(IntPtr));
+
+				return pMemoryRequirements;
+			}
+		}
+
+		public SparseImageMemoryRequirements2[] GetImageSparseMemoryRequirements2 (ImageSparseMemoryRequirementsInfo2 pInfo)
 		{
 			unsafe {
 				UInt32 pSparseMemoryRequirementCount;
-				Interop.NativeMethods.vkGetImageSparseMemoryRequirements2KHR (this.m, pInfo != null ? pInfo.m : (Interop.ImageSparseMemoryRequirementsInfo2Khr*)default(IntPtr), &pSparseMemoryRequirementCount, null);
+				Interop.NativeMethods.vkGetImageSparseMemoryRequirements2 (this.m, pInfo != null ? pInfo.m : (Interop.ImageSparseMemoryRequirementsInfo2*)default(IntPtr), &pSparseMemoryRequirementCount, null);
 				if (pSparseMemoryRequirementCount <= 0)
 					return null;
 
-				int size = Marshal.SizeOf (typeof (Interop.SparseImageMemoryRequirements2Khr));
+				int size = Marshal.SizeOf (typeof (Interop.SparseImageMemoryRequirements2));
 				var refpSparseMemoryRequirements = new NativeReference ((int)(size * pSparseMemoryRequirementCount));
 				var ptrpSparseMemoryRequirements = refpSparseMemoryRequirements.Handle;
-				Interop.NativeMethods.vkGetImageSparseMemoryRequirements2KHR (this.m, pInfo != null ? pInfo.m : (Interop.ImageSparseMemoryRequirementsInfo2Khr*)default(IntPtr), &pSparseMemoryRequirementCount, (Interop.SparseImageMemoryRequirements2Khr*)ptrpSparseMemoryRequirements);
+				Interop.NativeMethods.vkGetImageSparseMemoryRequirements2 (this.m, pInfo != null ? pInfo.m : (Interop.ImageSparseMemoryRequirementsInfo2*)default(IntPtr), &pSparseMemoryRequirementCount, (Interop.SparseImageMemoryRequirements2*)ptrpSparseMemoryRequirements);
 
 				if (pSparseMemoryRequirementCount <= 0)
 					return null;
-				var arr = new SparseImageMemoryRequirements2Khr [pSparseMemoryRequirementCount];
+				var arr = new SparseImageMemoryRequirements2 [pSparseMemoryRequirementCount];
 				for (int i = 0; i < pSparseMemoryRequirementCount; i++) {
-					arr [i] = new SparseImageMemoryRequirements2Khr (new NativePointer (refpSparseMemoryRequirements, (IntPtr)(&((Interop.SparseImageMemoryRequirements2Khr*)ptrpSparseMemoryRequirements) [i])));
+					arr [i] = new SparseImageMemoryRequirements2 (new NativePointer (refpSparseMemoryRequirements, (IntPtr)(&((Interop.SparseImageMemoryRequirements2*)ptrpSparseMemoryRequirements) [i])));
 				}
 
 				return arr;
 			}
 		}
 
-		public SamplerYcbcrConversionKhr CreateSamplerYcbcrConversionKHR (SamplerYcbcrConversionCreateInfoKhr pCreateInfo, AllocationCallbacks pAllocator = null)
+		[Obsolete ("GetImageSparseMemoryRequirements2KHR is deprecated, please use GetImageSparseMemoryRequirements2 instead.")]
+		public SparseImageMemoryRequirements2[] GetImageSparseMemoryRequirements2KHR (ImageSparseMemoryRequirementsInfo2 pInfo)
+		{
+			unsafe {
+				UInt32 pSparseMemoryRequirementCount;
+				Interop.NativeMethods.vkGetImageSparseMemoryRequirements2KHR (this.m, pInfo != null ? pInfo.m : (Interop.ImageSparseMemoryRequirementsInfo2*)default(IntPtr), &pSparseMemoryRequirementCount, null);
+				if (pSparseMemoryRequirementCount <= 0)
+					return null;
+
+				int size = Marshal.SizeOf (typeof (Interop.SparseImageMemoryRequirements2));
+				var refpSparseMemoryRequirements = new NativeReference ((int)(size * pSparseMemoryRequirementCount));
+				var ptrpSparseMemoryRequirements = refpSparseMemoryRequirements.Handle;
+				Interop.NativeMethods.vkGetImageSparseMemoryRequirements2KHR (this.m, pInfo != null ? pInfo.m : (Interop.ImageSparseMemoryRequirementsInfo2*)default(IntPtr), &pSparseMemoryRequirementCount, (Interop.SparseImageMemoryRequirements2*)ptrpSparseMemoryRequirements);
+
+				if (pSparseMemoryRequirementCount <= 0)
+					return null;
+				var arr = new SparseImageMemoryRequirements2 [pSparseMemoryRequirementCount];
+				for (int i = 0; i < pSparseMemoryRequirementCount; i++) {
+					arr [i] = new SparseImageMemoryRequirements2 (new NativePointer (refpSparseMemoryRequirements, (IntPtr)(&((Interop.SparseImageMemoryRequirements2*)ptrpSparseMemoryRequirements) [i])));
+				}
+
+				return arr;
+			}
+		}
+
+		public SamplerYcbcrConversion CreateSamplerYcbcrConversion (SamplerYcbcrConversionCreateInfo pCreateInfo, AllocationCallbacks pAllocator = null)
 		{
 			Result result;
-			SamplerYcbcrConversionKhr pYcbcrConversion;
+			SamplerYcbcrConversion pYcbcrConversion;
 			unsafe {
-				pYcbcrConversion = new SamplerYcbcrConversionKhr ();
+				pYcbcrConversion = new SamplerYcbcrConversion ();
 
 				fixed (UInt64* ptrpYcbcrConversion = &pYcbcrConversion.m) {
-					result = Interop.NativeMethods.vkCreateSamplerYcbcrConversionKHR (this.m, pCreateInfo != null ? pCreateInfo.m : (Interop.SamplerYcbcrConversionCreateInfoKhr*)default(IntPtr), pAllocator != null ? pAllocator.m : null, ptrpYcbcrConversion);
+					result = Interop.NativeMethods.vkCreateSamplerYcbcrConversion (this.m, pCreateInfo != null ? pCreateInfo.m : (Interop.SamplerYcbcrConversionCreateInfo*)default(IntPtr), pAllocator != null ? pAllocator.m : null, ptrpYcbcrConversion);
 				}
 				if (result != Result.Success)
 					throw new ResultException (result);
@@ -2641,10 +3240,50 @@ namespace Vulkan
 			}
 		}
 
-		public void DestroySamplerYcbcrConversionKHR (SamplerYcbcrConversionKhr ycbcrConversion = null, AllocationCallbacks pAllocator = null)
+		[Obsolete ("CreateSamplerYcbcrConversionKHR is deprecated, please use CreateSamplerYcbcrConversion instead.")]
+		public SamplerYcbcrConversion CreateSamplerYcbcrConversionKHR (SamplerYcbcrConversionCreateInfo pCreateInfo, AllocationCallbacks pAllocator = null)
+		{
+			Result result;
+			SamplerYcbcrConversion pYcbcrConversion;
+			unsafe {
+				pYcbcrConversion = new SamplerYcbcrConversion ();
+
+				fixed (UInt64* ptrpYcbcrConversion = &pYcbcrConversion.m) {
+					result = Interop.NativeMethods.vkCreateSamplerYcbcrConversionKHR (this.m, pCreateInfo != null ? pCreateInfo.m : (Interop.SamplerYcbcrConversionCreateInfo*)default(IntPtr), pAllocator != null ? pAllocator.m : null, ptrpYcbcrConversion);
+				}
+				if (result != Result.Success)
+					throw new ResultException (result);
+
+				return pYcbcrConversion;
+			}
+		}
+
+		public void DestroySamplerYcbcrConversion (SamplerYcbcrConversion ycbcrConversion = null, AllocationCallbacks pAllocator = null)
+		{
+			unsafe {
+				Interop.NativeMethods.vkDestroySamplerYcbcrConversion (this.m, ycbcrConversion != null ? ycbcrConversion.m : default(UInt64), pAllocator != null ? pAllocator.m : null);
+			}
+		}
+
+		[Obsolete ("DestroySamplerYcbcrConversionKHR is deprecated, please use DestroySamplerYcbcrConversion instead.")]
+		public void DestroySamplerYcbcrConversionKHR (SamplerYcbcrConversion ycbcrConversion = null, AllocationCallbacks pAllocator = null)
 		{
 			unsafe {
 				Interop.NativeMethods.vkDestroySamplerYcbcrConversionKHR (this.m, ycbcrConversion != null ? ycbcrConversion.m : default(UInt64), pAllocator != null ? pAllocator.m : null);
+			}
+		}
+
+		public Queue GetQueue2 (DeviceQueueInfo2 pQueueInfo)
+		{
+			Queue pQueue;
+			unsafe {
+				pQueue = new Queue ();
+
+				fixed (IntPtr* ptrpQueue = &pQueue.m) {
+					Interop.NativeMethods.vkGetDeviceQueue2 (this.m, pQueueInfo != null ? pQueueInfo.m : (Interop.DeviceQueueInfo2*)default(IntPtr), ptrpQueue);
+				}
+
+				return pQueue;
 			}
 		}
 
@@ -2712,6 +3351,29 @@ namespace Vulkan
 			}
 		}
 
+		public DescriptorSetLayoutSupport GetDescriptorSetLayoutSupport (DescriptorSetLayoutCreateInfo pCreateInfo)
+		{
+			DescriptorSetLayoutSupport pSupport;
+			unsafe {
+				pSupport = new DescriptorSetLayoutSupport ();
+				Interop.NativeMethods.vkGetDescriptorSetLayoutSupport (this.m, pCreateInfo != null ? pCreateInfo.m : (Interop.DescriptorSetLayoutCreateInfo*)default(IntPtr), pSupport != null ? pSupport.m : (Interop.DescriptorSetLayoutSupport*)default(IntPtr));
+
+				return pSupport;
+			}
+		}
+
+		[Obsolete ("GetDescriptorSetLayoutSupportKHR is deprecated, please use GetDescriptorSetLayoutSupport instead.")]
+		public DescriptorSetLayoutSupport GetDescriptorSetLayoutSupportKHR (DescriptorSetLayoutCreateInfo pCreateInfo)
+		{
+			DescriptorSetLayoutSupport pSupport;
+			unsafe {
+				pSupport = new DescriptorSetLayoutSupport ();
+				Interop.NativeMethods.vkGetDescriptorSetLayoutSupportKHR (this.m, pCreateInfo != null ? pCreateInfo.m : (Interop.DescriptorSetLayoutCreateInfo*)default(IntPtr), pSupport != null ? pSupport.m : (Interop.DescriptorSetLayoutSupport*)default(IntPtr));
+
+				return pSupport;
+			}
+		}
+
 		public int GetSwapchainGrallocUsageANDROID (Format format, ImageUsageFlags imageUsage)
 		{
 			Result result;
@@ -2748,7 +3410,68 @@ namespace Vulkan
 			}
 		}
 
-		public MemoryHostPointerPropertiesExt GetMemoryHostPointerPropertiesEXT (ExternalMemoryHandleTypeFlagsKhr handleType, IntPtr pHostPointer)
+		public void SetLocalDimmingAMD (SwapchainKhr swapChain, Bool32 localDimmingEnable)
+		{
+			unsafe {
+				Interop.NativeMethods.vkSetLocalDimmingAMD (this.m, swapChain != null ? swapChain.m : default(UInt64), localDimmingEnable);
+			}
+		}
+
+		public void GetCalibratedTimestampsEXT (CalibratedTimestampInfoExt[] pTimestampInfos, out UInt64 pTimestamps, out UInt64 pMaxDeviation)
+		{
+			Result result;
+			unsafe {
+				fixed (UInt64* ptrpTimestamps = &pTimestamps) {
+					fixed (UInt64* ptrpMaxDeviation = &pMaxDeviation) {
+						var arraypTimestampInfos = pTimestampInfos == null ? IntPtr.Zero : Marshal.AllocHGlobal (pTimestampInfos.Length*sizeof (Interop.CalibratedTimestampInfoExt));
+						var lenpTimestampInfos = pTimestampInfos == null ? 0 : pTimestampInfos.Length;
+						if (pTimestampInfos != null)
+							for (int i = 0; i < pTimestampInfos.Length; i++)
+								((Interop.CalibratedTimestampInfoExt*)arraypTimestampInfos) [i] = *(pTimestampInfos [i].m);
+						result = Interop.NativeMethods.vkGetCalibratedTimestampsEXT (this.m, (uint)lenpTimestampInfos, (Interop.CalibratedTimestampInfoExt*)arraypTimestampInfos, ptrpTimestamps, ptrpMaxDeviation);
+						Marshal.FreeHGlobal (arraypTimestampInfos);
+					}
+				}
+				if (result != Result.Success)
+					throw new ResultException (result);
+			}
+		}
+
+		public void GetCalibratedTimestampsEXT (CalibratedTimestampInfoExt pTimestampInfo, out UInt64 pTimestamp, out UInt64 pMaxDeviation)
+		{
+			Result result;
+			unsafe {
+				fixed (UInt64* ptrpTimestamp = &pTimestamp) {
+					fixed (UInt64* ptrpMaxDeviation = &pMaxDeviation) {
+						result = Interop.NativeMethods.vkGetCalibratedTimestampsEXT (this.m, (UInt32)(pTimestampInfo != null ? 1 : 0), pTimestampInfo != null ? pTimestampInfo.m : (Interop.CalibratedTimestampInfoExt*)default(IntPtr), ptrpTimestamp, ptrpMaxDeviation);
+					}
+				}
+				if (result != Result.Success)
+					throw new ResultException (result);
+			}
+		}
+
+		public void SetDebugUtilsObjectNameEXT (DebugUtilsObjectNameInfoExt pNameInfo)
+		{
+			Result result;
+			unsafe {
+				result = Interop.NativeMethods.vkSetDebugUtilsObjectNameEXT (this.m, pNameInfo != null ? pNameInfo.m : (Interop.DebugUtilsObjectNameInfoExt*)default(IntPtr));
+				if (result != Result.Success)
+					throw new ResultException (result);
+			}
+		}
+
+		public void SetDebugUtilsObjectTagEXT (DebugUtilsObjectTagInfoExt pTagInfo)
+		{
+			Result result;
+			unsafe {
+				result = Interop.NativeMethods.vkSetDebugUtilsObjectTagEXT (this.m, pTagInfo != null ? pTagInfo.m : (Interop.DebugUtilsObjectTagInfoExt*)default(IntPtr));
+				if (result != Result.Success)
+					throw new ResultException (result);
+			}
+		}
+
+		public MemoryHostPointerPropertiesExt GetMemoryHostPointerPropertiesEXT (ExternalMemoryHandleTypeFlags handleType, IntPtr pHostPointer)
 		{
 			Result result;
 			MemoryHostPointerPropertiesExt pMemoryHostPointerProperties;
@@ -2759,6 +3482,263 @@ namespace Vulkan
 					throw new ResultException (result);
 
 				return pMemoryHostPointerProperties;
+			}
+		}
+
+		public RenderPass CreateRenderPass2KHR (RenderPassCreateInfo2Khr pCreateInfo, AllocationCallbacks pAllocator = null)
+		{
+			Result result;
+			RenderPass pRenderPass;
+			unsafe {
+				pRenderPass = new RenderPass ();
+
+				fixed (UInt64* ptrpRenderPass = &pRenderPass.m) {
+					result = Interop.NativeMethods.vkCreateRenderPass2KHR (this.m, pCreateInfo != null ? pCreateInfo.m : (Interop.RenderPassCreateInfo2Khr*)default(IntPtr), pAllocator != null ? pAllocator.m : null, ptrpRenderPass);
+				}
+				if (result != Result.Success)
+					throw new ResultException (result);
+
+				return pRenderPass;
+			}
+		}
+
+		public void CompileDeferredNV (Pipeline pipeline, UInt32 shader)
+		{
+			Result result;
+			unsafe {
+				result = Interop.NativeMethods.vkCompileDeferredNV (this.m, pipeline != null ? pipeline.m : default(UInt64), shader);
+				if (result != Result.Success)
+					throw new ResultException (result);
+			}
+		}
+
+		public AccelerationStructureNv CreateAccelerationStructureNV (AccelerationStructureCreateInfoNv pCreateInfo, AllocationCallbacks pAllocator = null)
+		{
+			Result result;
+			AccelerationStructureNv pAccelerationStructure;
+			unsafe {
+				pAccelerationStructure = new AccelerationStructureNv ();
+
+				fixed (UInt64* ptrpAccelerationStructure = &pAccelerationStructure.m) {
+					result = Interop.NativeMethods.vkCreateAccelerationStructureNV (this.m, pCreateInfo != null ? pCreateInfo.m : (Interop.AccelerationStructureCreateInfoNv*)default(IntPtr), pAllocator != null ? pAllocator.m : null, ptrpAccelerationStructure);
+				}
+				if (result != Result.Success)
+					throw new ResultException (result);
+
+				return pAccelerationStructure;
+			}
+		}
+
+		public void DestroyAccelerationStructureNV (AccelerationStructureNv accelerationStructure, AllocationCallbacks pAllocator = null)
+		{
+			unsafe {
+				Interop.NativeMethods.vkDestroyAccelerationStructureNV (this.m, accelerationStructure != null ? accelerationStructure.m : default(UInt64), pAllocator != null ? pAllocator.m : null);
+			}
+		}
+
+		public void BindAccelerationStructureMemoryNV (BindAccelerationStructureMemoryInfoNv[] pBindInfos)
+		{
+			Result result;
+			unsafe {
+				var arraypBindInfos = pBindInfos == null ? IntPtr.Zero : Marshal.AllocHGlobal (pBindInfos.Length*sizeof (Interop.BindAccelerationStructureMemoryInfoNv));
+				var lenpBindInfos = pBindInfos == null ? 0 : pBindInfos.Length;
+				if (pBindInfos != null)
+					for (int i = 0; i < pBindInfos.Length; i++)
+						((Interop.BindAccelerationStructureMemoryInfoNv*)arraypBindInfos) [i] = *(pBindInfos [i].m);
+				result = Interop.NativeMethods.vkBindAccelerationStructureMemoryNV (this.m, (uint)lenpBindInfos, (Interop.BindAccelerationStructureMemoryInfoNv*)arraypBindInfos);
+				Marshal.FreeHGlobal (arraypBindInfos);
+				if (result != Result.Success)
+					throw new ResultException (result);
+			}
+		}
+
+		public void BindAccelerationStructureMemoryNV (BindAccelerationStructureMemoryInfoNv pBindInfo)
+		{
+			Result result;
+			unsafe {
+				result = Interop.NativeMethods.vkBindAccelerationStructureMemoryNV (this.m, (UInt32)(pBindInfo != null ? 1 : 0), pBindInfo != null ? pBindInfo.m : (Interop.BindAccelerationStructureMemoryInfoNv*)default(IntPtr));
+				if (result != Result.Success)
+					throw new ResultException (result);
+			}
+		}
+
+		public IntPtr GetRayTracingShaderGroupHandlesNV (Pipeline pipeline, UInt32 firstGroup, UInt32 groupCount, UIntPtr dataSize)
+		{
+			Result result;
+			IntPtr pData;
+			unsafe {
+				pData = new IntPtr ();
+				result = Interop.NativeMethods.vkGetRayTracingShaderGroupHandlesNV (this.m, pipeline != null ? pipeline.m : default(UInt64), firstGroup, groupCount, dataSize, pData);
+				if (result != Result.Success)
+					throw new ResultException (result);
+
+				return pData;
+			}
+		}
+
+		public IntPtr GetAccelerationStructureHandleNV (AccelerationStructureNv accelerationStructure, UIntPtr dataSize)
+		{
+			Result result;
+			IntPtr pData;
+			unsafe {
+				pData = new IntPtr ();
+				result = Interop.NativeMethods.vkGetAccelerationStructureHandleNV (this.m, accelerationStructure != null ? accelerationStructure.m : default(UInt64), dataSize, pData);
+				if (result != Result.Success)
+					throw new ResultException (result);
+
+				return pData;
+			}
+		}
+
+		public Pipeline[] CreateRayTracingPipelinesNV (PipelineCache pipelineCache, RayTracingPipelineCreateInfoNv[] pCreateInfos, AllocationCallbacks pAllocator = null)
+		{
+			Result result;
+			unsafe {
+				if (pCreateInfos.Length <= 0)
+					return null;
+
+				int size = Marshal.SizeOf (typeof (UInt64));
+				var refpPipelines = new NativeReference ((int)(size * pCreateInfos.Length));
+				var ptrpPipelines = refpPipelines.Handle;
+				var arraypCreateInfos = pCreateInfos == null ? IntPtr.Zero : Marshal.AllocHGlobal (pCreateInfos.Length*sizeof (Interop.RayTracingPipelineCreateInfoNv));
+				var lenpCreateInfos = pCreateInfos == null ? 0 : pCreateInfos.Length;
+				if (pCreateInfos != null)
+					for (int i = 0; i < pCreateInfos.Length; i++)
+						((Interop.RayTracingPipelineCreateInfoNv*)arraypCreateInfos) [i] = *(pCreateInfos [i].m);
+				result = Interop.NativeMethods.vkCreateRayTracingPipelinesNV (this.m, pipelineCache != null ? pipelineCache.m : default(UInt64), (uint)lenpCreateInfos, (Interop.RayTracingPipelineCreateInfoNv*)arraypCreateInfos, pAllocator != null ? pAllocator.m : null, (UInt64*)ptrpPipelines);
+				Marshal.FreeHGlobal (arraypCreateInfos);
+				if (result != Result.Success)
+					throw new ResultException (result);
+
+				if (pCreateInfos.Length <= 0)
+					return null;
+				var arr = new Pipeline [pCreateInfos.Length];
+				for (int i = 0; i < pCreateInfos.Length; i++) {
+					arr [i] = new Pipeline ();
+					arr [i].m = ((UInt64*)ptrpPipelines) [i];
+				}
+
+				return arr;
+			}
+		}
+
+		public ImageDrmFormatModifierPropertiesExt GetImageDrmFormatModifierPropertiesEXT (Image image)
+		{
+			Result result;
+			ImageDrmFormatModifierPropertiesExt pProperties;
+			unsafe {
+				pProperties = new ImageDrmFormatModifierPropertiesExt ();
+				result = Interop.NativeMethods.vkGetImageDrmFormatModifierPropertiesEXT (this.m, image != null ? image.m : default(UInt64), pProperties != null ? pProperties.m : (Interop.ImageDrmFormatModifierPropertiesExt*)default(IntPtr));
+				if (result != Result.Success)
+					throw new ResultException (result);
+
+				return pProperties;
+			}
+		}
+
+		public DeviceAddress GetBufferDeviceAddressEXT (BufferDeviceAddressInfoExt pInfo)
+		{
+			unsafe {
+				return Interop.NativeMethods.vkGetBufferDeviceAddressEXT (this.m, pInfo != null ? pInfo.m : (Interop.BufferDeviceAddressInfoExt*)default(IntPtr));
+			}
+		}
+
+		public UInt32 GetImageViewHandleNVX (ImageViewHandleInfoNvx pInfo)
+		{
+			unsafe {
+				return Interop.NativeMethods.vkGetImageViewHandleNVX (this.m, pInfo != null ? pInfo.m : (Interop.ImageViewHandleInfoNvx*)default(IntPtr));
+			}
+		}
+
+		public DeviceGroupPresentModeFlagsKhr GetGroupSurfacePresentModes2EXT (PhysicalDeviceSurfaceInfo2Khr pSurfaceInfo)
+		{
+			Result result;
+			DeviceGroupPresentModeFlagsKhr pModes;
+			unsafe {
+				pModes = new DeviceGroupPresentModeFlagsKhr ();
+				result = Interop.NativeMethods.vkGetDeviceGroupSurfacePresentModes2EXT (this.m, pSurfaceInfo != null ? pSurfaceInfo.m : (Interop.PhysicalDeviceSurfaceInfo2Khr*)default(IntPtr), &pModes);
+				if (result != Result.Success)
+					throw new ResultException (result);
+
+				return pModes;
+			}
+		}
+
+		public void AcquireFullScreenExclusiveModeEXT (SwapchainKhr swapchain)
+		{
+			Result result;
+			unsafe {
+				result = Interop.NativeMethods.vkAcquireFullScreenExclusiveModeEXT (this.m, swapchain != null ? swapchain.m : default(UInt64));
+				if (result != Result.Success)
+					throw new ResultException (result);
+			}
+		}
+
+		public void ReleaseFullScreenExclusiveModeEXT (SwapchainKhr swapchain)
+		{
+			Result result;
+			unsafe {
+				result = Interop.NativeMethods.vkReleaseFullScreenExclusiveModeEXT (this.m, swapchain != null ? swapchain.m : default(UInt64));
+				if (result != Result.Success)
+					throw new ResultException (result);
+			}
+		}
+
+		public void InitializePerformanceApiINTEL (InitializePerformanceApiInfoIntel pInitializeInfo)
+		{
+			Result result;
+			unsafe {
+				result = Interop.NativeMethods.vkInitializePerformanceApiINTEL (this.m, pInitializeInfo != null ? pInitializeInfo.m : (Interop.InitializePerformanceApiInfoIntel*)default(IntPtr));
+				if (result != Result.Success)
+					throw new ResultException (result);
+			}
+		}
+
+		public void UninitializePerformanceApiINTEL ()
+		{
+			unsafe {
+				Interop.NativeMethods.vkUninitializePerformanceApiINTEL (this.m);
+			}
+		}
+
+		public PerformanceConfigurationIntel AcquirePerformanceConfigurationINTEL (PerformanceConfigurationAcquireInfoIntel pAcquireInfo)
+		{
+			Result result;
+			PerformanceConfigurationIntel pConfiguration;
+			unsafe {
+				pConfiguration = new PerformanceConfigurationIntel ();
+
+				fixed (UInt64* ptrpConfiguration = &pConfiguration.m) {
+					result = Interop.NativeMethods.vkAcquirePerformanceConfigurationINTEL (this.m, pAcquireInfo != null ? pAcquireInfo.m : (Interop.PerformanceConfigurationAcquireInfoIntel*)default(IntPtr), ptrpConfiguration);
+				}
+				if (result != Result.Success)
+					throw new ResultException (result);
+
+				return pConfiguration;
+			}
+		}
+
+		public void ReleasePerformanceConfigurationINTEL (PerformanceConfigurationIntel configuration)
+		{
+			Result result;
+			unsafe {
+				result = Interop.NativeMethods.vkReleasePerformanceConfigurationINTEL (this.m, configuration != null ? configuration.m : default(UInt64));
+				if (result != Result.Success)
+					throw new ResultException (result);
+			}
+		}
+
+		public PerformanceValueIntel GetPerformanceParameterINTEL (PerformanceParameterTypeIntel parameter)
+		{
+			Result result;
+			PerformanceValueIntel pValue;
+			unsafe {
+				pValue = new PerformanceValueIntel ();
+				result = Interop.NativeMethods.vkGetPerformanceParameterINTEL (this.m, parameter, pValue != null ? pValue.m : (Interop.PerformanceValueIntel*)default(IntPtr));
+				if (result != Result.Success)
+					throw new ResultException (result);
+
+				return pValue;
 			}
 		}
 	}
@@ -2860,6 +3840,61 @@ namespace Vulkan
 					throw new ResultException (result);
 
 				return pNativeFenceFd;
+			}
+		}
+
+		public void BeginDebugUtilsLabelEXT (DebugUtilsLabelExt pLabelInfo)
+		{
+			unsafe {
+				Interop.NativeMethods.vkQueueBeginDebugUtilsLabelEXT (this.m, pLabelInfo != null ? pLabelInfo.m : (Interop.DebugUtilsLabelExt*)default(IntPtr));
+			}
+		}
+
+		public void EndDebugUtilsLabelEXT ()
+		{
+			unsafe {
+				Interop.NativeMethods.vkQueueEndDebugUtilsLabelEXT (this.m);
+			}
+		}
+
+		public void InsertDebugUtilsLabelEXT (DebugUtilsLabelExt pLabelInfo)
+		{
+			unsafe {
+				Interop.NativeMethods.vkQueueInsertDebugUtilsLabelEXT (this.m, pLabelInfo != null ? pLabelInfo.m : (Interop.DebugUtilsLabelExt*)default(IntPtr));
+			}
+		}
+
+		public CheckpointDataNv[] GetCheckpointDataNV ()
+		{
+			unsafe {
+				UInt32 pCheckpointDataCount;
+				Interop.NativeMethods.vkGetQueueCheckpointDataNV (this.m, &pCheckpointDataCount, null);
+				if (pCheckpointDataCount <= 0)
+					return null;
+
+				int size = Marshal.SizeOf (typeof (Interop.CheckpointDataNv));
+				var refpCheckpointData = new NativeReference ((int)(size * pCheckpointDataCount));
+				var ptrpCheckpointData = refpCheckpointData.Handle;
+				Interop.NativeMethods.vkGetQueueCheckpointDataNV (this.m, &pCheckpointDataCount, (Interop.CheckpointDataNv*)ptrpCheckpointData);
+
+				if (pCheckpointDataCount <= 0)
+					return null;
+				var arr = new CheckpointDataNv [pCheckpointDataCount];
+				for (int i = 0; i < pCheckpointDataCount; i++) {
+					arr [i] = new CheckpointDataNv (new NativePointer (refpCheckpointData, (IntPtr)(&((Interop.CheckpointDataNv*)ptrpCheckpointData) [i])));
+				}
+
+				return arr;
+			}
+		}
+
+		public void SetPerformanceConfigurationINTEL (PerformanceConfigurationIntel configuration)
+		{
+			Result result;
+			unsafe {
+				result = Interop.NativeMethods.vkQueueSetPerformanceConfigurationINTEL (this.m, configuration != null ? configuration.m : default(UInt64));
+				if (result != Result.Success)
+					throw new ResultException (result);
 			}
 		}
 	}
@@ -3429,6 +4464,20 @@ namespace Vulkan
 			}
 		}
 
+		public void CmdBeginConditionalRenderingEXT (ConditionalRenderingBeginInfoExt pConditionalRenderingBegin)
+		{
+			unsafe {
+				Interop.NativeMethods.vkCmdBeginConditionalRenderingEXT (this.m, pConditionalRenderingBegin != null ? pConditionalRenderingBegin.m : (Interop.ConditionalRenderingBeginInfoExt*)default(IntPtr));
+			}
+		}
+
+		public void CmdEndConditionalRenderingEXT ()
+		{
+			unsafe {
+				Interop.NativeMethods.vkCmdEndConditionalRenderingEXT (this.m);
+			}
+		}
+
 		public void CmdResetQueryPool (QueryPool queryPool, UInt32 firstQuery, UInt32 queryCount)
 		{
 			unsafe {
@@ -3521,20 +4570,6 @@ namespace Vulkan
 			}
 		}
 
-		public void CmdDrawIndirectCountAMD (Buffer buffer, DeviceSize offset, Buffer countBuffer, DeviceSize countBufferOffset, UInt32 maxDrawCount, UInt32 stride)
-		{
-			unsafe {
-				Interop.NativeMethods.vkCmdDrawIndirectCountAMD (this.m, buffer != null ? buffer.m : default(UInt64), offset, countBuffer != null ? countBuffer.m : default(UInt64), countBufferOffset, maxDrawCount, stride);
-			}
-		}
-
-		public void CmdDrawIndexedIndirectCountAMD (Buffer buffer, DeviceSize offset, Buffer countBuffer, DeviceSize countBufferOffset, UInt32 maxDrawCount, UInt32 stride)
-		{
-			unsafe {
-				Interop.NativeMethods.vkCmdDrawIndexedIndirectCountAMD (this.m, buffer != null ? buffer.m : default(UInt64), offset, countBuffer != null ? countBuffer.m : default(UInt64), countBufferOffset, maxDrawCount, stride);
-			}
-		}
-
 		public void CmdProcessCommandsNVX (CmdProcessCommandsInfoNvx pProcessCommandsInfo)
 		{
 			unsafe {
@@ -3569,21 +4604,37 @@ namespace Vulkan
 			}
 		}
 
-		public void CmdSetDeviceMaskKHX (UInt32 deviceMask)
+		public void CmdSetDeviceMask (UInt32 deviceMask)
 		{
 			unsafe {
-				Interop.NativeMethods.vkCmdSetDeviceMaskKHX (this.m, deviceMask);
+				Interop.NativeMethods.vkCmdSetDeviceMask (this.m, deviceMask);
 			}
 		}
 
-		public void CmdDispatchBaseKHX (UInt32 baseGroupX, UInt32 baseGroupY, UInt32 baseGroupZ, UInt32 groupCountX, UInt32 groupCountY, UInt32 groupCountZ)
+		[Obsolete ("CmdSetDeviceMaskKHR is deprecated, please use CmdSetDeviceMask instead.")]
+		public void CmdSetDeviceMaskKHR (UInt32 deviceMask)
 		{
 			unsafe {
-				Interop.NativeMethods.vkCmdDispatchBaseKHX (this.m, baseGroupX, baseGroupY, baseGroupZ, groupCountX, groupCountY, groupCountZ);
+				Interop.NativeMethods.vkCmdSetDeviceMaskKHR (this.m, deviceMask);
 			}
 		}
 
-		public void CmdPushDescriptorSetWithTemplateKHR (DescriptorUpdateTemplateKhr descriptorUpdateTemplate, PipelineLayout layout, UInt32 set, IntPtr pData)
+		public void CmdDispatchBase (UInt32 baseGroupX, UInt32 baseGroupY, UInt32 baseGroupZ, UInt32 groupCountX, UInt32 groupCountY, UInt32 groupCountZ)
+		{
+			unsafe {
+				Interop.NativeMethods.vkCmdDispatchBase (this.m, baseGroupX, baseGroupY, baseGroupZ, groupCountX, groupCountY, groupCountZ);
+			}
+		}
+
+		[Obsolete ("CmdDispatchBaseKHR is deprecated, please use CmdDispatchBase instead.")]
+		public void CmdDispatchBaseKHR (UInt32 baseGroupX, UInt32 baseGroupY, UInt32 baseGroupZ, UInt32 groupCountX, UInt32 groupCountY, UInt32 groupCountZ)
+		{
+			unsafe {
+				Interop.NativeMethods.vkCmdDispatchBaseKHR (this.m, baseGroupX, baseGroupY, baseGroupZ, groupCountX, groupCountY, groupCountZ);
+			}
+		}
+
+		public void CmdPushDescriptorSetWithTemplateKHR (DescriptorUpdateTemplate descriptorUpdateTemplate, PipelineLayout layout, UInt32 set, IntPtr pData)
 		{
 			unsafe {
 				Interop.NativeMethods.vkCmdPushDescriptorSetWithTemplateKHR (this.m, descriptorUpdateTemplate != null ? descriptorUpdateTemplate.m : default(UInt64), layout != null ? layout.m : default(UInt64), set, pData);
@@ -3641,10 +4692,336 @@ namespace Vulkan
 			}
 		}
 
+		public void CmdBeginDebugUtilsLabelEXT (DebugUtilsLabelExt pLabelInfo)
+		{
+			unsafe {
+				Interop.NativeMethods.vkCmdBeginDebugUtilsLabelEXT (this.m, pLabelInfo != null ? pLabelInfo.m : (Interop.DebugUtilsLabelExt*)default(IntPtr));
+			}
+		}
+
+		public void CmdEndDebugUtilsLabelEXT ()
+		{
+			unsafe {
+				Interop.NativeMethods.vkCmdEndDebugUtilsLabelEXT (this.m);
+			}
+		}
+
+		public void CmdInsertDebugUtilsLabelEXT (DebugUtilsLabelExt pLabelInfo)
+		{
+			unsafe {
+				Interop.NativeMethods.vkCmdInsertDebugUtilsLabelEXT (this.m, pLabelInfo != null ? pLabelInfo.m : (Interop.DebugUtilsLabelExt*)default(IntPtr));
+			}
+		}
+
 		public void CmdWriteBufferMarkerAMD (PipelineStageFlags pipelineStage, Buffer dstBuffer, DeviceSize dstOffset, UInt32 marker)
 		{
 			unsafe {
 				Interop.NativeMethods.vkCmdWriteBufferMarkerAMD (this.m, pipelineStage, dstBuffer != null ? dstBuffer.m : default(UInt64), dstOffset, marker);
+			}
+		}
+
+		public void CmdBeginRenderPass2KHR (RenderPassBeginInfo pRenderPassBegin, SubpassBeginInfoKhr pSubpassBeginInfo)
+		{
+			unsafe {
+				Interop.NativeMethods.vkCmdBeginRenderPass2KHR (this.m, pRenderPassBegin != null ? pRenderPassBegin.m : (Interop.RenderPassBeginInfo*)default(IntPtr), pSubpassBeginInfo != null ? pSubpassBeginInfo.m : (Interop.SubpassBeginInfoKhr*)default(IntPtr));
+			}
+		}
+
+		public void CmdNextSubpass2KHR (SubpassBeginInfoKhr pSubpassBeginInfo, SubpassEndInfoKhr pSubpassEndInfo)
+		{
+			unsafe {
+				Interop.NativeMethods.vkCmdNextSubpass2KHR (this.m, pSubpassBeginInfo != null ? pSubpassBeginInfo.m : (Interop.SubpassBeginInfoKhr*)default(IntPtr), pSubpassEndInfo != null ? pSubpassEndInfo.m : (Interop.SubpassEndInfoKhr*)default(IntPtr));
+			}
+		}
+
+		public void CmdEndRenderPass2KHR (SubpassEndInfoKhr pSubpassEndInfo)
+		{
+			unsafe {
+				Interop.NativeMethods.vkCmdEndRenderPass2KHR (this.m, pSubpassEndInfo != null ? pSubpassEndInfo.m : (Interop.SubpassEndInfoKhr*)default(IntPtr));
+			}
+		}
+
+		public void CmdDrawIndirectCountKHR (Buffer buffer, DeviceSize offset, Buffer countBuffer, DeviceSize countBufferOffset, UInt32 maxDrawCount, UInt32 stride)
+		{
+			unsafe {
+				Interop.NativeMethods.vkCmdDrawIndirectCountKHR (this.m, buffer != null ? buffer.m : default(UInt64), offset, countBuffer != null ? countBuffer.m : default(UInt64), countBufferOffset, maxDrawCount, stride);
+			}
+		}
+
+		[Obsolete ("CmdDrawIndirectCountAMD is deprecated, please use CmdDrawIndirectCountKHR instead.")]
+		public void CmdDrawIndirectCountAMD (Buffer buffer, DeviceSize offset, Buffer countBuffer, DeviceSize countBufferOffset, UInt32 maxDrawCount, UInt32 stride)
+		{
+			unsafe {
+				Interop.NativeMethods.vkCmdDrawIndirectCountAMD (this.m, buffer != null ? buffer.m : default(UInt64), offset, countBuffer != null ? countBuffer.m : default(UInt64), countBufferOffset, maxDrawCount, stride);
+			}
+		}
+
+		public void CmdDrawIndexedIndirectCountKHR (Buffer buffer, DeviceSize offset, Buffer countBuffer, DeviceSize countBufferOffset, UInt32 maxDrawCount, UInt32 stride)
+		{
+			unsafe {
+				Interop.NativeMethods.vkCmdDrawIndexedIndirectCountKHR (this.m, buffer != null ? buffer.m : default(UInt64), offset, countBuffer != null ? countBuffer.m : default(UInt64), countBufferOffset, maxDrawCount, stride);
+			}
+		}
+
+		[Obsolete ("CmdDrawIndexedIndirectCountAMD is deprecated, please use CmdDrawIndexedIndirectCountKHR instead.")]
+		public void CmdDrawIndexedIndirectCountAMD (Buffer buffer, DeviceSize offset, Buffer countBuffer, DeviceSize countBufferOffset, UInt32 maxDrawCount, UInt32 stride)
+		{
+			unsafe {
+				Interop.NativeMethods.vkCmdDrawIndexedIndirectCountAMD (this.m, buffer != null ? buffer.m : default(UInt64), offset, countBuffer != null ? countBuffer.m : default(UInt64), countBufferOffset, maxDrawCount, stride);
+			}
+		}
+
+		public void CmdSetCheckpointNV (IntPtr pCheckpointMarker)
+		{
+			unsafe {
+				Interop.NativeMethods.vkCmdSetCheckpointNV (this.m, pCheckpointMarker);
+			}
+		}
+
+		public void CmdBindTransformFeedbackBuffersEXT (UInt32 firstBinding, Buffer[] pBuffers, DeviceSize[] pOffsets, DeviceSize[] pSizes = null)
+		{
+			unsafe {
+				var arraypBuffers = pBuffers == null ? IntPtr.Zero : Marshal.AllocHGlobal (pBuffers.Length*sizeof (UInt64));
+				var lenpBuffers = pBuffers == null ? 0 : pBuffers.Length;
+				if (pBuffers != null)
+					for (int i = 0; i < pBuffers.Length; i++)
+						((UInt64*)arraypBuffers) [i] = (pBuffers [i].m);
+				var arraypOffsets = pOffsets == null ? IntPtr.Zero : Marshal.AllocHGlobal (pOffsets.Length*sizeof (DeviceSize));
+				var lenpOffsets = pOffsets == null ? 0 : pOffsets.Length;
+				if (pOffsets != null)
+					for (int i = 0; i < pOffsets.Length; i++)
+						((DeviceSize*)arraypOffsets) [i] = (pOffsets [i]);
+				var arraypSizes = pSizes == null ? IntPtr.Zero : Marshal.AllocHGlobal (pSizes.Length*sizeof (DeviceSize));
+				var lenpSizes = pSizes == null ? 0 : pSizes.Length;
+				if (pSizes != null)
+					for (int i = 0; i < pSizes.Length; i++)
+						((DeviceSize*)arraypSizes) [i] = (pSizes [i]);
+				Interop.NativeMethods.vkCmdBindTransformFeedbackBuffersEXT (this.m, firstBinding, (uint)lenpSizes, (UInt64*)arraypBuffers, (DeviceSize*)arraypOffsets, (DeviceSize*)arraypSizes);
+				Marshal.FreeHGlobal (arraypBuffers);
+				Marshal.FreeHGlobal (arraypOffsets);
+				Marshal.FreeHGlobal (arraypSizes);
+			}
+		}
+
+		public void CmdBeginTransformFeedbackEXT (UInt32 firstCounterBuffer, Buffer[] pCounterBuffers, DeviceSize[] pCounterBufferOffsets = null)
+		{
+			unsafe {
+				var arraypCounterBuffers = pCounterBuffers == null ? IntPtr.Zero : Marshal.AllocHGlobal (pCounterBuffers.Length*sizeof (UInt64));
+				var lenpCounterBuffers = pCounterBuffers == null ? 0 : pCounterBuffers.Length;
+				if (pCounterBuffers != null)
+					for (int i = 0; i < pCounterBuffers.Length; i++)
+						((UInt64*)arraypCounterBuffers) [i] = (pCounterBuffers [i].m);
+				var arraypCounterBufferOffsets = pCounterBufferOffsets == null ? IntPtr.Zero : Marshal.AllocHGlobal (pCounterBufferOffsets.Length*sizeof (DeviceSize));
+				var lenpCounterBufferOffsets = pCounterBufferOffsets == null ? 0 : pCounterBufferOffsets.Length;
+				if (pCounterBufferOffsets != null)
+					for (int i = 0; i < pCounterBufferOffsets.Length; i++)
+						((DeviceSize*)arraypCounterBufferOffsets) [i] = (pCounterBufferOffsets [i]);
+				Interop.NativeMethods.vkCmdBeginTransformFeedbackEXT (this.m, firstCounterBuffer, (uint)lenpCounterBufferOffsets, (UInt64*)arraypCounterBuffers, (DeviceSize*)arraypCounterBufferOffsets);
+				Marshal.FreeHGlobal (arraypCounterBuffers);
+				Marshal.FreeHGlobal (arraypCounterBufferOffsets);
+			}
+		}
+
+		public void CmdEndTransformFeedbackEXT (UInt32 firstCounterBuffer, Buffer[] pCounterBuffers, DeviceSize[] pCounterBufferOffsets = null)
+		{
+			unsafe {
+				var arraypCounterBuffers = pCounterBuffers == null ? IntPtr.Zero : Marshal.AllocHGlobal (pCounterBuffers.Length*sizeof (UInt64));
+				var lenpCounterBuffers = pCounterBuffers == null ? 0 : pCounterBuffers.Length;
+				if (pCounterBuffers != null)
+					for (int i = 0; i < pCounterBuffers.Length; i++)
+						((UInt64*)arraypCounterBuffers) [i] = (pCounterBuffers [i].m);
+				var arraypCounterBufferOffsets = pCounterBufferOffsets == null ? IntPtr.Zero : Marshal.AllocHGlobal (pCounterBufferOffsets.Length*sizeof (DeviceSize));
+				var lenpCounterBufferOffsets = pCounterBufferOffsets == null ? 0 : pCounterBufferOffsets.Length;
+				if (pCounterBufferOffsets != null)
+					for (int i = 0; i < pCounterBufferOffsets.Length; i++)
+						((DeviceSize*)arraypCounterBufferOffsets) [i] = (pCounterBufferOffsets [i]);
+				Interop.NativeMethods.vkCmdEndTransformFeedbackEXT (this.m, firstCounterBuffer, (uint)lenpCounterBufferOffsets, (UInt64*)arraypCounterBuffers, (DeviceSize*)arraypCounterBufferOffsets);
+				Marshal.FreeHGlobal (arraypCounterBuffers);
+				Marshal.FreeHGlobal (arraypCounterBufferOffsets);
+			}
+		}
+
+		public void CmdBeginQueryIndexedEXT (QueryPool queryPool, UInt32 query, QueryControlFlags flags, UInt32 index)
+		{
+			unsafe {
+				Interop.NativeMethods.vkCmdBeginQueryIndexedEXT (this.m, queryPool != null ? queryPool.m : default(UInt64), query, flags, index);
+			}
+		}
+
+		public void CmdEndQueryIndexedEXT (QueryPool queryPool, UInt32 query, UInt32 index)
+		{
+			unsafe {
+				Interop.NativeMethods.vkCmdEndQueryIndexedEXT (this.m, queryPool != null ? queryPool.m : default(UInt64), query, index);
+			}
+		}
+
+		public void CmdDrawIndirectByteCountEXT (UInt32 instanceCount, UInt32 firstInstance, Buffer counterBuffer, DeviceSize counterBufferOffset, UInt32 counterOffset, UInt32 vertexStride)
+		{
+			unsafe {
+				Interop.NativeMethods.vkCmdDrawIndirectByteCountEXT (this.m, instanceCount, firstInstance, counterBuffer != null ? counterBuffer.m : default(UInt64), counterBufferOffset, counterOffset, vertexStride);
+			}
+		}
+
+		public void CmdSetExclusiveScissorNV (UInt32 firstExclusiveScissor, Rect2D[] pExclusiveScissors)
+		{
+			unsafe {
+				var arraypExclusiveScissors = pExclusiveScissors == null ? IntPtr.Zero : Marshal.AllocHGlobal (pExclusiveScissors.Length*sizeof (Rect2D));
+				var lenpExclusiveScissors = pExclusiveScissors == null ? 0 : pExclusiveScissors.Length;
+				if (pExclusiveScissors != null)
+					for (int i = 0; i < pExclusiveScissors.Length; i++)
+						((Rect2D*)arraypExclusiveScissors) [i] = (pExclusiveScissors [i]);
+				Interop.NativeMethods.vkCmdSetExclusiveScissorNV (this.m, firstExclusiveScissor, (uint)lenpExclusiveScissors, (Rect2D*)arraypExclusiveScissors);
+				Marshal.FreeHGlobal (arraypExclusiveScissors);
+			}
+		}
+
+		public void CmdSetExclusiveScissorNV (UInt32 firstExclusiveScissor, Rect2D? pExclusiveScissor)
+		{
+			unsafe {
+				Rect2D valpExclusiveScissor = pExclusiveScissor ?? default(Rect2D);
+				Rect2D* ptrpExclusiveScissor = pExclusiveScissor != null ? &valpExclusiveScissor : (Rect2D*)IntPtr.Zero;
+				Interop.NativeMethods.vkCmdSetExclusiveScissorNV (this.m, firstExclusiveScissor, (UInt32)(pExclusiveScissor != null ? 1 : 0), ptrpExclusiveScissor);
+			}
+		}
+
+		public void CmdBindShadingRateImageNV (ImageView imageView, ImageLayout imageLayout)
+		{
+			unsafe {
+				Interop.NativeMethods.vkCmdBindShadingRateImageNV (this.m, imageView != null ? imageView.m : default(UInt64), imageLayout);
+			}
+		}
+
+		public void CmdSetViewportShadingRatePaletteNV (UInt32 firstViewport, ShadingRatePaletteNv[] pShadingRatePalettes)
+		{
+			unsafe {
+				var arraypShadingRatePalettes = pShadingRatePalettes == null ? IntPtr.Zero : Marshal.AllocHGlobal (pShadingRatePalettes.Length*sizeof (Interop.ShadingRatePaletteNv));
+				var lenpShadingRatePalettes = pShadingRatePalettes == null ? 0 : pShadingRatePalettes.Length;
+				if (pShadingRatePalettes != null)
+					for (int i = 0; i < pShadingRatePalettes.Length; i++)
+						((Interop.ShadingRatePaletteNv*)arraypShadingRatePalettes) [i] = *(pShadingRatePalettes [i].m);
+				Interop.NativeMethods.vkCmdSetViewportShadingRatePaletteNV (this.m, firstViewport, (uint)lenpShadingRatePalettes, (Interop.ShadingRatePaletteNv*)arraypShadingRatePalettes);
+				Marshal.FreeHGlobal (arraypShadingRatePalettes);
+			}
+		}
+
+		public void CmdSetViewportShadingRatePaletteNV (UInt32 firstViewport, ShadingRatePaletteNv pShadingRatePalette)
+		{
+			unsafe {
+				Interop.NativeMethods.vkCmdSetViewportShadingRatePaletteNV (this.m, firstViewport, (UInt32)(pShadingRatePalette != null ? 1 : 0), pShadingRatePalette != null ? pShadingRatePalette.m : (Interop.ShadingRatePaletteNv*)default(IntPtr));
+			}
+		}
+
+		public void CmdSetCoarseSampleOrderNV (CoarseSampleOrderTypeNv sampleOrderType, CoarseSampleOrderCustomNv[] pCustomSampleOrders)
+		{
+			unsafe {
+				var arraypCustomSampleOrders = pCustomSampleOrders == null ? IntPtr.Zero : Marshal.AllocHGlobal (pCustomSampleOrders.Length*sizeof (Interop.CoarseSampleOrderCustomNv));
+				var lenpCustomSampleOrders = pCustomSampleOrders == null ? 0 : pCustomSampleOrders.Length;
+				if (pCustomSampleOrders != null)
+					for (int i = 0; i < pCustomSampleOrders.Length; i++)
+						((Interop.CoarseSampleOrderCustomNv*)arraypCustomSampleOrders) [i] = *(pCustomSampleOrders [i].m);
+				Interop.NativeMethods.vkCmdSetCoarseSampleOrderNV (this.m, sampleOrderType, (uint)lenpCustomSampleOrders, (Interop.CoarseSampleOrderCustomNv*)arraypCustomSampleOrders);
+				Marshal.FreeHGlobal (arraypCustomSampleOrders);
+			}
+		}
+
+		public void CmdSetCoarseSampleOrderNV (CoarseSampleOrderTypeNv sampleOrderType, CoarseSampleOrderCustomNv pCustomSampleOrder)
+		{
+			unsafe {
+				Interop.NativeMethods.vkCmdSetCoarseSampleOrderNV (this.m, sampleOrderType, (UInt32)(pCustomSampleOrder != null ? 1 : 0), pCustomSampleOrder != null ? pCustomSampleOrder.m : (Interop.CoarseSampleOrderCustomNv*)default(IntPtr));
+			}
+		}
+
+		public void CmdDrawMeshTasksNV (UInt32 taskCount, UInt32 firstTask)
+		{
+			unsafe {
+				Interop.NativeMethods.vkCmdDrawMeshTasksNV (this.m, taskCount, firstTask);
+			}
+		}
+
+		public void CmdDrawMeshTasksIndirectNV (Buffer buffer, DeviceSize offset, UInt32 drawCount, UInt32 stride)
+		{
+			unsafe {
+				Interop.NativeMethods.vkCmdDrawMeshTasksIndirectNV (this.m, buffer != null ? buffer.m : default(UInt64), offset, drawCount, stride);
+			}
+		}
+
+		public void CmdDrawMeshTasksIndirectCountNV (Buffer buffer, DeviceSize offset, Buffer countBuffer, DeviceSize countBufferOffset, UInt32 maxDrawCount, UInt32 stride)
+		{
+			unsafe {
+				Interop.NativeMethods.vkCmdDrawMeshTasksIndirectCountNV (this.m, buffer != null ? buffer.m : default(UInt64), offset, countBuffer != null ? countBuffer.m : default(UInt64), countBufferOffset, maxDrawCount, stride);
+			}
+		}
+
+		public void CmdCopyAccelerationStructureNV (AccelerationStructureNv dst, AccelerationStructureNv src, CopyAccelerationStructureModeNv mode)
+		{
+			unsafe {
+				Interop.NativeMethods.vkCmdCopyAccelerationStructureNV (this.m, dst != null ? dst.m : default(UInt64), src != null ? src.m : default(UInt64), mode);
+			}
+		}
+
+		public void CmdWriteAccelerationStructuresPropertiesNV (AccelerationStructureNv[] pAccelerationStructures, QueryType queryType, QueryPool queryPool, UInt32 firstQuery)
+		{
+			unsafe {
+				var arraypAccelerationStructures = pAccelerationStructures == null ? IntPtr.Zero : Marshal.AllocHGlobal (pAccelerationStructures.Length*sizeof (UInt64));
+				var lenpAccelerationStructures = pAccelerationStructures == null ? 0 : pAccelerationStructures.Length;
+				if (pAccelerationStructures != null)
+					for (int i = 0; i < pAccelerationStructures.Length; i++)
+						((UInt64*)arraypAccelerationStructures) [i] = (pAccelerationStructures [i].m);
+				Interop.NativeMethods.vkCmdWriteAccelerationStructuresPropertiesNV (this.m, (uint)lenpAccelerationStructures, (UInt64*)arraypAccelerationStructures, queryType, queryPool != null ? queryPool.m : default(UInt64), firstQuery);
+				Marshal.FreeHGlobal (arraypAccelerationStructures);
+			}
+		}
+
+		public void CmdWriteAccelerationStructuresPropertiesNV (AccelerationStructureNv pAccelerationStructure, QueryType queryType, QueryPool queryPool, UInt32 firstQuery)
+		{
+			unsafe {
+				fixed (UInt64* ptrpAccelerationStructure = &pAccelerationStructure.m) {
+					Interop.NativeMethods.vkCmdWriteAccelerationStructuresPropertiesNV (this.m, (UInt32)(pAccelerationStructure != null ? 1 : 0), ptrpAccelerationStructure, queryType, queryPool != null ? queryPool.m : default(UInt64), firstQuery);
+				}
+			}
+		}
+
+		public void CmdBuildAccelerationStructureNV (AccelerationStructureInfoNv pInfo, Buffer instanceData, DeviceSize instanceOffset, Bool32 update, AccelerationStructureNv dst, AccelerationStructureNv src, Buffer scratch, DeviceSize scratchOffset)
+		{
+			unsafe {
+				Interop.NativeMethods.vkCmdBuildAccelerationStructureNV (this.m, pInfo != null ? pInfo.m : (Interop.AccelerationStructureInfoNv*)default(IntPtr), instanceData != null ? instanceData.m : default(UInt64), instanceOffset, update, dst != null ? dst.m : default(UInt64), src != null ? src.m : default(UInt64), scratch != null ? scratch.m : default(UInt64), scratchOffset);
+			}
+		}
+
+		public void CmdTraceRaysNV (Buffer raygenShaderBindingTableBuffer, DeviceSize raygenShaderBindingOffset, Buffer missShaderBindingTableBuffer, DeviceSize missShaderBindingOffset, DeviceSize missShaderBindingStride, Buffer hitShaderBindingTableBuffer, DeviceSize hitShaderBindingOffset, DeviceSize hitShaderBindingStride, Buffer callableShaderBindingTableBuffer, DeviceSize callableShaderBindingOffset, DeviceSize callableShaderBindingStride, UInt32 width, UInt32 height, UInt32 depth)
+		{
+			unsafe {
+				Interop.NativeMethods.vkCmdTraceRaysNV (this.m, raygenShaderBindingTableBuffer != null ? raygenShaderBindingTableBuffer.m : default(UInt64), raygenShaderBindingOffset, missShaderBindingTableBuffer != null ? missShaderBindingTableBuffer.m : default(UInt64), missShaderBindingOffset, missShaderBindingStride, hitShaderBindingTableBuffer != null ? hitShaderBindingTableBuffer.m : default(UInt64), hitShaderBindingOffset, hitShaderBindingStride, callableShaderBindingTableBuffer != null ? callableShaderBindingTableBuffer.m : default(UInt64), callableShaderBindingOffset, callableShaderBindingStride, width, height, depth);
+			}
+		}
+
+		public void CmdSetPerformanceMarkerINTEL (PerformanceMarkerInfoIntel pMarkerInfo)
+		{
+			Result result;
+			unsafe {
+				result = Interop.NativeMethods.vkCmdSetPerformanceMarkerINTEL (this.m, pMarkerInfo != null ? pMarkerInfo.m : (Interop.PerformanceMarkerInfoIntel*)default(IntPtr));
+				if (result != Result.Success)
+					throw new ResultException (result);
+			}
+		}
+
+		public void CmdSetPerformanceStreamMarkerINTEL (PerformanceStreamMarkerInfoIntel pMarkerInfo)
+		{
+			Result result;
+			unsafe {
+				result = Interop.NativeMethods.vkCmdSetPerformanceStreamMarkerINTEL (this.m, pMarkerInfo != null ? pMarkerInfo.m : (Interop.PerformanceStreamMarkerInfoIntel*)default(IntPtr));
+				if (result != Result.Success)
+					throw new ResultException (result);
+			}
+		}
+
+		public void CmdSetPerformanceOverrideINTEL (PerformanceOverrideInfoIntel pOverrideInfo)
+		{
+			Result result;
+			unsafe {
+				result = Interop.NativeMethods.vkCmdSetPerformanceOverrideINTEL (this.m, pOverrideInfo != null ? pOverrideInfo.m : (Interop.PerformanceOverrideInfoIntel*)default(IntPtr));
+				if (result != Result.Success)
+					throw new ResultException (result);
 			}
 		}
 	}
@@ -3935,9 +5312,35 @@ namespace Vulkan
 		}
 	}
 
+	public partial class DescriptorUpdateTemplate : INonDispatchableHandleMarshalling
+	{
+		internal DescriptorUpdateTemplate() {}
+
+		internal UInt64 m;
+
+		UInt64 INonDispatchableHandleMarshalling.Handle {
+			get {
+				return m;
+			}
+		}
+	}
+
 	public partial class DescriptorUpdateTemplateKhr : INonDispatchableHandleMarshalling
 	{
 		internal DescriptorUpdateTemplateKhr() {}
+
+		internal UInt64 m;
+
+		UInt64 INonDispatchableHandleMarshalling.Handle {
+			get {
+				return m;
+			}
+		}
+	}
+
+	public partial class SamplerYcbcrConversion : INonDispatchableHandleMarshalling
+	{
+		internal SamplerYcbcrConversion() {}
 
 		internal UInt64 m;
 
@@ -3964,6 +5367,32 @@ namespace Vulkan
 	public partial class ValidationCacheExt : INonDispatchableHandleMarshalling
 	{
 		internal ValidationCacheExt() {}
+
+		internal UInt64 m;
+
+		UInt64 INonDispatchableHandleMarshalling.Handle {
+			get {
+				return m;
+			}
+		}
+	}
+
+	public partial class AccelerationStructureNv : INonDispatchableHandleMarshalling
+	{
+		internal AccelerationStructureNv() {}
+
+		internal UInt64 m;
+
+		UInt64 INonDispatchableHandleMarshalling.Handle {
+			get {
+				return m;
+			}
+		}
+	}
+
+	public partial class PerformanceConfigurationIntel : INonDispatchableHandleMarshalling
+	{
+		internal PerformanceConfigurationIntel() {}
 
 		internal UInt64 m;
 
@@ -4029,6 +5458,19 @@ namespace Vulkan
 	public partial class DebugReportCallbackExt : INonDispatchableHandleMarshalling
 	{
 		internal DebugReportCallbackExt() {}
+
+		internal UInt64 m;
+
+		UInt64 INonDispatchableHandleMarshalling.Handle {
+			get {
+				return m;
+			}
+		}
+	}
+
+	public partial class DebugUtilsMessengerExt : INonDispatchableHandleMarshalling
+	{
+		internal DebugUtilsMessengerExt() {}
 
 		internal UInt64 m;
 

--- a/src/Vulkan/Helpers.cs
+++ b/src/Vulkan/Helpers.cs
@@ -48,6 +48,31 @@ namespace Vulkan
 		}
 	}
 
+	public struct DeviceAddress
+	{
+		UInt64 value;
+
+		public static implicit operator DeviceAddress (UInt64 iValue)
+		{
+			return new DeviceAddress { value = iValue };
+		}
+
+		public static implicit operator DeviceAddress (uint iValue)
+		{
+			return new DeviceAddress { value = iValue };
+		}
+
+		public static implicit operator DeviceAddress (int iValue)
+		{
+			return new DeviceAddress { value = (ulong)iValue };
+		}
+
+		public static implicit operator UInt64 (DeviceAddress size)
+		{
+			return size.value;
+		}
+	}
+
 	public class ResultException : Exception
 	{
 		internal Result result;

--- a/src/Vulkan/Interop/ImportedCommands.cs
+++ b/src/Vulkan/Interop/ImportedCommands.cs
@@ -57,6 +57,9 @@ namespace Vulkan.Interop
 		internal static unsafe extern void vkDestroyDevice (IntPtr device, AllocationCallbacks* pAllocator);
 
 		[DllImport (VulkanLibrary, CallingConvention = CallingConvention.Winapi)]
+		internal static unsafe extern Result vkEnumerateInstanceVersion (UInt32* pApiVersion);
+
+		[DllImport (VulkanLibrary, CallingConvention = CallingConvention.Winapi)]
 		internal static unsafe extern Result vkEnumerateInstanceLayerProperties (UInt32* pPropertyCount, LayerProperties* pProperties);
 
 		[DllImport (VulkanLibrary, CallingConvention = CallingConvention.Winapi)]
@@ -166,6 +169,9 @@ namespace Vulkan.Interop
 
 		[DllImport (VulkanLibrary, CallingConvention = CallingConvention.Winapi)]
 		internal static unsafe extern Result vkGetQueryPoolResults (IntPtr device, UInt64 queryPool, UInt32 firstQuery, UInt32 queryCount, UIntPtr dataSize, IntPtr pData, DeviceSize stride, QueryResultFlags flags);
+
+		[DllImport (VulkanLibrary, CallingConvention = CallingConvention.Winapi)]
+		internal static unsafe extern void vkResetQueryPoolEXT (IntPtr device, UInt64 queryPool, UInt32 firstQuery, UInt32 queryCount);
 
 		[DllImport (VulkanLibrary, CallingConvention = CallingConvention.Winapi)]
 		internal static unsafe extern Result vkCreateBuffer (IntPtr device, BufferCreateInfo* pCreateInfo, AllocationCallbacks* pAllocator, UInt64* pBuffer);
@@ -405,6 +411,12 @@ namespace Vulkan.Interop
 		internal static unsafe extern void vkCmdEndQuery (IntPtr commandBuffer, UInt64 queryPool, UInt32 query);
 
 		[DllImport (VulkanLibrary, CallingConvention = CallingConvention.Winapi)]
+		internal static unsafe extern void vkCmdBeginConditionalRenderingEXT (IntPtr commandBuffer, ConditionalRenderingBeginInfoExt* pConditionalRenderingBegin);
+
+		[DllImport (VulkanLibrary, CallingConvention = CallingConvention.Winapi)]
+		internal static unsafe extern void vkCmdEndConditionalRenderingEXT (IntPtr commandBuffer);
+
+		[DllImport (VulkanLibrary, CallingConvention = CallingConvention.Winapi)]
 		internal static unsafe extern void vkCmdResetQueryPool (IntPtr commandBuffer, UInt64 queryPool, UInt32 firstQuery, UInt32 queryCount);
 
 		[DllImport (VulkanLibrary, CallingConvention = CallingConvention.Winapi)]
@@ -485,6 +497,12 @@ namespace Vulkan.Interop
 		[DllImport (VulkanLibrary, CallingConvention = CallingConvention.Winapi)]
 		internal static unsafe extern Result vkCreateViSurfaceNN (IntPtr instance, ViSurfaceCreateInfoNn* pCreateInfo, AllocationCallbacks* pAllocator, UInt64* pSurface);
 
+		[DllImport (VulkanLibrary, CallingConvention = CallingConvention.Winapi)]
+		internal static unsafe extern Result vkCreateImagePipeSurfaceFUCHSIA (IntPtr instance, ImagePipeSurfaceCreateInfoFUCHSIA* pCreateInfo, AllocationCallbacks* pAllocator, UInt64* pSurface);
+
+		[DllImport (VulkanLibrary, CallingConvention = CallingConvention.Winapi)]
+		internal static unsafe extern Result vkCreateStreamDescriptorSurfaceGGP (IntPtr instance, StreamDescriptorSurfaceCreateInfoGGP* pCreateInfo, AllocationCallbacks* pAllocator, UInt64* pSurface);
+
 		internal unsafe delegate Result vkCreateDebugReportCallbackEXT (IntPtr instance, DebugReportCallbackCreateInfoExt* pCreateInfo, AllocationCallbacks* pAllocator, UInt64* pCallback);
 
 		internal unsafe delegate void vkDestroyDebugReportCallbackEXT (IntPtr instance, UInt64 callback, AllocationCallbacks* pAllocator);
@@ -508,12 +526,6 @@ namespace Vulkan.Interop
 
 		[DllImport (VulkanLibrary, CallingConvention = CallingConvention.Winapi)]
 		internal static unsafe extern Result vkGetPhysicalDeviceExternalImageFormatPropertiesNV (IntPtr physicalDevice, Format format, ImageType type, ImageTiling tiling, ImageUsageFlags usage, ImageCreateFlags flags, ExternalMemoryHandleTypeFlagsNv externalHandleType, ExternalImageFormatPropertiesNv* pExternalImageFormatProperties);
-
-		[DllImport (VulkanLibrary, CallingConvention = CallingConvention.Winapi)]
-		internal static unsafe extern void vkCmdDrawIndirectCountAMD (IntPtr commandBuffer, UInt64 buffer, DeviceSize offset, UInt64 countBuffer, DeviceSize countBufferOffset, UInt32 maxDrawCount, UInt32 stride);
-
-		[DllImport (VulkanLibrary, CallingConvention = CallingConvention.Winapi)]
-		internal static unsafe extern void vkCmdDrawIndexedIndirectCountAMD (IntPtr commandBuffer, UInt64 buffer, DeviceSize offset, UInt64 countBuffer, DeviceSize countBufferOffset, UInt32 maxDrawCount, UInt32 stride);
 
 		[DllImport (VulkanLibrary, CallingConvention = CallingConvention.Winapi)]
 		internal static unsafe extern void vkCmdProcessCommandsNVX (IntPtr commandBuffer, CmdProcessCommandsInfoNvx* pProcessCommandsInfo);
@@ -543,49 +555,79 @@ namespace Vulkan.Interop
 		internal static unsafe extern void vkGetPhysicalDeviceGeneratedCommandsPropertiesNVX (IntPtr physicalDevice, DeviceGeneratedCommandsFeaturesNvx* pFeatures, DeviceGeneratedCommandsLimitsNvx* pLimits);
 
 		[DllImport (VulkanLibrary, CallingConvention = CallingConvention.Winapi)]
-		internal static unsafe extern void vkGetPhysicalDeviceFeatures2KHR (IntPtr physicalDevice, PhysicalDeviceFeatures2Khr* pFeatures);
+		internal static unsafe extern void vkGetPhysicalDeviceFeatures2 (IntPtr physicalDevice, PhysicalDeviceFeatures2* pFeatures);
 
 		[DllImport (VulkanLibrary, CallingConvention = CallingConvention.Winapi)]
-		internal static unsafe extern void vkGetPhysicalDeviceProperties2KHR (IntPtr physicalDevice, PhysicalDeviceProperties2Khr* pProperties);
+		internal static unsafe extern void vkGetPhysicalDeviceFeatures2KHR (IntPtr physicalDevice, PhysicalDeviceFeatures2* pFeatures);
 
 		[DllImport (VulkanLibrary, CallingConvention = CallingConvention.Winapi)]
-		internal static unsafe extern void vkGetPhysicalDeviceFormatProperties2KHR (IntPtr physicalDevice, Format format, FormatProperties2Khr* pFormatProperties);
+		internal static unsafe extern void vkGetPhysicalDeviceProperties2 (IntPtr physicalDevice, PhysicalDeviceProperties2* pProperties);
 
 		[DllImport (VulkanLibrary, CallingConvention = CallingConvention.Winapi)]
-		internal static unsafe extern Result vkGetPhysicalDeviceImageFormatProperties2KHR (IntPtr physicalDevice, PhysicalDeviceImageFormatInfo2Khr* pImageFormatInfo, ImageFormatProperties2Khr* pImageFormatProperties);
+		internal static unsafe extern void vkGetPhysicalDeviceProperties2KHR (IntPtr physicalDevice, PhysicalDeviceProperties2* pProperties);
 
 		[DllImport (VulkanLibrary, CallingConvention = CallingConvention.Winapi)]
-		internal static unsafe extern void vkGetPhysicalDeviceQueueFamilyProperties2KHR (IntPtr physicalDevice, UInt32* pQueueFamilyPropertyCount, QueueFamilyProperties2Khr* pQueueFamilyProperties);
+		internal static unsafe extern void vkGetPhysicalDeviceFormatProperties2 (IntPtr physicalDevice, Format format, FormatProperties2* pFormatProperties);
 
 		[DllImport (VulkanLibrary, CallingConvention = CallingConvention.Winapi)]
-		internal static unsafe extern void vkGetPhysicalDeviceMemoryProperties2KHR (IntPtr physicalDevice, PhysicalDeviceMemoryProperties2Khr* pMemoryProperties);
+		internal static unsafe extern void vkGetPhysicalDeviceFormatProperties2KHR (IntPtr physicalDevice, Format format, FormatProperties2* pFormatProperties);
 
 		[DllImport (VulkanLibrary, CallingConvention = CallingConvention.Winapi)]
-		internal static unsafe extern void vkGetPhysicalDeviceSparseImageFormatProperties2KHR (IntPtr physicalDevice, PhysicalDeviceSparseImageFormatInfo2Khr* pFormatInfo, UInt32* pPropertyCount, SparseImageFormatProperties2Khr* pProperties);
+		internal static unsafe extern Result vkGetPhysicalDeviceImageFormatProperties2 (IntPtr physicalDevice, PhysicalDeviceImageFormatInfo2* pImageFormatInfo, ImageFormatProperties2* pImageFormatProperties);
+
+		[DllImport (VulkanLibrary, CallingConvention = CallingConvention.Winapi)]
+		internal static unsafe extern Result vkGetPhysicalDeviceImageFormatProperties2KHR (IntPtr physicalDevice, PhysicalDeviceImageFormatInfo2* pImageFormatInfo, ImageFormatProperties2* pImageFormatProperties);
+
+		[DllImport (VulkanLibrary, CallingConvention = CallingConvention.Winapi)]
+		internal static unsafe extern void vkGetPhysicalDeviceQueueFamilyProperties2 (IntPtr physicalDevice, UInt32* pQueueFamilyPropertyCount, QueueFamilyProperties2* pQueueFamilyProperties);
+
+		[DllImport (VulkanLibrary, CallingConvention = CallingConvention.Winapi)]
+		internal static unsafe extern void vkGetPhysicalDeviceQueueFamilyProperties2KHR (IntPtr physicalDevice, UInt32* pQueueFamilyPropertyCount, QueueFamilyProperties2* pQueueFamilyProperties);
+
+		[DllImport (VulkanLibrary, CallingConvention = CallingConvention.Winapi)]
+		internal static unsafe extern void vkGetPhysicalDeviceMemoryProperties2 (IntPtr physicalDevice, PhysicalDeviceMemoryProperties2* pMemoryProperties);
+
+		[DllImport (VulkanLibrary, CallingConvention = CallingConvention.Winapi)]
+		internal static unsafe extern void vkGetPhysicalDeviceMemoryProperties2KHR (IntPtr physicalDevice, PhysicalDeviceMemoryProperties2* pMemoryProperties);
+
+		[DllImport (VulkanLibrary, CallingConvention = CallingConvention.Winapi)]
+		internal static unsafe extern void vkGetPhysicalDeviceSparseImageFormatProperties2 (IntPtr physicalDevice, PhysicalDeviceSparseImageFormatInfo2* pFormatInfo, UInt32* pPropertyCount, SparseImageFormatProperties2* pProperties);
+
+		[DllImport (VulkanLibrary, CallingConvention = CallingConvention.Winapi)]
+		internal static unsafe extern void vkGetPhysicalDeviceSparseImageFormatProperties2KHR (IntPtr physicalDevice, PhysicalDeviceSparseImageFormatInfo2* pFormatInfo, UInt32* pPropertyCount, SparseImageFormatProperties2* pProperties);
 
 		[DllImport (VulkanLibrary, CallingConvention = CallingConvention.Winapi)]
 		internal static unsafe extern void vkCmdPushDescriptorSetKHR (IntPtr commandBuffer, PipelineBindPoint pipelineBindPoint, UInt64 layout, UInt32 set, UInt32 descriptorWriteCount, WriteDescriptorSet* pDescriptorWrites);
 
 		[DllImport (VulkanLibrary, CallingConvention = CallingConvention.Winapi)]
+		internal static unsafe extern void vkTrimCommandPool (IntPtr device, UInt64 commandPool, UInt32 flags);
+
+		[DllImport (VulkanLibrary, CallingConvention = CallingConvention.Winapi)]
 		internal static unsafe extern void vkTrimCommandPoolKHR (IntPtr device, UInt64 commandPool, UInt32 flags);
 
 		[DllImport (VulkanLibrary, CallingConvention = CallingConvention.Winapi)]
-		internal static unsafe extern void vkGetPhysicalDeviceExternalBufferPropertiesKHR (IntPtr physicalDevice, PhysicalDeviceExternalBufferInfoKhr* pExternalBufferInfo, ExternalBufferPropertiesKhr* pExternalBufferProperties);
+		internal static unsafe extern void vkGetPhysicalDeviceExternalBufferProperties (IntPtr physicalDevice, PhysicalDeviceExternalBufferInfo* pExternalBufferInfo, ExternalBufferProperties* pExternalBufferProperties);
+
+		[DllImport (VulkanLibrary, CallingConvention = CallingConvention.Winapi)]
+		internal static unsafe extern void vkGetPhysicalDeviceExternalBufferPropertiesKHR (IntPtr physicalDevice, PhysicalDeviceExternalBufferInfo* pExternalBufferInfo, ExternalBufferProperties* pExternalBufferProperties);
 
 		[DllImport (VulkanLibrary, CallingConvention = CallingConvention.Winapi)]
 		internal static unsafe extern Result vkGetMemoryWin32HandleKHR (IntPtr device, MemoryGetWin32HandleInfoKhr* pGetWin32HandleInfo, IntPtr* pHandle);
 
 		[DllImport (VulkanLibrary, CallingConvention = CallingConvention.Winapi)]
-		internal static unsafe extern Result vkGetMemoryWin32HandlePropertiesKHR (IntPtr device, ExternalMemoryHandleTypeFlagsKhr handleType, IntPtr handle, MemoryWin32HandlePropertiesKhr* pMemoryWin32HandleProperties);
+		internal static unsafe extern Result vkGetMemoryWin32HandlePropertiesKHR (IntPtr device, ExternalMemoryHandleTypeFlags handleType, IntPtr handle, MemoryWin32HandlePropertiesKhr* pMemoryWin32HandleProperties);
 
 		[DllImport (VulkanLibrary, CallingConvention = CallingConvention.Winapi)]
 		internal static unsafe extern Result vkGetMemoryFdKHR (IntPtr device, MemoryGetFdInfoKhr* pGetFdInfo, int* pFd);
 
 		[DllImport (VulkanLibrary, CallingConvention = CallingConvention.Winapi)]
-		internal static unsafe extern Result vkGetMemoryFdPropertiesKHR (IntPtr device, ExternalMemoryHandleTypeFlagsKhr handleType, int fd, MemoryFdPropertiesKhr* pMemoryFdProperties);
+		internal static unsafe extern Result vkGetMemoryFdPropertiesKHR (IntPtr device, ExternalMemoryHandleTypeFlags handleType, int fd, MemoryFdPropertiesKhr* pMemoryFdProperties);
 
 		[DllImport (VulkanLibrary, CallingConvention = CallingConvention.Winapi)]
-		internal static unsafe extern void vkGetPhysicalDeviceExternalSemaphorePropertiesKHR (IntPtr physicalDevice, PhysicalDeviceExternalSemaphoreInfoKhr* pExternalSemaphoreInfo, ExternalSemaphorePropertiesKhr* pExternalSemaphoreProperties);
+		internal static unsafe extern void vkGetPhysicalDeviceExternalSemaphoreProperties (IntPtr physicalDevice, PhysicalDeviceExternalSemaphoreInfo* pExternalSemaphoreInfo, ExternalSemaphoreProperties* pExternalSemaphoreProperties);
+
+		[DllImport (VulkanLibrary, CallingConvention = CallingConvention.Winapi)]
+		internal static unsafe extern void vkGetPhysicalDeviceExternalSemaphorePropertiesKHR (IntPtr physicalDevice, PhysicalDeviceExternalSemaphoreInfo* pExternalSemaphoreInfo, ExternalSemaphoreProperties* pExternalSemaphoreProperties);
 
 		[DllImport (VulkanLibrary, CallingConvention = CallingConvention.Winapi)]
 		internal static unsafe extern Result vkGetSemaphoreWin32HandleKHR (IntPtr device, SemaphoreGetWin32HandleInfoKhr* pGetWin32HandleInfo, IntPtr* pHandle);
@@ -597,7 +639,10 @@ namespace Vulkan.Interop
 		internal static unsafe extern Result vkImportSemaphoreFdKHR (IntPtr device, ImportSemaphoreFdInfoKhr* pImportSemaphoreFdInfo);
 
 		[DllImport (VulkanLibrary, CallingConvention = CallingConvention.Winapi)]
-		internal static unsafe extern void vkGetPhysicalDeviceExternalFencePropertiesKHR (IntPtr physicalDevice, PhysicalDeviceExternalFenceInfoKhr* pExternalFenceInfo, ExternalFencePropertiesKhr* pExternalFenceProperties);
+		internal static unsafe extern void vkGetPhysicalDeviceExternalFenceProperties (IntPtr physicalDevice, PhysicalDeviceExternalFenceInfo* pExternalFenceInfo, ExternalFenceProperties* pExternalFenceProperties);
+
+		[DllImport (VulkanLibrary, CallingConvention = CallingConvention.Winapi)]
+		internal static unsafe extern void vkGetPhysicalDeviceExternalFencePropertiesKHR (IntPtr physicalDevice, PhysicalDeviceExternalFenceInfo* pExternalFenceInfo, ExternalFenceProperties* pExternalFenceProperties);
 
 		[DllImport (VulkanLibrary, CallingConvention = CallingConvention.Winapi)]
 		internal static unsafe extern Result vkGetFenceWin32HandleKHR (IntPtr device, FenceGetWin32HandleInfoKhr* pGetWin32HandleInfo, IntPtr* pHandle);
@@ -633,37 +678,61 @@ namespace Vulkan.Interop
 		internal static unsafe extern Result vkGetPhysicalDeviceSurfaceCapabilities2EXT (IntPtr physicalDevice, UInt64 surface, SurfaceCapabilities2Ext* pSurfaceCapabilities);
 
 		[DllImport (VulkanLibrary, CallingConvention = CallingConvention.Winapi)]
-		internal static unsafe extern void vkGetDeviceGroupPeerMemoryFeaturesKHX (IntPtr device, UInt32 heapIndex, UInt32 localDeviceIndex, UInt32 remoteDeviceIndex, PeerMemoryFeatureFlagsKhx* pPeerMemoryFeatures);
+		internal static unsafe extern void vkGetDeviceGroupPeerMemoryFeatures (IntPtr device, UInt32 heapIndex, UInt32 localDeviceIndex, UInt32 remoteDeviceIndex, PeerMemoryFeatureFlags* pPeerMemoryFeatures);
 
 		[DllImport (VulkanLibrary, CallingConvention = CallingConvention.Winapi)]
-		internal static unsafe extern Result vkBindBufferMemory2KHR (IntPtr device, UInt32 bindInfoCount, BindBufferMemoryInfoKhr* pBindInfos);
+		internal static unsafe extern void vkGetDeviceGroupPeerMemoryFeaturesKHR (IntPtr device, UInt32 heapIndex, UInt32 localDeviceIndex, UInt32 remoteDeviceIndex, PeerMemoryFeatureFlags* pPeerMemoryFeatures);
 
 		[DllImport (VulkanLibrary, CallingConvention = CallingConvention.Winapi)]
-		internal static unsafe extern Result vkBindImageMemory2KHR (IntPtr device, UInt32 bindInfoCount, BindImageMemoryInfoKhr* pBindInfos);
+		internal static unsafe extern Result vkBindBufferMemory2 (IntPtr device, UInt32 bindInfoCount, BindBufferMemoryInfo* pBindInfos);
 
 		[DllImport (VulkanLibrary, CallingConvention = CallingConvention.Winapi)]
-		internal static unsafe extern void vkCmdSetDeviceMaskKHX (IntPtr commandBuffer, UInt32 deviceMask);
+		internal static unsafe extern Result vkBindBufferMemory2KHR (IntPtr device, UInt32 bindInfoCount, BindBufferMemoryInfo* pBindInfos);
 
 		[DllImport (VulkanLibrary, CallingConvention = CallingConvention.Winapi)]
-		internal static unsafe extern Result vkGetDeviceGroupPresentCapabilitiesKHX (IntPtr device, DeviceGroupPresentCapabilitiesKhx* pDeviceGroupPresentCapabilities);
+		internal static unsafe extern Result vkBindImageMemory2 (IntPtr device, UInt32 bindInfoCount, BindImageMemoryInfo* pBindInfos);
 
 		[DllImport (VulkanLibrary, CallingConvention = CallingConvention.Winapi)]
-		internal static unsafe extern Result vkGetDeviceGroupSurfacePresentModesKHX (IntPtr device, UInt64 surface, DeviceGroupPresentModeFlagsKhx* pModes);
+		internal static unsafe extern Result vkBindImageMemory2KHR (IntPtr device, UInt32 bindInfoCount, BindImageMemoryInfo* pBindInfos);
 
 		[DllImport (VulkanLibrary, CallingConvention = CallingConvention.Winapi)]
-		internal static unsafe extern Result vkAcquireNextImage2KHX (IntPtr device, AcquireNextImageInfoKhx* pAcquireInfo, UInt32* pImageIndex);
+		internal static unsafe extern void vkCmdSetDeviceMask (IntPtr commandBuffer, UInt32 deviceMask);
 
 		[DllImport (VulkanLibrary, CallingConvention = CallingConvention.Winapi)]
-		internal static unsafe extern void vkCmdDispatchBaseKHX (IntPtr commandBuffer, UInt32 baseGroupX, UInt32 baseGroupY, UInt32 baseGroupZ, UInt32 groupCountX, UInt32 groupCountY, UInt32 groupCountZ);
+		internal static unsafe extern void vkCmdSetDeviceMaskKHR (IntPtr commandBuffer, UInt32 deviceMask);
 
 		[DllImport (VulkanLibrary, CallingConvention = CallingConvention.Winapi)]
-		internal static unsafe extern Result vkGetPhysicalDevicePresentRectanglesKHX (IntPtr physicalDevice, UInt64 surface, UInt32* pRectCount, Rect2D* pRects);
+		internal static unsafe extern Result vkGetDeviceGroupPresentCapabilitiesKHR (IntPtr device, DeviceGroupPresentCapabilitiesKhr* pDeviceGroupPresentCapabilities);
 
 		[DllImport (VulkanLibrary, CallingConvention = CallingConvention.Winapi)]
-		internal static unsafe extern Result vkCreateDescriptorUpdateTemplateKHR (IntPtr device, DescriptorUpdateTemplateCreateInfoKhr* pCreateInfo, AllocationCallbacks* pAllocator, UInt64* pDescriptorUpdateTemplate);
+		internal static unsafe extern Result vkGetDeviceGroupSurfacePresentModesKHR (IntPtr device, UInt64 surface, DeviceGroupPresentModeFlagsKhr* pModes);
+
+		[DllImport (VulkanLibrary, CallingConvention = CallingConvention.Winapi)]
+		internal static unsafe extern Result vkAcquireNextImage2KHR (IntPtr device, AcquireNextImageInfoKhr* pAcquireInfo, UInt32* pImageIndex);
+
+		[DllImport (VulkanLibrary, CallingConvention = CallingConvention.Winapi)]
+		internal static unsafe extern void vkCmdDispatchBase (IntPtr commandBuffer, UInt32 baseGroupX, UInt32 baseGroupY, UInt32 baseGroupZ, UInt32 groupCountX, UInt32 groupCountY, UInt32 groupCountZ);
+
+		[DllImport (VulkanLibrary, CallingConvention = CallingConvention.Winapi)]
+		internal static unsafe extern void vkCmdDispatchBaseKHR (IntPtr commandBuffer, UInt32 baseGroupX, UInt32 baseGroupY, UInt32 baseGroupZ, UInt32 groupCountX, UInt32 groupCountY, UInt32 groupCountZ);
+
+		[DllImport (VulkanLibrary, CallingConvention = CallingConvention.Winapi)]
+		internal static unsafe extern Result vkGetPhysicalDevicePresentRectanglesKHR (IntPtr physicalDevice, UInt64 surface, UInt32* pRectCount, Rect2D* pRects);
+
+		[DllImport (VulkanLibrary, CallingConvention = CallingConvention.Winapi)]
+		internal static unsafe extern Result vkCreateDescriptorUpdateTemplate (IntPtr device, DescriptorUpdateTemplateCreateInfo* pCreateInfo, AllocationCallbacks* pAllocator, UInt64* pDescriptorUpdateTemplate);
+
+		[DllImport (VulkanLibrary, CallingConvention = CallingConvention.Winapi)]
+		internal static unsafe extern Result vkCreateDescriptorUpdateTemplateKHR (IntPtr device, DescriptorUpdateTemplateCreateInfo* pCreateInfo, AllocationCallbacks* pAllocator, UInt64* pDescriptorUpdateTemplate);
+
+		[DllImport (VulkanLibrary, CallingConvention = CallingConvention.Winapi)]
+		internal static unsafe extern void vkDestroyDescriptorUpdateTemplate (IntPtr device, UInt64 descriptorUpdateTemplate, AllocationCallbacks* pAllocator);
 
 		[DllImport (VulkanLibrary, CallingConvention = CallingConvention.Winapi)]
 		internal static unsafe extern void vkDestroyDescriptorUpdateTemplateKHR (IntPtr device, UInt64 descriptorUpdateTemplate, AllocationCallbacks* pAllocator);
+
+		[DllImport (VulkanLibrary, CallingConvention = CallingConvention.Winapi)]
+		internal static unsafe extern void vkUpdateDescriptorSetWithTemplate (IntPtr device, UInt64 descriptorSet, UInt64 descriptorUpdateTemplate, IntPtr pData);
 
 		[DllImport (VulkanLibrary, CallingConvention = CallingConvention.Winapi)]
 		internal static unsafe extern void vkUpdateDescriptorSetWithTemplateKHR (IntPtr device, UInt64 descriptorSet, UInt64 descriptorUpdateTemplate, IntPtr pData);
@@ -682,9 +751,6 @@ namespace Vulkan.Interop
 
 		[DllImport (VulkanLibrary, CallingConvention = CallingConvention.Winapi)]
 		internal static unsafe extern Result vkGetPastPresentationTimingGOOGLE (IntPtr device, UInt64 swapchain, UInt32* pPresentationTimingCount, PastPresentationTimingGoogle* pPresentationTimings);
-
-		[DllImport (VulkanLibrary, CallingConvention = CallingConvention.Winapi)]
-		internal static unsafe extern Result vkCreateIOSSurfaceMVK (IntPtr instance, IOSSurfaceCreateInfoMvk* pCreateInfo, AllocationCallbacks* pAllocator, UInt64* pSurface);
 
 		[DllImport (VulkanLibrary, CallingConvention = CallingConvention.Winapi)]
 		internal static unsafe extern Result vkCreateMacOSSurfaceMVK (IntPtr instance, MacOSSurfaceCreateInfoMvk* pCreateInfo, AllocationCallbacks* pAllocator, UInt64* pSurface);
@@ -708,19 +774,49 @@ namespace Vulkan.Interop
 		internal static unsafe extern Result vkGetPhysicalDeviceSurfaceFormats2KHR (IntPtr physicalDevice, PhysicalDeviceSurfaceInfo2Khr* pSurfaceInfo, UInt32* pSurfaceFormatCount, SurfaceFormat2Khr* pSurfaceFormats);
 
 		[DllImport (VulkanLibrary, CallingConvention = CallingConvention.Winapi)]
-		internal static unsafe extern void vkGetBufferMemoryRequirements2KHR (IntPtr device, BufferMemoryRequirementsInfo2Khr* pInfo, MemoryRequirements2Khr* pMemoryRequirements);
+		internal static unsafe extern Result vkGetPhysicalDeviceDisplayProperties2KHR (IntPtr physicalDevice, UInt32* pPropertyCount, DisplayProperties2Khr* pProperties);
 
 		[DllImport (VulkanLibrary, CallingConvention = CallingConvention.Winapi)]
-		internal static unsafe extern void vkGetImageMemoryRequirements2KHR (IntPtr device, ImageMemoryRequirementsInfo2Khr* pInfo, MemoryRequirements2Khr* pMemoryRequirements);
+		internal static unsafe extern Result vkGetPhysicalDeviceDisplayPlaneProperties2KHR (IntPtr physicalDevice, UInt32* pPropertyCount, DisplayPlaneProperties2Khr* pProperties);
 
 		[DllImport (VulkanLibrary, CallingConvention = CallingConvention.Winapi)]
-		internal static unsafe extern void vkGetImageSparseMemoryRequirements2KHR (IntPtr device, ImageSparseMemoryRequirementsInfo2Khr* pInfo, UInt32* pSparseMemoryRequirementCount, SparseImageMemoryRequirements2Khr* pSparseMemoryRequirements);
+		internal static unsafe extern Result vkGetDisplayModeProperties2KHR (IntPtr physicalDevice, UInt64 display, UInt32* pPropertyCount, DisplayModeProperties2Khr* pProperties);
 
 		[DllImport (VulkanLibrary, CallingConvention = CallingConvention.Winapi)]
-		internal static unsafe extern Result vkCreateSamplerYcbcrConversionKHR (IntPtr device, SamplerYcbcrConversionCreateInfoKhr* pCreateInfo, AllocationCallbacks* pAllocator, UInt64* pYcbcrConversion);
+		internal static unsafe extern Result vkGetDisplayPlaneCapabilities2KHR (IntPtr physicalDevice, DisplayPlaneInfo2Khr* pDisplayPlaneInfo, DisplayPlaneCapabilities2Khr* pCapabilities);
+
+		[DllImport (VulkanLibrary, CallingConvention = CallingConvention.Winapi)]
+		internal static unsafe extern void vkGetBufferMemoryRequirements2 (IntPtr device, BufferMemoryRequirementsInfo2* pInfo, MemoryRequirements2* pMemoryRequirements);
+
+		[DllImport (VulkanLibrary, CallingConvention = CallingConvention.Winapi)]
+		internal static unsafe extern void vkGetBufferMemoryRequirements2KHR (IntPtr device, BufferMemoryRequirementsInfo2* pInfo, MemoryRequirements2* pMemoryRequirements);
+
+		[DllImport (VulkanLibrary, CallingConvention = CallingConvention.Winapi)]
+		internal static unsafe extern void vkGetImageMemoryRequirements2 (IntPtr device, ImageMemoryRequirementsInfo2* pInfo, MemoryRequirements2* pMemoryRequirements);
+
+		[DllImport (VulkanLibrary, CallingConvention = CallingConvention.Winapi)]
+		internal static unsafe extern void vkGetImageMemoryRequirements2KHR (IntPtr device, ImageMemoryRequirementsInfo2* pInfo, MemoryRequirements2* pMemoryRequirements);
+
+		[DllImport (VulkanLibrary, CallingConvention = CallingConvention.Winapi)]
+		internal static unsafe extern void vkGetImageSparseMemoryRequirements2 (IntPtr device, ImageSparseMemoryRequirementsInfo2* pInfo, UInt32* pSparseMemoryRequirementCount, SparseImageMemoryRequirements2* pSparseMemoryRequirements);
+
+		[DllImport (VulkanLibrary, CallingConvention = CallingConvention.Winapi)]
+		internal static unsafe extern void vkGetImageSparseMemoryRequirements2KHR (IntPtr device, ImageSparseMemoryRequirementsInfo2* pInfo, UInt32* pSparseMemoryRequirementCount, SparseImageMemoryRequirements2* pSparseMemoryRequirements);
+
+		[DllImport (VulkanLibrary, CallingConvention = CallingConvention.Winapi)]
+		internal static unsafe extern Result vkCreateSamplerYcbcrConversion (IntPtr device, SamplerYcbcrConversionCreateInfo* pCreateInfo, AllocationCallbacks* pAllocator, UInt64* pYcbcrConversion);
+
+		[DllImport (VulkanLibrary, CallingConvention = CallingConvention.Winapi)]
+		internal static unsafe extern Result vkCreateSamplerYcbcrConversionKHR (IntPtr device, SamplerYcbcrConversionCreateInfo* pCreateInfo, AllocationCallbacks* pAllocator, UInt64* pYcbcrConversion);
+
+		[DllImport (VulkanLibrary, CallingConvention = CallingConvention.Winapi)]
+		internal static unsafe extern void vkDestroySamplerYcbcrConversion (IntPtr device, UInt64 ycbcrConversion, AllocationCallbacks* pAllocator);
 
 		[DllImport (VulkanLibrary, CallingConvention = CallingConvention.Winapi)]
 		internal static unsafe extern void vkDestroySamplerYcbcrConversionKHR (IntPtr device, UInt64 ycbcrConversion, AllocationCallbacks* pAllocator);
+
+		[DllImport (VulkanLibrary, CallingConvention = CallingConvention.Winapi)]
+		internal static unsafe extern void vkGetDeviceQueue2 (IntPtr device, DeviceQueueInfo2* pQueueInfo, IntPtr* pQueue);
 
 		[DllImport (VulkanLibrary, CallingConvention = CallingConvention.Winapi)]
 		internal static unsafe extern Result vkCreateValidationCacheEXT (IntPtr device, ValidationCacheCreateInfoExt* pCreateInfo, AllocationCallbacks* pAllocator, UInt64* pValidationCache);
@@ -735,6 +831,12 @@ namespace Vulkan.Interop
 		internal static unsafe extern Result vkMergeValidationCachesEXT (IntPtr device, UInt64 dstCache, UInt32 srcCacheCount, UInt64* pSrcCaches);
 
 		[DllImport (VulkanLibrary, CallingConvention = CallingConvention.Winapi)]
+		internal static unsafe extern void vkGetDescriptorSetLayoutSupport (IntPtr device, DescriptorSetLayoutCreateInfo* pCreateInfo, DescriptorSetLayoutSupport* pSupport);
+
+		[DllImport (VulkanLibrary, CallingConvention = CallingConvention.Winapi)]
+		internal static unsafe extern void vkGetDescriptorSetLayoutSupportKHR (IntPtr device, DescriptorSetLayoutCreateInfo* pCreateInfo, DescriptorSetLayoutSupport* pSupport);
+
+		[DllImport (VulkanLibrary, CallingConvention = CallingConvention.Winapi)]
 		internal static unsafe extern Result vkGetSwapchainGrallocUsageANDROID (IntPtr device, Format format, ImageUsageFlags imageUsage, int* grallocUsage);
 
 		[DllImport (VulkanLibrary, CallingConvention = CallingConvention.Winapi)]
@@ -747,9 +849,210 @@ namespace Vulkan.Interop
 		internal static unsafe extern Result vkGetShaderInfoAMD (IntPtr device, UInt64 pipeline, ShaderStageFlags shaderStage, ShaderInfoTypeAmd infoType, UIntPtr* pInfoSize, IntPtr pInfo);
 
 		[DllImport (VulkanLibrary, CallingConvention = CallingConvention.Winapi)]
-		internal static unsafe extern Result vkGetMemoryHostPointerPropertiesEXT (IntPtr device, ExternalMemoryHandleTypeFlagsKhr handleType, IntPtr pHostPointer, MemoryHostPointerPropertiesExt* pMemoryHostPointerProperties);
+		internal static unsafe extern void vkSetLocalDimmingAMD (IntPtr device, UInt64 swapChain, Bool32 localDimmingEnable);
+
+		[DllImport (VulkanLibrary, CallingConvention = CallingConvention.Winapi)]
+		internal static unsafe extern Result vkGetPhysicalDeviceCalibrateableTimeDomainsEXT (IntPtr physicalDevice, UInt32* pTimeDomainCount, TimeDomainExt* pTimeDomains);
+
+		[DllImport (VulkanLibrary, CallingConvention = CallingConvention.Winapi)]
+		internal static unsafe extern Result vkGetCalibratedTimestampsEXT (IntPtr device, UInt32 timestampCount, CalibratedTimestampInfoExt* pTimestampInfos, UInt64* pTimestamps, UInt64* pMaxDeviation);
+
+		[DllImport (VulkanLibrary, CallingConvention = CallingConvention.Winapi)]
+		internal static unsafe extern Result vkSetDebugUtilsObjectNameEXT (IntPtr device, DebugUtilsObjectNameInfoExt* pNameInfo);
+
+		[DllImport (VulkanLibrary, CallingConvention = CallingConvention.Winapi)]
+		internal static unsafe extern Result vkSetDebugUtilsObjectTagEXT (IntPtr device, DebugUtilsObjectTagInfoExt* pTagInfo);
+
+		[DllImport (VulkanLibrary, CallingConvention = CallingConvention.Winapi)]
+		internal static unsafe extern void vkQueueBeginDebugUtilsLabelEXT (IntPtr queue, DebugUtilsLabelExt* pLabelInfo);
+
+		[DllImport (VulkanLibrary, CallingConvention = CallingConvention.Winapi)]
+		internal static unsafe extern void vkQueueEndDebugUtilsLabelEXT (IntPtr queue);
+
+		[DllImport (VulkanLibrary, CallingConvention = CallingConvention.Winapi)]
+		internal static unsafe extern void vkQueueInsertDebugUtilsLabelEXT (IntPtr queue, DebugUtilsLabelExt* pLabelInfo);
+
+		[DllImport (VulkanLibrary, CallingConvention = CallingConvention.Winapi)]
+		internal static unsafe extern void vkCmdBeginDebugUtilsLabelEXT (IntPtr commandBuffer, DebugUtilsLabelExt* pLabelInfo);
+
+		[DllImport (VulkanLibrary, CallingConvention = CallingConvention.Winapi)]
+		internal static unsafe extern void vkCmdEndDebugUtilsLabelEXT (IntPtr commandBuffer);
+
+		[DllImport (VulkanLibrary, CallingConvention = CallingConvention.Winapi)]
+		internal static unsafe extern void vkCmdInsertDebugUtilsLabelEXT (IntPtr commandBuffer, DebugUtilsLabelExt* pLabelInfo);
+
+		[DllImport (VulkanLibrary, CallingConvention = CallingConvention.Winapi)]
+		internal static unsafe extern Result vkCreateDebugUtilsMessengerEXT (IntPtr instance, DebugUtilsMessengerCreateInfoExt* pCreateInfo, AllocationCallbacks* pAllocator, UInt64* pMessenger);
+
+		[DllImport (VulkanLibrary, CallingConvention = CallingConvention.Winapi)]
+		internal static unsafe extern void vkDestroyDebugUtilsMessengerEXT (IntPtr instance, UInt64 messenger, AllocationCallbacks* pAllocator);
+
+		[DllImport (VulkanLibrary, CallingConvention = CallingConvention.Winapi)]
+		internal static unsafe extern void vkSubmitDebugUtilsMessageEXT (IntPtr instance, DebugUtilsMessageSeverityFlagsExt messageSeverity, DebugUtilsMessageTypeFlagsExt messageTypes, DebugUtilsMessengerCallbackDataExt* pCallbackData);
+
+		[DllImport (VulkanLibrary, CallingConvention = CallingConvention.Winapi)]
+		internal static unsafe extern Result vkGetMemoryHostPointerPropertiesEXT (IntPtr device, ExternalMemoryHandleTypeFlags handleType, IntPtr pHostPointer, MemoryHostPointerPropertiesExt* pMemoryHostPointerProperties);
 
 		[DllImport (VulkanLibrary, CallingConvention = CallingConvention.Winapi)]
 		internal static unsafe extern void vkCmdWriteBufferMarkerAMD (IntPtr commandBuffer, PipelineStageFlags pipelineStage, UInt64 dstBuffer, DeviceSize dstOffset, UInt32 marker);
+
+		[DllImport (VulkanLibrary, CallingConvention = CallingConvention.Winapi)]
+		internal static unsafe extern Result vkCreateRenderPass2KHR (IntPtr device, RenderPassCreateInfo2Khr* pCreateInfo, AllocationCallbacks* pAllocator, UInt64* pRenderPass);
+
+		[DllImport (VulkanLibrary, CallingConvention = CallingConvention.Winapi)]
+		internal static unsafe extern void vkCmdBeginRenderPass2KHR (IntPtr commandBuffer, RenderPassBeginInfo* pRenderPassBegin, SubpassBeginInfoKhr* pSubpassBeginInfo);
+
+		[DllImport (VulkanLibrary, CallingConvention = CallingConvention.Winapi)]
+		internal static unsafe extern void vkCmdNextSubpass2KHR (IntPtr commandBuffer, SubpassBeginInfoKhr* pSubpassBeginInfo, SubpassEndInfoKhr* pSubpassEndInfo);
+
+		[DllImport (VulkanLibrary, CallingConvention = CallingConvention.Winapi)]
+		internal static unsafe extern void vkCmdEndRenderPass2KHR (IntPtr commandBuffer, SubpassEndInfoKhr* pSubpassEndInfo);
+
+		[DllImport (VulkanLibrary, CallingConvention = CallingConvention.Winapi)]
+		internal static unsafe extern void vkCmdDrawIndirectCountKHR (IntPtr commandBuffer, UInt64 buffer, DeviceSize offset, UInt64 countBuffer, DeviceSize countBufferOffset, UInt32 maxDrawCount, UInt32 stride);
+
+		[DllImport (VulkanLibrary, CallingConvention = CallingConvention.Winapi)]
+		internal static unsafe extern void vkCmdDrawIndirectCountAMD (IntPtr commandBuffer, UInt64 buffer, DeviceSize offset, UInt64 countBuffer, DeviceSize countBufferOffset, UInt32 maxDrawCount, UInt32 stride);
+
+		[DllImport (VulkanLibrary, CallingConvention = CallingConvention.Winapi)]
+		internal static unsafe extern void vkCmdDrawIndexedIndirectCountKHR (IntPtr commandBuffer, UInt64 buffer, DeviceSize offset, UInt64 countBuffer, DeviceSize countBufferOffset, UInt32 maxDrawCount, UInt32 stride);
+
+		[DllImport (VulkanLibrary, CallingConvention = CallingConvention.Winapi)]
+		internal static unsafe extern void vkCmdDrawIndexedIndirectCountAMD (IntPtr commandBuffer, UInt64 buffer, DeviceSize offset, UInt64 countBuffer, DeviceSize countBufferOffset, UInt32 maxDrawCount, UInt32 stride);
+
+		[DllImport (VulkanLibrary, CallingConvention = CallingConvention.Winapi)]
+		internal static unsafe extern void vkCmdSetCheckpointNV (IntPtr commandBuffer, IntPtr pCheckpointMarker);
+
+		[DllImport (VulkanLibrary, CallingConvention = CallingConvention.Winapi)]
+		internal static unsafe extern void vkGetQueueCheckpointDataNV (IntPtr queue, UInt32* pCheckpointDataCount, CheckpointDataNv* pCheckpointData);
+
+		[DllImport (VulkanLibrary, CallingConvention = CallingConvention.Winapi)]
+		internal static unsafe extern void vkCmdBindTransformFeedbackBuffersEXT (IntPtr commandBuffer, UInt32 firstBinding, UInt32 bindingCount, UInt64* pBuffers, DeviceSize* pOffsets, DeviceSize* pSizes);
+
+		[DllImport (VulkanLibrary, CallingConvention = CallingConvention.Winapi)]
+		internal static unsafe extern void vkCmdBeginTransformFeedbackEXT (IntPtr commandBuffer, UInt32 firstCounterBuffer, UInt32 counterBufferCount, UInt64* pCounterBuffers, DeviceSize* pCounterBufferOffsets);
+
+		[DllImport (VulkanLibrary, CallingConvention = CallingConvention.Winapi)]
+		internal static unsafe extern void vkCmdEndTransformFeedbackEXT (IntPtr commandBuffer, UInt32 firstCounterBuffer, UInt32 counterBufferCount, UInt64* pCounterBuffers, DeviceSize* pCounterBufferOffsets);
+
+		[DllImport (VulkanLibrary, CallingConvention = CallingConvention.Winapi)]
+		internal static unsafe extern void vkCmdBeginQueryIndexedEXT (IntPtr commandBuffer, UInt64 queryPool, UInt32 query, QueryControlFlags flags, UInt32 index);
+
+		[DllImport (VulkanLibrary, CallingConvention = CallingConvention.Winapi)]
+		internal static unsafe extern void vkCmdEndQueryIndexedEXT (IntPtr commandBuffer, UInt64 queryPool, UInt32 query, UInt32 index);
+
+		[DllImport (VulkanLibrary, CallingConvention = CallingConvention.Winapi)]
+		internal static unsafe extern void vkCmdDrawIndirectByteCountEXT (IntPtr commandBuffer, UInt32 instanceCount, UInt32 firstInstance, UInt64 counterBuffer, DeviceSize counterBufferOffset, UInt32 counterOffset, UInt32 vertexStride);
+
+		[DllImport (VulkanLibrary, CallingConvention = CallingConvention.Winapi)]
+		internal static unsafe extern void vkCmdSetExclusiveScissorNV (IntPtr commandBuffer, UInt32 firstExclusiveScissor, UInt32 exclusiveScissorCount, Rect2D* pExclusiveScissors);
+
+		[DllImport (VulkanLibrary, CallingConvention = CallingConvention.Winapi)]
+		internal static unsafe extern void vkCmdBindShadingRateImageNV (IntPtr commandBuffer, UInt64 imageView, ImageLayout imageLayout);
+
+		[DllImport (VulkanLibrary, CallingConvention = CallingConvention.Winapi)]
+		internal static unsafe extern void vkCmdSetViewportShadingRatePaletteNV (IntPtr commandBuffer, UInt32 firstViewport, UInt32 viewportCount, ShadingRatePaletteNv* pShadingRatePalettes);
+
+		[DllImport (VulkanLibrary, CallingConvention = CallingConvention.Winapi)]
+		internal static unsafe extern void vkCmdSetCoarseSampleOrderNV (IntPtr commandBuffer, CoarseSampleOrderTypeNv sampleOrderType, UInt32 customSampleOrderCount, CoarseSampleOrderCustomNv* pCustomSampleOrders);
+
+		[DllImport (VulkanLibrary, CallingConvention = CallingConvention.Winapi)]
+		internal static unsafe extern void vkCmdDrawMeshTasksNV (IntPtr commandBuffer, UInt32 taskCount, UInt32 firstTask);
+
+		[DllImport (VulkanLibrary, CallingConvention = CallingConvention.Winapi)]
+		internal static unsafe extern void vkCmdDrawMeshTasksIndirectNV (IntPtr commandBuffer, UInt64 buffer, DeviceSize offset, UInt32 drawCount, UInt32 stride);
+
+		[DllImport (VulkanLibrary, CallingConvention = CallingConvention.Winapi)]
+		internal static unsafe extern void vkCmdDrawMeshTasksIndirectCountNV (IntPtr commandBuffer, UInt64 buffer, DeviceSize offset, UInt64 countBuffer, DeviceSize countBufferOffset, UInt32 maxDrawCount, UInt32 stride);
+
+		[DllImport (VulkanLibrary, CallingConvention = CallingConvention.Winapi)]
+		internal static unsafe extern Result vkCompileDeferredNV (IntPtr device, UInt64 pipeline, UInt32 shader);
+
+		[DllImport (VulkanLibrary, CallingConvention = CallingConvention.Winapi)]
+		internal static unsafe extern Result vkCreateAccelerationStructureNV (IntPtr device, AccelerationStructureCreateInfoNv* pCreateInfo, AllocationCallbacks* pAllocator, UInt64* pAccelerationStructure);
+
+		[DllImport (VulkanLibrary, CallingConvention = CallingConvention.Winapi)]
+		internal static unsafe extern void vkDestroyAccelerationStructureNV (IntPtr device, UInt64 accelerationStructure, AllocationCallbacks* pAllocator);
+
+		[DllImport (VulkanLibrary, CallingConvention = CallingConvention.Winapi)]
+		internal static unsafe extern Result vkBindAccelerationStructureMemoryNV (IntPtr device, UInt32 bindInfoCount, BindAccelerationStructureMemoryInfoNv* pBindInfos);
+
+		[DllImport (VulkanLibrary, CallingConvention = CallingConvention.Winapi)]
+		internal static unsafe extern void vkCmdCopyAccelerationStructureNV (IntPtr commandBuffer, UInt64 dst, UInt64 src, CopyAccelerationStructureModeNv mode);
+
+		[DllImport (VulkanLibrary, CallingConvention = CallingConvention.Winapi)]
+		internal static unsafe extern void vkCmdWriteAccelerationStructuresPropertiesNV (IntPtr commandBuffer, UInt32 accelerationStructureCount, UInt64* pAccelerationStructures, QueryType queryType, UInt64 queryPool, UInt32 firstQuery);
+
+		[DllImport (VulkanLibrary, CallingConvention = CallingConvention.Winapi)]
+		internal static unsafe extern void vkCmdBuildAccelerationStructureNV (IntPtr commandBuffer, AccelerationStructureInfoNv* pInfo, UInt64 instanceData, DeviceSize instanceOffset, Bool32 update, UInt64 dst, UInt64 src, UInt64 scratch, DeviceSize scratchOffset);
+
+		[DllImport (VulkanLibrary, CallingConvention = CallingConvention.Winapi)]
+		internal static unsafe extern void vkCmdTraceRaysNV (IntPtr commandBuffer, UInt64 raygenShaderBindingTableBuffer, DeviceSize raygenShaderBindingOffset, UInt64 missShaderBindingTableBuffer, DeviceSize missShaderBindingOffset, DeviceSize missShaderBindingStride, UInt64 hitShaderBindingTableBuffer, DeviceSize hitShaderBindingOffset, DeviceSize hitShaderBindingStride, UInt64 callableShaderBindingTableBuffer, DeviceSize callableShaderBindingOffset, DeviceSize callableShaderBindingStride, UInt32 width, UInt32 height, UInt32 depth);
+
+		[DllImport (VulkanLibrary, CallingConvention = CallingConvention.Winapi)]
+		internal static unsafe extern Result vkGetRayTracingShaderGroupHandlesNV (IntPtr device, UInt64 pipeline, UInt32 firstGroup, UInt32 groupCount, UIntPtr dataSize, IntPtr pData);
+
+		[DllImport (VulkanLibrary, CallingConvention = CallingConvention.Winapi)]
+		internal static unsafe extern Result vkGetAccelerationStructureHandleNV (IntPtr device, UInt64 accelerationStructure, UIntPtr dataSize, IntPtr pData);
+
+		[DllImport (VulkanLibrary, CallingConvention = CallingConvention.Winapi)]
+		internal static unsafe extern Result vkCreateRayTracingPipelinesNV (IntPtr device, UInt64 pipelineCache, UInt32 createInfoCount, RayTracingPipelineCreateInfoNv* pCreateInfos, AllocationCallbacks* pAllocator, UInt64* pPipelines);
+
+		[DllImport (VulkanLibrary, CallingConvention = CallingConvention.Winapi)]
+		internal static unsafe extern Result vkGetImageDrmFormatModifierPropertiesEXT (IntPtr device, UInt64 image, ImageDrmFormatModifierPropertiesExt* pProperties);
+
+		[DllImport (VulkanLibrary, CallingConvention = CallingConvention.Winapi)]
+		internal static unsafe extern DeviceAddress vkGetBufferDeviceAddressEXT (IntPtr device, BufferDeviceAddressInfoExt* pInfo);
+
+		[DllImport (VulkanLibrary, CallingConvention = CallingConvention.Winapi)]
+		internal static unsafe extern Result vkGetPhysicalDeviceCooperativeMatrixPropertiesNV (IntPtr physicalDevice, UInt32* pPropertyCount, CooperativeMatrixPropertiesNv* pProperties);
+
+		[DllImport (VulkanLibrary, CallingConvention = CallingConvention.Winapi)]
+		internal static unsafe extern UInt32 vkGetImageViewHandleNVX (IntPtr device, ImageViewHandleInfoNvx* pInfo);
+
+		[DllImport (VulkanLibrary, CallingConvention = CallingConvention.Winapi)]
+		internal static unsafe extern Result vkGetPhysicalDeviceSurfacePresentModes2EXT (IntPtr physicalDevice, PhysicalDeviceSurfaceInfo2Khr* pSurfaceInfo, UInt32* pPresentModeCount, PresentModeKhr* pPresentModes);
+
+		[DllImport (VulkanLibrary, CallingConvention = CallingConvention.Winapi)]
+		internal static unsafe extern Result vkGetDeviceGroupSurfacePresentModes2EXT (IntPtr device, PhysicalDeviceSurfaceInfo2Khr* pSurfaceInfo, DeviceGroupPresentModeFlagsKhr* pModes);
+
+		[DllImport (VulkanLibrary, CallingConvention = CallingConvention.Winapi)]
+		internal static unsafe extern Result vkAcquireFullScreenExclusiveModeEXT (IntPtr device, UInt64 swapchain);
+
+		[DllImport (VulkanLibrary, CallingConvention = CallingConvention.Winapi)]
+		internal static unsafe extern Result vkReleaseFullScreenExclusiveModeEXT (IntPtr device, UInt64 swapchain);
+
+		[DllImport (VulkanLibrary, CallingConvention = CallingConvention.Winapi)]
+		internal static unsafe extern Result vkCreateHeadlessSurfaceEXT (IntPtr instance, HeadlessSurfaceCreateInfoExt* pCreateInfo, AllocationCallbacks* pAllocator, UInt64* pSurface);
+
+		[DllImport (VulkanLibrary, CallingConvention = CallingConvention.Winapi)]
+		internal static unsafe extern Result vkGetPhysicalDeviceSupportedFramebufferMixedSamplesCombinationsNV (IntPtr physicalDevice, UInt32* pCombinationCount, FramebufferMixedSamplesCombinationNv* pCombinations);
+
+		[DllImport (VulkanLibrary, CallingConvention = CallingConvention.Winapi)]
+		internal static unsafe extern Result vkInitializePerformanceApiINTEL (IntPtr device, InitializePerformanceApiInfoIntel* pInitializeInfo);
+
+		[DllImport (VulkanLibrary, CallingConvention = CallingConvention.Winapi)]
+		internal static unsafe extern void vkUninitializePerformanceApiINTEL (IntPtr device);
+
+		[DllImport (VulkanLibrary, CallingConvention = CallingConvention.Winapi)]
+		internal static unsafe extern Result vkCmdSetPerformanceMarkerINTEL (IntPtr commandBuffer, PerformanceMarkerInfoIntel* pMarkerInfo);
+
+		[DllImport (VulkanLibrary, CallingConvention = CallingConvention.Winapi)]
+		internal static unsafe extern Result vkCmdSetPerformanceStreamMarkerINTEL (IntPtr commandBuffer, PerformanceStreamMarkerInfoIntel* pMarkerInfo);
+
+		[DllImport (VulkanLibrary, CallingConvention = CallingConvention.Winapi)]
+		internal static unsafe extern Result vkCmdSetPerformanceOverrideINTEL (IntPtr commandBuffer, PerformanceOverrideInfoIntel* pOverrideInfo);
+
+		[DllImport (VulkanLibrary, CallingConvention = CallingConvention.Winapi)]
+		internal static unsafe extern Result vkAcquirePerformanceConfigurationINTEL (IntPtr device, PerformanceConfigurationAcquireInfoIntel* pAcquireInfo, UInt64* pConfiguration);
+
+		[DllImport (VulkanLibrary, CallingConvention = CallingConvention.Winapi)]
+		internal static unsafe extern Result vkReleasePerformanceConfigurationINTEL (IntPtr device, UInt64 configuration);
+
+		[DllImport (VulkanLibrary, CallingConvention = CallingConvention.Winapi)]
+		internal static unsafe extern Result vkQueueSetPerformanceConfigurationINTEL (IntPtr queue, UInt64 configuration);
+
+		[DllImport (VulkanLibrary, CallingConvention = CallingConvention.Winapi)]
+		internal static unsafe extern Result vkGetPerformanceParameterINTEL (IntPtr device, PerformanceParameterTypeIntel parameter, PerformanceValueIntel* pValue);
 	}
 }

--- a/src/Vulkan/Interop/MarshalStructs.cs
+++ b/src/Vulkan/Interop/MarshalStructs.cs
@@ -12,6 +12,18 @@ using System;
 
 namespace Vulkan.Interop
 {
+	internal partial struct BaseOutStructure
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+	}
+
+	internal partial struct BaseInStructure
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+	}
+
 	internal partial struct PhysicalDeviceProperties
 	{
 		internal UInt32 ApiVersion;
@@ -64,7 +76,7 @@ namespace Vulkan.Interop
 	{
 		internal StructureType SType;
 		internal IntPtr Next;
-		internal UInt32 Flags;
+		internal DeviceQueueCreateFlags Flags;
 		internal UInt32 QueueFamilyIndex;
 		internal UInt32 QueueCount;
 		internal IntPtr QueuePriorities;
@@ -289,7 +301,7 @@ namespace Vulkan.Interop
 	{
 		internal StructureType SType;
 		internal IntPtr Next;
-		internal UInt32 Flags;
+		internal ImageViewCreateFlags Flags;
 		internal UInt64 Image;
 		internal ImageViewType ViewType;
 		internal Format Format;
@@ -592,7 +604,7 @@ namespace Vulkan.Interop
 	{
 		internal StructureType SType;
 		internal IntPtr Next;
-		internal UInt32 Flags;
+		internal SamplerCreateFlags Flags;
 		internal Filter MagFilter;
 		internal Filter MinFilter;
 		internal SamplerMipmapMode MipmapMode;
@@ -921,6 +933,22 @@ namespace Vulkan.Interop
 		internal IntPtr Window;
 	}
 
+	internal partial struct ImagePipeSurfaceCreateInfoFUCHSIA
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal UInt32 Flags;
+		internal UInt32 ImagePipeHandle;
+	}
+
+	internal partial struct StreamDescriptorSurfaceCreateInfoGGP
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal UInt32 Flags;
+		internal int StreamDescriptor;
+	}
+
 	internal partial struct SwapchainCreateInfoKhr
 	{
 		internal StructureType SType;
@@ -970,6 +998,16 @@ namespace Vulkan.Interop
 		internal IntPtr Next;
 		internal UInt32 DisabledValidationCheckCount;
 		internal IntPtr DisabledValidationChecks;
+	}
+
+	internal partial struct ValidationFeaturesExt
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal UInt32 EnabledValidationFeatureCount;
+		internal IntPtr EnabledValidationFeatures;
+		internal UInt32 DisabledValidationFeatureCount;
+		internal IntPtr DisabledValidationFeatures;
 	}
 
 	internal partial struct PipelineRasterizationStateRasterizationOrderAmd
@@ -1156,11 +1194,45 @@ namespace Vulkan.Interop
 		internal ShaderStageFlags StageFlags;
 	}
 
+	internal partial struct PhysicalDeviceFeatures2
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal PhysicalDeviceFeatures Features;
+	}
+
 	internal partial struct PhysicalDeviceFeatures2Khr
 	{
 		internal StructureType SType;
 		internal IntPtr Next;
 		internal PhysicalDeviceFeatures Features;
+
+		public static implicit operator PhysicalDeviceFeatures2Khr (PhysicalDeviceFeatures2 that) {
+			var ret = new PhysicalDeviceFeatures2Khr {
+				SType = that.SType,
+				Next = that.Next,
+				Features = that.Features,
+			};
+
+			return ret;
+		}
+
+		public static implicit operator PhysicalDeviceFeatures2 (PhysicalDeviceFeatures2Khr that) {
+			var ret = new PhysicalDeviceFeatures2 {
+				SType = that.SType,
+				Next = that.Next,
+				Features = that.Features,
+			};
+
+			return ret;
+		}
+	}
+
+	internal partial struct PhysicalDeviceProperties2
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal PhysicalDeviceProperties Properties;
 	}
 
 	internal partial struct PhysicalDeviceProperties2Khr
@@ -1168,6 +1240,33 @@ namespace Vulkan.Interop
 		internal StructureType SType;
 		internal IntPtr Next;
 		internal PhysicalDeviceProperties Properties;
+
+		public static implicit operator PhysicalDeviceProperties2Khr (PhysicalDeviceProperties2 that) {
+			var ret = new PhysicalDeviceProperties2Khr {
+				SType = that.SType,
+				Next = that.Next,
+				Properties = that.Properties,
+			};
+
+			return ret;
+		}
+
+		public static implicit operator PhysicalDeviceProperties2 (PhysicalDeviceProperties2Khr that) {
+			var ret = new PhysicalDeviceProperties2 {
+				SType = that.SType,
+				Next = that.Next,
+				Properties = that.Properties,
+			};
+
+			return ret;
+		}
+	}
+
+	internal partial struct FormatProperties2
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal FormatProperties FormatProperties;
 	}
 
 	internal partial struct FormatProperties2Khr
@@ -1175,6 +1274,33 @@ namespace Vulkan.Interop
 		internal StructureType SType;
 		internal IntPtr Next;
 		internal FormatProperties FormatProperties;
+
+		public static implicit operator FormatProperties2Khr (FormatProperties2 that) {
+			var ret = new FormatProperties2Khr {
+				SType = that.SType,
+				Next = that.Next,
+				FormatProperties = that.FormatProperties,
+			};
+
+			return ret;
+		}
+
+		public static implicit operator FormatProperties2 (FormatProperties2Khr that) {
+			var ret = new FormatProperties2 {
+				SType = that.SType,
+				Next = that.Next,
+				FormatProperties = that.FormatProperties,
+			};
+
+			return ret;
+		}
+	}
+
+	internal partial struct ImageFormatProperties2
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal ImageFormatProperties ImageFormatProperties;
 	}
 
 	internal partial struct ImageFormatProperties2Khr
@@ -1182,6 +1308,37 @@ namespace Vulkan.Interop
 		internal StructureType SType;
 		internal IntPtr Next;
 		internal ImageFormatProperties ImageFormatProperties;
+
+		public static implicit operator ImageFormatProperties2Khr (ImageFormatProperties2 that) {
+			var ret = new ImageFormatProperties2Khr {
+				SType = that.SType,
+				Next = that.Next,
+				ImageFormatProperties = that.ImageFormatProperties,
+			};
+
+			return ret;
+		}
+
+		public static implicit operator ImageFormatProperties2 (ImageFormatProperties2Khr that) {
+			var ret = new ImageFormatProperties2 {
+				SType = that.SType,
+				Next = that.Next,
+				ImageFormatProperties = that.ImageFormatProperties,
+			};
+
+			return ret;
+		}
+	}
+
+	internal partial struct PhysicalDeviceImageFormatInfo2
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal Format Format;
+		internal ImageType Type;
+		internal ImageTiling Tiling;
+		internal ImageUsageFlags Usage;
+		internal ImageCreateFlags Flags;
 	}
 
 	internal partial struct PhysicalDeviceImageFormatInfo2Khr
@@ -1193,6 +1350,41 @@ namespace Vulkan.Interop
 		internal ImageTiling Tiling;
 		internal ImageUsageFlags Usage;
 		internal ImageCreateFlags Flags;
+
+		public static implicit operator PhysicalDeviceImageFormatInfo2Khr (PhysicalDeviceImageFormatInfo2 that) {
+			var ret = new PhysicalDeviceImageFormatInfo2Khr {
+				SType = that.SType,
+				Next = that.Next,
+				Format = that.Format,
+				Type = that.Type,
+				Tiling = that.Tiling,
+				Usage = that.Usage,
+				Flags = that.Flags,
+			};
+
+			return ret;
+		}
+
+		public static implicit operator PhysicalDeviceImageFormatInfo2 (PhysicalDeviceImageFormatInfo2Khr that) {
+			var ret = new PhysicalDeviceImageFormatInfo2 {
+				SType = that.SType,
+				Next = that.Next,
+				Format = that.Format,
+				Type = that.Type,
+				Tiling = that.Tiling,
+				Usage = that.Usage,
+				Flags = that.Flags,
+			};
+
+			return ret;
+		}
+	}
+
+	internal partial struct QueueFamilyProperties2
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal QueueFamilyProperties QueueFamilyProperties;
 	}
 
 	internal partial struct QueueFamilyProperties2Khr
@@ -1200,6 +1392,33 @@ namespace Vulkan.Interop
 		internal StructureType SType;
 		internal IntPtr Next;
 		internal QueueFamilyProperties QueueFamilyProperties;
+
+		public static implicit operator QueueFamilyProperties2Khr (QueueFamilyProperties2 that) {
+			var ret = new QueueFamilyProperties2Khr {
+				SType = that.SType,
+				Next = that.Next,
+				QueueFamilyProperties = that.QueueFamilyProperties,
+			};
+
+			return ret;
+		}
+
+		public static implicit operator QueueFamilyProperties2 (QueueFamilyProperties2Khr that) {
+			var ret = new QueueFamilyProperties2 {
+				SType = that.SType,
+				Next = that.Next,
+				QueueFamilyProperties = that.QueueFamilyProperties,
+			};
+
+			return ret;
+		}
+	}
+
+	internal partial struct PhysicalDeviceMemoryProperties2
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal PhysicalDeviceMemoryProperties MemoryProperties;
 	}
 
 	internal partial struct PhysicalDeviceMemoryProperties2Khr
@@ -1207,6 +1426,33 @@ namespace Vulkan.Interop
 		internal StructureType SType;
 		internal IntPtr Next;
 		internal PhysicalDeviceMemoryProperties MemoryProperties;
+
+		public static implicit operator PhysicalDeviceMemoryProperties2Khr (PhysicalDeviceMemoryProperties2 that) {
+			var ret = new PhysicalDeviceMemoryProperties2Khr {
+				SType = that.SType,
+				Next = that.Next,
+				MemoryProperties = that.MemoryProperties,
+			};
+
+			return ret;
+		}
+
+		public static implicit operator PhysicalDeviceMemoryProperties2 (PhysicalDeviceMemoryProperties2Khr that) {
+			var ret = new PhysicalDeviceMemoryProperties2 {
+				SType = that.SType,
+				Next = that.Next,
+				MemoryProperties = that.MemoryProperties,
+			};
+
+			return ret;
+		}
+	}
+
+	internal partial struct SparseImageFormatProperties2
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal SparseImageFormatProperties Properties;
 	}
 
 	internal partial struct SparseImageFormatProperties2Khr
@@ -1214,6 +1460,37 @@ namespace Vulkan.Interop
 		internal StructureType SType;
 		internal IntPtr Next;
 		internal SparseImageFormatProperties Properties;
+
+		public static implicit operator SparseImageFormatProperties2Khr (SparseImageFormatProperties2 that) {
+			var ret = new SparseImageFormatProperties2Khr {
+				SType = that.SType,
+				Next = that.Next,
+				Properties = that.Properties,
+			};
+
+			return ret;
+		}
+
+		public static implicit operator SparseImageFormatProperties2 (SparseImageFormatProperties2Khr that) {
+			var ret = new SparseImageFormatProperties2 {
+				SType = that.SType,
+				Next = that.Next,
+				Properties = that.Properties,
+			};
+
+			return ret;
+		}
+	}
+
+	internal partial struct PhysicalDeviceSparseImageFormatInfo2
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal Format Format;
+		internal ImageType Type;
+		internal SampleCountFlags Samples;
+		internal ImageUsageFlags Usage;
+		internal ImageTiling Tiling;
 	}
 
 	internal partial struct PhysicalDeviceSparseImageFormatInfo2Khr
@@ -1225,6 +1502,34 @@ namespace Vulkan.Interop
 		internal SampleCountFlags Samples;
 		internal ImageUsageFlags Usage;
 		internal ImageTiling Tiling;
+
+		public static implicit operator PhysicalDeviceSparseImageFormatInfo2Khr (PhysicalDeviceSparseImageFormatInfo2 that) {
+			var ret = new PhysicalDeviceSparseImageFormatInfo2Khr {
+				SType = that.SType,
+				Next = that.Next,
+				Format = that.Format,
+				Type = that.Type,
+				Samples = that.Samples,
+				Usage = that.Usage,
+				Tiling = that.Tiling,
+			};
+
+			return ret;
+		}
+
+		public static implicit operator PhysicalDeviceSparseImageFormatInfo2 (PhysicalDeviceSparseImageFormatInfo2Khr that) {
+			var ret = new PhysicalDeviceSparseImageFormatInfo2 {
+				SType = that.SType,
+				Next = that.Next,
+				Format = that.Format,
+				Type = that.Type,
+				Samples = that.Samples,
+				Usage = that.Usage,
+				Tiling = that.Tiling,
+			};
+
+			return ret;
+		}
 	}
 
 	internal partial struct PhysicalDevicePushDescriptorPropertiesKhr
@@ -1232,6 +1537,16 @@ namespace Vulkan.Interop
 		internal StructureType SType;
 		internal IntPtr Next;
 		internal UInt32 MaxPushDescriptors;
+	}
+
+	internal partial struct PhysicalDeviceDriverPropertiesKhr
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal DriverIdKhr DriverId;
+		internal unsafe fixed byte DriverName[256];
+		internal unsafe fixed byte DriverInfo[256];
+		internal ConformanceVersionKhr ConformanceVersion;
 	}
 
 	internal partial struct PresentRegionsKhr
@@ -1248,7 +1563,7 @@ namespace Vulkan.Interop
 		internal IntPtr Rectangles;
 	}
 
-	internal partial struct PhysicalDeviceVariablePointerFeaturesKhr
+	internal partial struct PhysicalDeviceVariablePointersFeatures
 	{
 		internal StructureType SType;
 		internal IntPtr Next;
@@ -1256,18 +1571,171 @@ namespace Vulkan.Interop
 		internal Bool32 VariablePointers;
 	}
 
+	internal partial struct PhysicalDeviceVariablePointersFeaturesKhr
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal Bool32 VariablePointersStorageBuffer;
+		internal Bool32 VariablePointers;
+
+		public static implicit operator PhysicalDeviceVariablePointersFeaturesKhr (PhysicalDeviceVariablePointersFeatures that) {
+			var ret = new PhysicalDeviceVariablePointersFeaturesKhr {
+				SType = that.SType,
+				Next = that.Next,
+				VariablePointersStorageBuffer = that.VariablePointersStorageBuffer,
+				VariablePointers = that.VariablePointers,
+			};
+
+			return ret;
+		}
+
+		public static implicit operator PhysicalDeviceVariablePointersFeatures (PhysicalDeviceVariablePointersFeaturesKhr that) {
+			var ret = new PhysicalDeviceVariablePointersFeatures {
+				SType = that.SType,
+				Next = that.Next,
+				VariablePointersStorageBuffer = that.VariablePointersStorageBuffer,
+				VariablePointers = that.VariablePointers,
+			};
+
+			return ret;
+		}
+	}
+
+	internal partial struct PhysicalDeviceVariablePointerFeaturesKhr
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal Bool32 VariablePointersStorageBuffer;
+		internal Bool32 VariablePointers;
+
+		public static implicit operator PhysicalDeviceVariablePointerFeaturesKhr (PhysicalDeviceVariablePointersFeatures that) {
+			var ret = new PhysicalDeviceVariablePointerFeaturesKhr {
+				SType = that.SType,
+				Next = that.Next,
+				VariablePointersStorageBuffer = that.VariablePointersStorageBuffer,
+				VariablePointers = that.VariablePointers,
+			};
+
+			return ret;
+		}
+
+		public static implicit operator PhysicalDeviceVariablePointersFeatures (PhysicalDeviceVariablePointerFeaturesKhr that) {
+			var ret = new PhysicalDeviceVariablePointersFeatures {
+				SType = that.SType,
+				Next = that.Next,
+				VariablePointersStorageBuffer = that.VariablePointersStorageBuffer,
+				VariablePointers = that.VariablePointers,
+			};
+
+			return ret;
+		}
+	}
+
+	internal partial struct PhysicalDeviceVariablePointerFeatures
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal Bool32 VariablePointersStorageBuffer;
+		internal Bool32 VariablePointers;
+
+		public static implicit operator PhysicalDeviceVariablePointerFeatures (PhysicalDeviceVariablePointersFeatures that) {
+			var ret = new PhysicalDeviceVariablePointerFeatures {
+				SType = that.SType,
+				Next = that.Next,
+				VariablePointersStorageBuffer = that.VariablePointersStorageBuffer,
+				VariablePointers = that.VariablePointers,
+			};
+
+			return ret;
+		}
+
+		public static implicit operator PhysicalDeviceVariablePointersFeatures (PhysicalDeviceVariablePointerFeatures that) {
+			var ret = new PhysicalDeviceVariablePointersFeatures {
+				SType = that.SType,
+				Next = that.Next,
+				VariablePointersStorageBuffer = that.VariablePointersStorageBuffer,
+				VariablePointers = that.VariablePointers,
+			};
+
+			return ret;
+		}
+	}
+
+	internal partial struct PhysicalDeviceExternalImageFormatInfo
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal ExternalMemoryHandleTypeFlags HandleType;
+	}
+
 	internal partial struct PhysicalDeviceExternalImageFormatInfoKhr
 	{
 		internal StructureType SType;
 		internal IntPtr Next;
-		internal ExternalMemoryHandleTypeFlagsKhr HandleType;
+		internal ExternalMemoryHandleTypeFlags HandleType;
+
+		public static implicit operator PhysicalDeviceExternalImageFormatInfoKhr (PhysicalDeviceExternalImageFormatInfo that) {
+			var ret = new PhysicalDeviceExternalImageFormatInfoKhr {
+				SType = that.SType,
+				Next = that.Next,
+				HandleType = that.HandleType,
+			};
+
+			return ret;
+		}
+
+		public static implicit operator PhysicalDeviceExternalImageFormatInfo (PhysicalDeviceExternalImageFormatInfoKhr that) {
+			var ret = new PhysicalDeviceExternalImageFormatInfo {
+				SType = that.SType,
+				Next = that.Next,
+				HandleType = that.HandleType,
+			};
+
+			return ret;
+		}
+	}
+
+	internal partial struct ExternalImageFormatProperties
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal ExternalMemoryProperties ExternalMemoryProperties;
 	}
 
 	internal partial struct ExternalImageFormatPropertiesKhr
 	{
 		internal StructureType SType;
 		internal IntPtr Next;
-		internal ExternalMemoryPropertiesKhr ExternalMemoryProperties;
+		internal ExternalMemoryProperties ExternalMemoryProperties;
+
+		public static implicit operator ExternalImageFormatPropertiesKhr (ExternalImageFormatProperties that) {
+			var ret = new ExternalImageFormatPropertiesKhr {
+				SType = that.SType,
+				Next = that.Next,
+				ExternalMemoryProperties = that.ExternalMemoryProperties,
+			};
+
+			return ret;
+		}
+
+		public static implicit operator ExternalImageFormatProperties (ExternalImageFormatPropertiesKhr that) {
+			var ret = new ExternalImageFormatProperties {
+				SType = that.SType,
+				Next = that.Next,
+				ExternalMemoryProperties = that.ExternalMemoryProperties,
+			};
+
+			return ret;
+		}
+	}
+
+	internal partial struct PhysicalDeviceExternalBufferInfo
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal BufferCreateFlags Flags;
+		internal BufferUsageFlags Usage;
+		internal ExternalMemoryHandleTypeFlags HandleType;
 	}
 
 	internal partial struct PhysicalDeviceExternalBufferInfoKhr
@@ -1276,14 +1744,76 @@ namespace Vulkan.Interop
 		internal IntPtr Next;
 		internal BufferCreateFlags Flags;
 		internal BufferUsageFlags Usage;
-		internal ExternalMemoryHandleTypeFlagsKhr HandleType;
+		internal ExternalMemoryHandleTypeFlags HandleType;
+
+		public static implicit operator PhysicalDeviceExternalBufferInfoKhr (PhysicalDeviceExternalBufferInfo that) {
+			var ret = new PhysicalDeviceExternalBufferInfoKhr {
+				SType = that.SType,
+				Next = that.Next,
+				Flags = that.Flags,
+				Usage = that.Usage,
+				HandleType = that.HandleType,
+			};
+
+			return ret;
+		}
+
+		public static implicit operator PhysicalDeviceExternalBufferInfo (PhysicalDeviceExternalBufferInfoKhr that) {
+			var ret = new PhysicalDeviceExternalBufferInfo {
+				SType = that.SType,
+				Next = that.Next,
+				Flags = that.Flags,
+				Usage = that.Usage,
+				HandleType = that.HandleType,
+			};
+
+			return ret;
+		}
+	}
+
+	internal partial struct ExternalBufferProperties
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal ExternalMemoryProperties ExternalMemoryProperties;
 	}
 
 	internal partial struct ExternalBufferPropertiesKhr
 	{
 		internal StructureType SType;
 		internal IntPtr Next;
-		internal ExternalMemoryPropertiesKhr ExternalMemoryProperties;
+		internal ExternalMemoryProperties ExternalMemoryProperties;
+
+		public static implicit operator ExternalBufferPropertiesKhr (ExternalBufferProperties that) {
+			var ret = new ExternalBufferPropertiesKhr {
+				SType = that.SType,
+				Next = that.Next,
+				ExternalMemoryProperties = that.ExternalMemoryProperties,
+			};
+
+			return ret;
+		}
+
+		public static implicit operator ExternalBufferProperties (ExternalBufferPropertiesKhr that) {
+			var ret = new ExternalBufferProperties {
+				SType = that.SType,
+				Next = that.Next,
+				ExternalMemoryProperties = that.ExternalMemoryProperties,
+			};
+
+			return ret;
+		}
+	}
+
+	internal partial struct PhysicalDeviceIDProperties
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal unsafe fixed byte DeviceUuid[16];
+		internal unsafe fixed byte DriverUuid[16];
+		internal unsafe fixed byte DeviceLuid[8];
+		internal UInt32 DeviceNodeMask;
+		internal Bool32 DeviceLuidvalid;
 	}
 
 	internal partial struct PhysicalDeviceIDPropertiesKhr
@@ -1295,27 +1825,216 @@ namespace Vulkan.Interop
 		internal unsafe fixed byte DeviceLuid[8];
 		internal UInt32 DeviceNodeMask;
 		internal Bool32 DeviceLuidvalid;
+
+		unsafe public static implicit operator PhysicalDeviceIDPropertiesKhr (PhysicalDeviceIDProperties that) {
+			var ret = new PhysicalDeviceIDPropertiesKhr {
+				SType = that.SType,
+				Next = that.Next,
+				DeviceNodeMask = that.DeviceNodeMask,
+				DeviceLuidvalid = that.DeviceLuidvalid,
+			};
+
+			ret.DeviceUuid[0] = that.DeviceUuid[0];
+			ret.DeviceUuid[1] = that.DeviceUuid[1];
+			ret.DeviceUuid[2] = that.DeviceUuid[2];
+			ret.DeviceUuid[3] = that.DeviceUuid[3];
+			ret.DeviceUuid[4] = that.DeviceUuid[4];
+			ret.DeviceUuid[5] = that.DeviceUuid[5];
+			ret.DeviceUuid[6] = that.DeviceUuid[6];
+			ret.DeviceUuid[7] = that.DeviceUuid[7];
+			ret.DeviceUuid[8] = that.DeviceUuid[8];
+			ret.DeviceUuid[9] = that.DeviceUuid[9];
+			ret.DeviceUuid[10] = that.DeviceUuid[10];
+			ret.DeviceUuid[11] = that.DeviceUuid[11];
+			ret.DeviceUuid[12] = that.DeviceUuid[12];
+			ret.DeviceUuid[13] = that.DeviceUuid[13];
+			ret.DeviceUuid[14] = that.DeviceUuid[14];
+			ret.DeviceUuid[15] = that.DeviceUuid[15];
+
+			ret.DriverUuid[0] = that.DriverUuid[0];
+			ret.DriverUuid[1] = that.DriverUuid[1];
+			ret.DriverUuid[2] = that.DriverUuid[2];
+			ret.DriverUuid[3] = that.DriverUuid[3];
+			ret.DriverUuid[4] = that.DriverUuid[4];
+			ret.DriverUuid[5] = that.DriverUuid[5];
+			ret.DriverUuid[6] = that.DriverUuid[6];
+			ret.DriverUuid[7] = that.DriverUuid[7];
+			ret.DriverUuid[8] = that.DriverUuid[8];
+			ret.DriverUuid[9] = that.DriverUuid[9];
+			ret.DriverUuid[10] = that.DriverUuid[10];
+			ret.DriverUuid[11] = that.DriverUuid[11];
+			ret.DriverUuid[12] = that.DriverUuid[12];
+			ret.DriverUuid[13] = that.DriverUuid[13];
+			ret.DriverUuid[14] = that.DriverUuid[14];
+			ret.DriverUuid[15] = that.DriverUuid[15];
+
+			ret.DeviceLuid[0] = that.DeviceLuid[0];
+			ret.DeviceLuid[1] = that.DeviceLuid[1];
+			ret.DeviceLuid[2] = that.DeviceLuid[2];
+			ret.DeviceLuid[3] = that.DeviceLuid[3];
+			ret.DeviceLuid[4] = that.DeviceLuid[4];
+			ret.DeviceLuid[5] = that.DeviceLuid[5];
+			ret.DeviceLuid[6] = that.DeviceLuid[6];
+			ret.DeviceLuid[7] = that.DeviceLuid[7];
+
+			return ret;
+		}
+
+		unsafe public static implicit operator PhysicalDeviceIDProperties (PhysicalDeviceIDPropertiesKhr that) {
+			var ret = new PhysicalDeviceIDProperties {
+				SType = that.SType,
+				Next = that.Next,
+				DeviceNodeMask = that.DeviceNodeMask,
+				DeviceLuidvalid = that.DeviceLuidvalid,
+			};
+
+			ret.DeviceUuid[0] = that.DeviceUuid[0];
+			ret.DeviceUuid[1] = that.DeviceUuid[1];
+			ret.DeviceUuid[2] = that.DeviceUuid[2];
+			ret.DeviceUuid[3] = that.DeviceUuid[3];
+			ret.DeviceUuid[4] = that.DeviceUuid[4];
+			ret.DeviceUuid[5] = that.DeviceUuid[5];
+			ret.DeviceUuid[6] = that.DeviceUuid[6];
+			ret.DeviceUuid[7] = that.DeviceUuid[7];
+			ret.DeviceUuid[8] = that.DeviceUuid[8];
+			ret.DeviceUuid[9] = that.DeviceUuid[9];
+			ret.DeviceUuid[10] = that.DeviceUuid[10];
+			ret.DeviceUuid[11] = that.DeviceUuid[11];
+			ret.DeviceUuid[12] = that.DeviceUuid[12];
+			ret.DeviceUuid[13] = that.DeviceUuid[13];
+			ret.DeviceUuid[14] = that.DeviceUuid[14];
+			ret.DeviceUuid[15] = that.DeviceUuid[15];
+
+			ret.DriverUuid[0] = that.DriverUuid[0];
+			ret.DriverUuid[1] = that.DriverUuid[1];
+			ret.DriverUuid[2] = that.DriverUuid[2];
+			ret.DriverUuid[3] = that.DriverUuid[3];
+			ret.DriverUuid[4] = that.DriverUuid[4];
+			ret.DriverUuid[5] = that.DriverUuid[5];
+			ret.DriverUuid[6] = that.DriverUuid[6];
+			ret.DriverUuid[7] = that.DriverUuid[7];
+			ret.DriverUuid[8] = that.DriverUuid[8];
+			ret.DriverUuid[9] = that.DriverUuid[9];
+			ret.DriverUuid[10] = that.DriverUuid[10];
+			ret.DriverUuid[11] = that.DriverUuid[11];
+			ret.DriverUuid[12] = that.DriverUuid[12];
+			ret.DriverUuid[13] = that.DriverUuid[13];
+			ret.DriverUuid[14] = that.DriverUuid[14];
+			ret.DriverUuid[15] = that.DriverUuid[15];
+
+			ret.DeviceLuid[0] = that.DeviceLuid[0];
+			ret.DeviceLuid[1] = that.DeviceLuid[1];
+			ret.DeviceLuid[2] = that.DeviceLuid[2];
+			ret.DeviceLuid[3] = that.DeviceLuid[3];
+			ret.DeviceLuid[4] = that.DeviceLuid[4];
+			ret.DeviceLuid[5] = that.DeviceLuid[5];
+			ret.DeviceLuid[6] = that.DeviceLuid[6];
+			ret.DeviceLuid[7] = that.DeviceLuid[7];
+
+			return ret;
+		}
+	}
+
+	internal partial struct ExternalMemoryImageCreateInfo
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal ExternalMemoryHandleTypeFlags HandleTypes;
 	}
 
 	internal partial struct ExternalMemoryImageCreateInfoKhr
 	{
 		internal StructureType SType;
 		internal IntPtr Next;
-		internal ExternalMemoryHandleTypeFlagsKhr HandleTypes;
+		internal ExternalMemoryHandleTypeFlags HandleTypes;
+
+		public static implicit operator ExternalMemoryImageCreateInfoKhr (ExternalMemoryImageCreateInfo that) {
+			var ret = new ExternalMemoryImageCreateInfoKhr {
+				SType = that.SType,
+				Next = that.Next,
+				HandleTypes = that.HandleTypes,
+			};
+
+			return ret;
+		}
+
+		public static implicit operator ExternalMemoryImageCreateInfo (ExternalMemoryImageCreateInfoKhr that) {
+			var ret = new ExternalMemoryImageCreateInfo {
+				SType = that.SType,
+				Next = that.Next,
+				HandleTypes = that.HandleTypes,
+			};
+
+			return ret;
+		}
+	}
+
+	internal partial struct ExternalMemoryBufferCreateInfo
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal ExternalMemoryHandleTypeFlags HandleTypes;
 	}
 
 	internal partial struct ExternalMemoryBufferCreateInfoKhr
 	{
 		internal StructureType SType;
 		internal IntPtr Next;
-		internal ExternalMemoryHandleTypeFlagsKhr HandleTypes;
+		internal ExternalMemoryHandleTypeFlags HandleTypes;
+
+		public static implicit operator ExternalMemoryBufferCreateInfoKhr (ExternalMemoryBufferCreateInfo that) {
+			var ret = new ExternalMemoryBufferCreateInfoKhr {
+				SType = that.SType,
+				Next = that.Next,
+				HandleTypes = that.HandleTypes,
+			};
+
+			return ret;
+		}
+
+		public static implicit operator ExternalMemoryBufferCreateInfo (ExternalMemoryBufferCreateInfoKhr that) {
+			var ret = new ExternalMemoryBufferCreateInfo {
+				SType = that.SType,
+				Next = that.Next,
+				HandleTypes = that.HandleTypes,
+			};
+
+			return ret;
+		}
+	}
+
+	internal partial struct ExportMemoryAllocateInfo
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal ExternalMemoryHandleTypeFlags HandleTypes;
 	}
 
 	internal partial struct ExportMemoryAllocateInfoKhr
 	{
 		internal StructureType SType;
 		internal IntPtr Next;
-		internal ExternalMemoryHandleTypeFlagsKhr HandleTypes;
+		internal ExternalMemoryHandleTypeFlags HandleTypes;
+
+		public static implicit operator ExportMemoryAllocateInfoKhr (ExportMemoryAllocateInfo that) {
+			var ret = new ExportMemoryAllocateInfoKhr {
+				SType = that.SType,
+				Next = that.Next,
+				HandleTypes = that.HandleTypes,
+			};
+
+			return ret;
+		}
+
+		public static implicit operator ExportMemoryAllocateInfo (ExportMemoryAllocateInfoKhr that) {
+			var ret = new ExportMemoryAllocateInfo {
+				SType = that.SType,
+				Next = that.Next,
+				HandleTypes = that.HandleTypes,
+			};
+
+			return ret;
+		}
 	}
 
 	internal partial struct MemoryWin32HandlePropertiesKhr
@@ -1330,14 +2049,14 @@ namespace Vulkan.Interop
 		internal StructureType SType;
 		internal IntPtr Next;
 		internal UInt64 Memory;
-		internal ExternalMemoryHandleTypeFlagsKhr HandleType;
+		internal ExternalMemoryHandleTypeFlags HandleType;
 	}
 
 	internal partial struct ImportMemoryFdInfoKhr
 	{
 		internal StructureType SType;
 		internal IntPtr Next;
-		internal ExternalMemoryHandleTypeFlagsKhr HandleType;
+		internal ExternalMemoryHandleTypeFlags HandleType;
 		internal int Fd;
 	}
 
@@ -1353,7 +2072,7 @@ namespace Vulkan.Interop
 		internal StructureType SType;
 		internal IntPtr Next;
 		internal UInt64 Memory;
-		internal ExternalMemoryHandleTypeFlagsKhr HandleType;
+		internal ExternalMemoryHandleTypeFlags HandleType;
 	}
 
 	internal partial struct Win32KeyedMutexAcquireReleaseInfoKhr
@@ -1369,27 +2088,114 @@ namespace Vulkan.Interop
 		internal IntPtr ReleaseKeys;
 	}
 
+	internal partial struct PhysicalDeviceExternalSemaphoreInfo
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal ExternalSemaphoreHandleTypeFlags HandleType;
+	}
+
 	internal partial struct PhysicalDeviceExternalSemaphoreInfoKhr
 	{
 		internal StructureType SType;
 		internal IntPtr Next;
-		internal ExternalSemaphoreHandleTypeFlagsKhr HandleType;
+		internal ExternalSemaphoreHandleTypeFlags HandleType;
+
+		public static implicit operator PhysicalDeviceExternalSemaphoreInfoKhr (PhysicalDeviceExternalSemaphoreInfo that) {
+			var ret = new PhysicalDeviceExternalSemaphoreInfoKhr {
+				SType = that.SType,
+				Next = that.Next,
+				HandleType = that.HandleType,
+			};
+
+			return ret;
+		}
+
+		public static implicit operator PhysicalDeviceExternalSemaphoreInfo (PhysicalDeviceExternalSemaphoreInfoKhr that) {
+			var ret = new PhysicalDeviceExternalSemaphoreInfo {
+				SType = that.SType,
+				Next = that.Next,
+				HandleType = that.HandleType,
+			};
+
+			return ret;
+		}
+	}
+
+	internal partial struct ExternalSemaphoreProperties
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal ExternalSemaphoreHandleTypeFlags ExportFromImportedHandleTypes;
+		internal ExternalSemaphoreHandleTypeFlags CompatibleHandleTypes;
+		internal ExternalSemaphoreFeatureFlags ExternalSemaphoreFeatures;
 	}
 
 	internal partial struct ExternalSemaphorePropertiesKhr
 	{
 		internal StructureType SType;
 		internal IntPtr Next;
-		internal ExternalSemaphoreHandleTypeFlagsKhr ExportFromImportedHandleTypes;
-		internal ExternalSemaphoreHandleTypeFlagsKhr CompatibleHandleTypes;
-		internal ExternalSemaphoreFeatureFlagsKhr ExternalSemaphoreFeatures;
+		internal ExternalSemaphoreHandleTypeFlags ExportFromImportedHandleTypes;
+		internal ExternalSemaphoreHandleTypeFlags CompatibleHandleTypes;
+		internal ExternalSemaphoreFeatureFlags ExternalSemaphoreFeatures;
+
+		public static implicit operator ExternalSemaphorePropertiesKhr (ExternalSemaphoreProperties that) {
+			var ret = new ExternalSemaphorePropertiesKhr {
+				SType = that.SType,
+				Next = that.Next,
+				ExportFromImportedHandleTypes = that.ExportFromImportedHandleTypes,
+				CompatibleHandleTypes = that.CompatibleHandleTypes,
+				ExternalSemaphoreFeatures = that.ExternalSemaphoreFeatures,
+			};
+
+			return ret;
+		}
+
+		public static implicit operator ExternalSemaphoreProperties (ExternalSemaphorePropertiesKhr that) {
+			var ret = new ExternalSemaphoreProperties {
+				SType = that.SType,
+				Next = that.Next,
+				ExportFromImportedHandleTypes = that.ExportFromImportedHandleTypes,
+				CompatibleHandleTypes = that.CompatibleHandleTypes,
+				ExternalSemaphoreFeatures = that.ExternalSemaphoreFeatures,
+			};
+
+			return ret;
+		}
+	}
+
+	internal partial struct ExportSemaphoreCreateInfo
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal ExternalSemaphoreHandleTypeFlags HandleTypes;
 	}
 
 	internal partial struct ExportSemaphoreCreateInfoKhr
 	{
 		internal StructureType SType;
 		internal IntPtr Next;
-		internal ExternalSemaphoreHandleTypeFlagsKhr HandleTypes;
+		internal ExternalSemaphoreHandleTypeFlags HandleTypes;
+
+		public static implicit operator ExportSemaphoreCreateInfoKhr (ExportSemaphoreCreateInfo that) {
+			var ret = new ExportSemaphoreCreateInfoKhr {
+				SType = that.SType,
+				Next = that.Next,
+				HandleTypes = that.HandleTypes,
+			};
+
+			return ret;
+		}
+
+		public static implicit operator ExportSemaphoreCreateInfo (ExportSemaphoreCreateInfoKhr that) {
+			var ret = new ExportSemaphoreCreateInfo {
+				SType = that.SType,
+				Next = that.Next,
+				HandleTypes = that.HandleTypes,
+			};
+
+			return ret;
+		}
 	}
 
 	internal partial struct D3D12FenceSubmitInfoKhr
@@ -1407,7 +2213,7 @@ namespace Vulkan.Interop
 		internal StructureType SType;
 		internal IntPtr Next;
 		internal UInt64 Semaphore;
-		internal ExternalSemaphoreHandleTypeFlagsKhr HandleType;
+		internal ExternalSemaphoreHandleTypeFlags HandleType;
 	}
 
 	internal partial struct ImportSemaphoreFdInfoKhr
@@ -1415,8 +2221,8 @@ namespace Vulkan.Interop
 		internal StructureType SType;
 		internal IntPtr Next;
 		internal UInt64 Semaphore;
-		internal SemaphoreImportFlagsKhr Flags;
-		internal ExternalSemaphoreHandleTypeFlagsKhr HandleType;
+		internal SemaphoreImportFlags Flags;
+		internal ExternalSemaphoreHandleTypeFlags HandleType;
 		internal int Fd;
 	}
 
@@ -1425,30 +2231,117 @@ namespace Vulkan.Interop
 		internal StructureType SType;
 		internal IntPtr Next;
 		internal UInt64 Semaphore;
-		internal ExternalSemaphoreHandleTypeFlagsKhr HandleType;
+		internal ExternalSemaphoreHandleTypeFlags HandleType;
+	}
+
+	internal partial struct PhysicalDeviceExternalFenceInfo
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal ExternalFenceHandleTypeFlags HandleType;
 	}
 
 	internal partial struct PhysicalDeviceExternalFenceInfoKhr
 	{
 		internal StructureType SType;
 		internal IntPtr Next;
-		internal ExternalFenceHandleTypeFlagsKhr HandleType;
+		internal ExternalFenceHandleTypeFlags HandleType;
+
+		public static implicit operator PhysicalDeviceExternalFenceInfoKhr (PhysicalDeviceExternalFenceInfo that) {
+			var ret = new PhysicalDeviceExternalFenceInfoKhr {
+				SType = that.SType,
+				Next = that.Next,
+				HandleType = that.HandleType,
+			};
+
+			return ret;
+		}
+
+		public static implicit operator PhysicalDeviceExternalFenceInfo (PhysicalDeviceExternalFenceInfoKhr that) {
+			var ret = new PhysicalDeviceExternalFenceInfo {
+				SType = that.SType,
+				Next = that.Next,
+				HandleType = that.HandleType,
+			};
+
+			return ret;
+		}
+	}
+
+	internal partial struct ExternalFenceProperties
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal ExternalFenceHandleTypeFlags ExportFromImportedHandleTypes;
+		internal ExternalFenceHandleTypeFlags CompatibleHandleTypes;
+		internal ExternalFenceFeatureFlags ExternalFenceFeatures;
 	}
 
 	internal partial struct ExternalFencePropertiesKhr
 	{
 		internal StructureType SType;
 		internal IntPtr Next;
-		internal ExternalFenceHandleTypeFlagsKhr ExportFromImportedHandleTypes;
-		internal ExternalFenceHandleTypeFlagsKhr CompatibleHandleTypes;
-		internal ExternalFenceFeatureFlagsKhr ExternalFenceFeatures;
+		internal ExternalFenceHandleTypeFlags ExportFromImportedHandleTypes;
+		internal ExternalFenceHandleTypeFlags CompatibleHandleTypes;
+		internal ExternalFenceFeatureFlags ExternalFenceFeatures;
+
+		public static implicit operator ExternalFencePropertiesKhr (ExternalFenceProperties that) {
+			var ret = new ExternalFencePropertiesKhr {
+				SType = that.SType,
+				Next = that.Next,
+				ExportFromImportedHandleTypes = that.ExportFromImportedHandleTypes,
+				CompatibleHandleTypes = that.CompatibleHandleTypes,
+				ExternalFenceFeatures = that.ExternalFenceFeatures,
+			};
+
+			return ret;
+		}
+
+		public static implicit operator ExternalFenceProperties (ExternalFencePropertiesKhr that) {
+			var ret = new ExternalFenceProperties {
+				SType = that.SType,
+				Next = that.Next,
+				ExportFromImportedHandleTypes = that.ExportFromImportedHandleTypes,
+				CompatibleHandleTypes = that.CompatibleHandleTypes,
+				ExternalFenceFeatures = that.ExternalFenceFeatures,
+			};
+
+			return ret;
+		}
+	}
+
+	internal partial struct ExportFenceCreateInfo
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal ExternalFenceHandleTypeFlags HandleTypes;
 	}
 
 	internal partial struct ExportFenceCreateInfoKhr
 	{
 		internal StructureType SType;
 		internal IntPtr Next;
-		internal ExternalFenceHandleTypeFlagsKhr HandleTypes;
+		internal ExternalFenceHandleTypeFlags HandleTypes;
+
+		public static implicit operator ExportFenceCreateInfoKhr (ExportFenceCreateInfo that) {
+			var ret = new ExportFenceCreateInfoKhr {
+				SType = that.SType,
+				Next = that.Next,
+				HandleTypes = that.HandleTypes,
+			};
+
+			return ret;
+		}
+
+		public static implicit operator ExportFenceCreateInfo (ExportFenceCreateInfoKhr that) {
+			var ret = new ExportFenceCreateInfo {
+				SType = that.SType,
+				Next = that.Next,
+				HandleTypes = that.HandleTypes,
+			};
+
+			return ret;
+		}
 	}
 
 	internal partial struct FenceGetWin32HandleInfoKhr
@@ -1456,7 +2349,7 @@ namespace Vulkan.Interop
 		internal StructureType SType;
 		internal IntPtr Next;
 		internal UInt64 Fence;
-		internal ExternalFenceHandleTypeFlagsKhr HandleType;
+		internal ExternalFenceHandleTypeFlags HandleType;
 	}
 
 	internal partial struct ImportFenceFdInfoKhr
@@ -1464,8 +2357,8 @@ namespace Vulkan.Interop
 		internal StructureType SType;
 		internal IntPtr Next;
 		internal UInt64 Fence;
-		internal FenceImportFlagsKhr Flags;
-		internal ExternalFenceHandleTypeFlagsKhr HandleType;
+		internal FenceImportFlags Flags;
+		internal ExternalFenceHandleTypeFlags HandleType;
 		internal int Fd;
 	}
 
@@ -1474,10 +2367,10 @@ namespace Vulkan.Interop
 		internal StructureType SType;
 		internal IntPtr Next;
 		internal UInt64 Fence;
-		internal ExternalFenceHandleTypeFlagsKhr HandleType;
+		internal ExternalFenceHandleTypeFlags HandleType;
 	}
 
-	internal partial struct PhysicalDeviceMultiviewFeaturesKhx
+	internal partial struct PhysicalDeviceMultiviewFeatures
 	{
 		internal StructureType SType;
 		internal IntPtr Next;
@@ -1486,7 +2379,40 @@ namespace Vulkan.Interop
 		internal Bool32 MultiviewTessellationShader;
 	}
 
-	internal partial struct PhysicalDeviceMultiviewPropertiesKhx
+	internal partial struct PhysicalDeviceMultiviewFeaturesKhr
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal Bool32 Multiview;
+		internal Bool32 MultiviewGeometryShader;
+		internal Bool32 MultiviewTessellationShader;
+
+		public static implicit operator PhysicalDeviceMultiviewFeaturesKhr (PhysicalDeviceMultiviewFeatures that) {
+			var ret = new PhysicalDeviceMultiviewFeaturesKhr {
+				SType = that.SType,
+				Next = that.Next,
+				Multiview = that.Multiview,
+				MultiviewGeometryShader = that.MultiviewGeometryShader,
+				MultiviewTessellationShader = that.MultiviewTessellationShader,
+			};
+
+			return ret;
+		}
+
+		public static implicit operator PhysicalDeviceMultiviewFeatures (PhysicalDeviceMultiviewFeaturesKhr that) {
+			var ret = new PhysicalDeviceMultiviewFeatures {
+				SType = that.SType,
+				Next = that.Next,
+				Multiview = that.Multiview,
+				MultiviewGeometryShader = that.MultiviewGeometryShader,
+				MultiviewTessellationShader = that.MultiviewTessellationShader,
+			};
+
+			return ret;
+		}
+	}
+
+	internal partial struct PhysicalDeviceMultiviewProperties
 	{
 		internal StructureType SType;
 		internal IntPtr Next;
@@ -1494,7 +2420,37 @@ namespace Vulkan.Interop
 		internal UInt32 MaxMultiviewInstanceIndex;
 	}
 
-	internal partial struct RenderPassMultiviewCreateInfoKhx
+	internal partial struct PhysicalDeviceMultiviewPropertiesKhr
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal UInt32 MaxMultiviewViewCount;
+		internal UInt32 MaxMultiviewInstanceIndex;
+
+		public static implicit operator PhysicalDeviceMultiviewPropertiesKhr (PhysicalDeviceMultiviewProperties that) {
+			var ret = new PhysicalDeviceMultiviewPropertiesKhr {
+				SType = that.SType,
+				Next = that.Next,
+				MaxMultiviewViewCount = that.MaxMultiviewViewCount,
+				MaxMultiviewInstanceIndex = that.MaxMultiviewInstanceIndex,
+			};
+
+			return ret;
+		}
+
+		public static implicit operator PhysicalDeviceMultiviewProperties (PhysicalDeviceMultiviewPropertiesKhr that) {
+			var ret = new PhysicalDeviceMultiviewProperties {
+				SType = that.SType,
+				Next = that.Next,
+				MaxMultiviewViewCount = that.MaxMultiviewViewCount,
+				MaxMultiviewInstanceIndex = that.MaxMultiviewInstanceIndex,
+			};
+
+			return ret;
+		}
+	}
+
+	internal partial struct RenderPassMultiviewCreateInfo
 	{
 		internal StructureType SType;
 		internal IntPtr Next;
@@ -1504,6 +2460,48 @@ namespace Vulkan.Interop
 		internal IntPtr ViewOffsets;
 		internal UInt32 CorrelationMaskCount;
 		internal IntPtr CorrelationMasks;
+	}
+
+	internal partial struct RenderPassMultiviewCreateInfoKhr
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal UInt32 SubpassCount;
+		internal IntPtr ViewMasks;
+		internal UInt32 DependencyCount;
+		internal IntPtr ViewOffsets;
+		internal UInt32 CorrelationMaskCount;
+		internal IntPtr CorrelationMasks;
+
+		public static implicit operator RenderPassMultiviewCreateInfoKhr (RenderPassMultiviewCreateInfo that) {
+			var ret = new RenderPassMultiviewCreateInfoKhr {
+				SType = that.SType,
+				Next = that.Next,
+				SubpassCount = that.SubpassCount,
+				ViewMasks = that.ViewMasks,
+				DependencyCount = that.DependencyCount,
+				ViewOffsets = that.ViewOffsets,
+				CorrelationMaskCount = that.CorrelationMaskCount,
+				CorrelationMasks = that.CorrelationMasks,
+			};
+
+			return ret;
+		}
+
+		public static implicit operator RenderPassMultiviewCreateInfo (RenderPassMultiviewCreateInfoKhr that) {
+			var ret = new RenderPassMultiviewCreateInfo {
+				SType = that.SType,
+				Next = that.Next,
+				SubpassCount = that.SubpassCount,
+				ViewMasks = that.ViewMasks,
+				DependencyCount = that.DependencyCount,
+				ViewOffsets = that.ViewOffsets,
+				CorrelationMaskCount = that.CorrelationMaskCount,
+				CorrelationMasks = that.CorrelationMasks,
+			};
+
+			return ret;
+		}
 	}
 
 	internal partial struct SurfaceCapabilities2Ext
@@ -1551,12 +2549,51 @@ namespace Vulkan.Interop
 		internal SurfaceCounterFlagsExt SurfaceCounters;
 	}
 
-	internal partial struct MemoryAllocateFlagsInfoKhx
+	internal partial struct MemoryAllocateFlagsInfo
 	{
 		internal StructureType SType;
 		internal IntPtr Next;
-		internal MemoryAllocateFlagsKhx Flags;
+		internal MemoryAllocateFlags Flags;
 		internal UInt32 DeviceMask;
+	}
+
+	internal partial struct MemoryAllocateFlagsInfoKhr
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal MemoryAllocateFlags Flags;
+		internal UInt32 DeviceMask;
+
+		public static implicit operator MemoryAllocateFlagsInfoKhr (MemoryAllocateFlagsInfo that) {
+			var ret = new MemoryAllocateFlagsInfoKhr {
+				SType = that.SType,
+				Next = that.Next,
+				Flags = that.Flags,
+				DeviceMask = that.DeviceMask,
+			};
+
+			return ret;
+		}
+
+		public static implicit operator MemoryAllocateFlagsInfo (MemoryAllocateFlagsInfoKhr that) {
+			var ret = new MemoryAllocateFlagsInfo {
+				SType = that.SType,
+				Next = that.Next,
+				Flags = that.Flags,
+				DeviceMask = that.DeviceMask,
+			};
+
+			return ret;
+		}
+	}
+
+	internal partial struct BindBufferMemoryInfo
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal UInt64 Buffer;
+		internal UInt64 Memory;
+		internal DeviceSize MemoryOffset;
 	}
 
 	internal partial struct BindBufferMemoryInfoKhr
@@ -1566,14 +2603,77 @@ namespace Vulkan.Interop
 		internal UInt64 Buffer;
 		internal UInt64 Memory;
 		internal DeviceSize MemoryOffset;
+
+		public static implicit operator BindBufferMemoryInfoKhr (BindBufferMemoryInfo that) {
+			var ret = new BindBufferMemoryInfoKhr {
+				SType = that.SType,
+				Next = that.Next,
+				Buffer = that.Buffer,
+				Memory = that.Memory,
+				MemoryOffset = that.MemoryOffset,
+			};
+
+			return ret;
+		}
+
+		public static implicit operator BindBufferMemoryInfo (BindBufferMemoryInfoKhr that) {
+			var ret = new BindBufferMemoryInfo {
+				SType = that.SType,
+				Next = that.Next,
+				Buffer = that.Buffer,
+				Memory = that.Memory,
+				MemoryOffset = that.MemoryOffset,
+			};
+
+			return ret;
+		}
 	}
 
-	internal partial struct BindBufferMemoryDeviceGroupInfoKhx
+	internal partial struct BindBufferMemoryDeviceGroupInfo
 	{
 		internal StructureType SType;
 		internal IntPtr Next;
 		internal UInt32 DeviceIndexCount;
 		internal IntPtr DeviceIndices;
+	}
+
+	internal partial struct BindBufferMemoryDeviceGroupInfoKhr
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal UInt32 DeviceIndexCount;
+		internal IntPtr DeviceIndices;
+
+		public static implicit operator BindBufferMemoryDeviceGroupInfoKhr (BindBufferMemoryDeviceGroupInfo that) {
+			var ret = new BindBufferMemoryDeviceGroupInfoKhr {
+				SType = that.SType,
+				Next = that.Next,
+				DeviceIndexCount = that.DeviceIndexCount,
+				DeviceIndices = that.DeviceIndices,
+			};
+
+			return ret;
+		}
+
+		public static implicit operator BindBufferMemoryDeviceGroupInfo (BindBufferMemoryDeviceGroupInfoKhr that) {
+			var ret = new BindBufferMemoryDeviceGroupInfo {
+				SType = that.SType,
+				Next = that.Next,
+				DeviceIndexCount = that.DeviceIndexCount,
+				DeviceIndices = that.DeviceIndices,
+			};
+
+			return ret;
+		}
+	}
+
+	internal partial struct BindImageMemoryInfo
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal UInt64 Image;
+		internal UInt64 Memory;
+		internal DeviceSize MemoryOffset;
 	}
 
 	internal partial struct BindImageMemoryInfoKhr
@@ -1583,19 +2683,79 @@ namespace Vulkan.Interop
 		internal UInt64 Image;
 		internal UInt64 Memory;
 		internal DeviceSize MemoryOffset;
+
+		public static implicit operator BindImageMemoryInfoKhr (BindImageMemoryInfo that) {
+			var ret = new BindImageMemoryInfoKhr {
+				SType = that.SType,
+				Next = that.Next,
+				Image = that.Image,
+				Memory = that.Memory,
+				MemoryOffset = that.MemoryOffset,
+			};
+
+			return ret;
+		}
+
+		public static implicit operator BindImageMemoryInfo (BindImageMemoryInfoKhr that) {
+			var ret = new BindImageMemoryInfo {
+				SType = that.SType,
+				Next = that.Next,
+				Image = that.Image,
+				Memory = that.Memory,
+				MemoryOffset = that.MemoryOffset,
+			};
+
+			return ret;
+		}
 	}
 
-	internal partial struct BindImageMemoryDeviceGroupInfoKhx
+	internal partial struct BindImageMemoryDeviceGroupInfo
 	{
 		internal StructureType SType;
 		internal IntPtr Next;
 		internal UInt32 DeviceIndexCount;
 		internal IntPtr DeviceIndices;
-		internal UInt32 SfrrectCount;
-		internal IntPtr Sfrrects;
+		internal UInt32 SplitInstanceBindRegionCount;
+		internal IntPtr SplitInstanceBindRegions;
 	}
 
-	internal partial struct DeviceGroupRenderPassBeginInfoKhx
+	internal partial struct BindImageMemoryDeviceGroupInfoKhr
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal UInt32 DeviceIndexCount;
+		internal IntPtr DeviceIndices;
+		internal UInt32 SplitInstanceBindRegionCount;
+		internal IntPtr SplitInstanceBindRegions;
+
+		public static implicit operator BindImageMemoryDeviceGroupInfoKhr (BindImageMemoryDeviceGroupInfo that) {
+			var ret = new BindImageMemoryDeviceGroupInfoKhr {
+				SType = that.SType,
+				Next = that.Next,
+				DeviceIndexCount = that.DeviceIndexCount,
+				DeviceIndices = that.DeviceIndices,
+				SplitInstanceBindRegionCount = that.SplitInstanceBindRegionCount,
+				SplitInstanceBindRegions = that.SplitInstanceBindRegions,
+			};
+
+			return ret;
+		}
+
+		public static implicit operator BindImageMemoryDeviceGroupInfo (BindImageMemoryDeviceGroupInfoKhr that) {
+			var ret = new BindImageMemoryDeviceGroupInfo {
+				SType = that.SType,
+				Next = that.Next,
+				DeviceIndexCount = that.DeviceIndexCount,
+				DeviceIndices = that.DeviceIndices,
+				SplitInstanceBindRegionCount = that.SplitInstanceBindRegionCount,
+				SplitInstanceBindRegions = that.SplitInstanceBindRegions,
+			};
+
+			return ret;
+		}
+	}
+
+	internal partial struct DeviceGroupRenderPassBeginInfo
 	{
 		internal StructureType SType;
 		internal IntPtr Next;
@@ -1604,14 +2764,74 @@ namespace Vulkan.Interop
 		internal IntPtr DeviceRenderAreas;
 	}
 
-	internal partial struct DeviceGroupCommandBufferBeginInfoKhx
+	internal partial struct DeviceGroupRenderPassBeginInfoKhr
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal UInt32 DeviceMask;
+		internal UInt32 DeviceRenderAreaCount;
+		internal IntPtr DeviceRenderAreas;
+
+		public static implicit operator DeviceGroupRenderPassBeginInfoKhr (DeviceGroupRenderPassBeginInfo that) {
+			var ret = new DeviceGroupRenderPassBeginInfoKhr {
+				SType = that.SType,
+				Next = that.Next,
+				DeviceMask = that.DeviceMask,
+				DeviceRenderAreaCount = that.DeviceRenderAreaCount,
+				DeviceRenderAreas = that.DeviceRenderAreas,
+			};
+
+			return ret;
+		}
+
+		public static implicit operator DeviceGroupRenderPassBeginInfo (DeviceGroupRenderPassBeginInfoKhr that) {
+			var ret = new DeviceGroupRenderPassBeginInfo {
+				SType = that.SType,
+				Next = that.Next,
+				DeviceMask = that.DeviceMask,
+				DeviceRenderAreaCount = that.DeviceRenderAreaCount,
+				DeviceRenderAreas = that.DeviceRenderAreas,
+			};
+
+			return ret;
+		}
+	}
+
+	internal partial struct DeviceGroupCommandBufferBeginInfo
 	{
 		internal StructureType SType;
 		internal IntPtr Next;
 		internal UInt32 DeviceMask;
 	}
 
-	internal partial struct DeviceGroupSubmitInfoKhx
+	internal partial struct DeviceGroupCommandBufferBeginInfoKhr
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal UInt32 DeviceMask;
+
+		public static implicit operator DeviceGroupCommandBufferBeginInfoKhr (DeviceGroupCommandBufferBeginInfo that) {
+			var ret = new DeviceGroupCommandBufferBeginInfoKhr {
+				SType = that.SType,
+				Next = that.Next,
+				DeviceMask = that.DeviceMask,
+			};
+
+			return ret;
+		}
+
+		public static implicit operator DeviceGroupCommandBufferBeginInfo (DeviceGroupCommandBufferBeginInfoKhr that) {
+			var ret = new DeviceGroupCommandBufferBeginInfo {
+				SType = that.SType,
+				Next = that.Next,
+				DeviceMask = that.DeviceMask,
+			};
+
+			return ret;
+		}
+	}
+
+	internal partial struct DeviceGroupSubmitInfo
 	{
 		internal StructureType SType;
 		internal IntPtr Next;
@@ -1623,7 +2843,49 @@ namespace Vulkan.Interop
 		internal IntPtr SignalSemaphoreDeviceIndices;
 	}
 
-	internal partial struct DeviceGroupBindSparseInfoKhx
+	internal partial struct DeviceGroupSubmitInfoKhr
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal UInt32 WaitSemaphoreCount;
+		internal IntPtr WaitSemaphoreDeviceIndices;
+		internal UInt32 CommandBufferCount;
+		internal IntPtr CommandBufferDeviceMasks;
+		internal UInt32 SignalSemaphoreCount;
+		internal IntPtr SignalSemaphoreDeviceIndices;
+
+		public static implicit operator DeviceGroupSubmitInfoKhr (DeviceGroupSubmitInfo that) {
+			var ret = new DeviceGroupSubmitInfoKhr {
+				SType = that.SType,
+				Next = that.Next,
+				WaitSemaphoreCount = that.WaitSemaphoreCount,
+				WaitSemaphoreDeviceIndices = that.WaitSemaphoreDeviceIndices,
+				CommandBufferCount = that.CommandBufferCount,
+				CommandBufferDeviceMasks = that.CommandBufferDeviceMasks,
+				SignalSemaphoreCount = that.SignalSemaphoreCount,
+				SignalSemaphoreDeviceIndices = that.SignalSemaphoreDeviceIndices,
+			};
+
+			return ret;
+		}
+
+		public static implicit operator DeviceGroupSubmitInfo (DeviceGroupSubmitInfoKhr that) {
+			var ret = new DeviceGroupSubmitInfo {
+				SType = that.SType,
+				Next = that.Next,
+				WaitSemaphoreCount = that.WaitSemaphoreCount,
+				WaitSemaphoreDeviceIndices = that.WaitSemaphoreDeviceIndices,
+				CommandBufferCount = that.CommandBufferCount,
+				CommandBufferDeviceMasks = that.CommandBufferDeviceMasks,
+				SignalSemaphoreCount = that.SignalSemaphoreCount,
+				SignalSemaphoreDeviceIndices = that.SignalSemaphoreDeviceIndices,
+			};
+
+			return ret;
+		}
+	}
+
+	internal partial struct DeviceGroupBindSparseInfo
 	{
 		internal StructureType SType;
 		internal IntPtr Next;
@@ -1631,22 +2893,52 @@ namespace Vulkan.Interop
 		internal UInt32 MemoryDeviceIndex;
 	}
 
-	internal partial struct DeviceGroupPresentCapabilitiesKhx
+	internal partial struct DeviceGroupBindSparseInfoKhr
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal UInt32 ResourceDeviceIndex;
+		internal UInt32 MemoryDeviceIndex;
+
+		public static implicit operator DeviceGroupBindSparseInfoKhr (DeviceGroupBindSparseInfo that) {
+			var ret = new DeviceGroupBindSparseInfoKhr {
+				SType = that.SType,
+				Next = that.Next,
+				ResourceDeviceIndex = that.ResourceDeviceIndex,
+				MemoryDeviceIndex = that.MemoryDeviceIndex,
+			};
+
+			return ret;
+		}
+
+		public static implicit operator DeviceGroupBindSparseInfo (DeviceGroupBindSparseInfoKhr that) {
+			var ret = new DeviceGroupBindSparseInfo {
+				SType = that.SType,
+				Next = that.Next,
+				ResourceDeviceIndex = that.ResourceDeviceIndex,
+				MemoryDeviceIndex = that.MemoryDeviceIndex,
+			};
+
+			return ret;
+		}
+	}
+
+	internal partial struct DeviceGroupPresentCapabilitiesKhr
 	{
 		internal StructureType SType;
 		internal IntPtr Next;
 		internal unsafe fixed UInt32 PresentMask[32];
-		internal DeviceGroupPresentModeFlagsKhx Modes;
+		internal DeviceGroupPresentModeFlagsKhr Modes;
 	}
 
-	internal partial struct ImageSwapchainCreateInfoKhx
+	internal partial struct ImageSwapchainCreateInfoKhr
 	{
 		internal StructureType SType;
 		internal IntPtr Next;
 		internal UInt64 Swapchain;
 	}
 
-	internal partial struct BindImageMemorySwapchainInfoKhx
+	internal partial struct BindImageMemorySwapchainInfoKhr
 	{
 		internal StructureType SType;
 		internal IntPtr Next;
@@ -1654,7 +2946,7 @@ namespace Vulkan.Interop
 		internal UInt32 ImageIndex;
 	}
 
-	internal partial struct AcquireNextImageInfoKhx
+	internal partial struct AcquireNextImageInfoKhr
 	{
 		internal StructureType SType;
 		internal IntPtr Next;
@@ -1665,16 +2957,16 @@ namespace Vulkan.Interop
 		internal UInt32 DeviceMask;
 	}
 
-	internal partial struct DeviceGroupPresentInfoKhx
+	internal partial struct DeviceGroupPresentInfoKhr
 	{
 		internal StructureType SType;
 		internal IntPtr Next;
 		internal UInt32 SwapchainCount;
 		internal IntPtr DeviceMasks;
-		internal DeviceGroupPresentModeFlagsKhx Mode;
+		internal DeviceGroupPresentModeFlagsKhr Mode;
 	}
 
-	internal partial struct DeviceGroupDeviceCreateInfoKhx
+	internal partial struct DeviceGroupDeviceCreateInfo
 	{
 		internal StructureType SType;
 		internal IntPtr Next;
@@ -1682,11 +2974,55 @@ namespace Vulkan.Interop
 		internal IntPtr PhysicalDevices;
 	}
 
-	internal partial struct DeviceGroupSwapchainCreateInfoKhx
+	internal partial struct DeviceGroupDeviceCreateInfoKhr
 	{
 		internal StructureType SType;
 		internal IntPtr Next;
-		internal DeviceGroupPresentModeFlagsKhx Modes;
+		internal UInt32 PhysicalDeviceCount;
+		internal IntPtr PhysicalDevices;
+
+		public static implicit operator DeviceGroupDeviceCreateInfoKhr (DeviceGroupDeviceCreateInfo that) {
+			var ret = new DeviceGroupDeviceCreateInfoKhr {
+				SType = that.SType,
+				Next = that.Next,
+				PhysicalDeviceCount = that.PhysicalDeviceCount,
+				PhysicalDevices = that.PhysicalDevices,
+			};
+
+			return ret;
+		}
+
+		public static implicit operator DeviceGroupDeviceCreateInfo (DeviceGroupDeviceCreateInfoKhr that) {
+			var ret = new DeviceGroupDeviceCreateInfo {
+				SType = that.SType,
+				Next = that.Next,
+				PhysicalDeviceCount = that.PhysicalDeviceCount,
+				PhysicalDevices = that.PhysicalDevices,
+			};
+
+			return ret;
+		}
+	}
+
+	internal partial struct DeviceGroupSwapchainCreateInfoKhr
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal DeviceGroupPresentModeFlagsKhr Modes;
+	}
+
+	internal partial struct DescriptorUpdateTemplateCreateInfo
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal UInt32 Flags;
+		internal UInt32 DescriptorUpdateEntryCount;
+		internal IntPtr DescriptorUpdateEntries;
+		internal DescriptorUpdateTemplateType TemplateType;
+		internal UInt64 DescriptorSetLayout;
+		internal PipelineBindPoint PipelineBindPoint;
+		internal UInt64 PipelineLayout;
+		internal UInt32 Set;
 	}
 
 	internal partial struct DescriptorUpdateTemplateCreateInfoKhr
@@ -1696,11 +3032,45 @@ namespace Vulkan.Interop
 		internal UInt32 Flags;
 		internal UInt32 DescriptorUpdateEntryCount;
 		internal IntPtr DescriptorUpdateEntries;
-		internal DescriptorUpdateTemplateTypeKhr TemplateType;
+		internal DescriptorUpdateTemplateType TemplateType;
 		internal UInt64 DescriptorSetLayout;
 		internal PipelineBindPoint PipelineBindPoint;
 		internal UInt64 PipelineLayout;
 		internal UInt32 Set;
+
+		public static implicit operator DescriptorUpdateTemplateCreateInfoKhr (DescriptorUpdateTemplateCreateInfo that) {
+			var ret = new DescriptorUpdateTemplateCreateInfoKhr {
+				SType = that.SType,
+				Next = that.Next,
+				Flags = that.Flags,
+				DescriptorUpdateEntryCount = that.DescriptorUpdateEntryCount,
+				DescriptorUpdateEntries = that.DescriptorUpdateEntries,
+				TemplateType = that.TemplateType,
+				DescriptorSetLayout = that.DescriptorSetLayout,
+				PipelineBindPoint = that.PipelineBindPoint,
+				PipelineLayout = that.PipelineLayout,
+				Set = that.Set,
+			};
+
+			return ret;
+		}
+
+		public static implicit operator DescriptorUpdateTemplateCreateInfo (DescriptorUpdateTemplateCreateInfoKhr that) {
+			var ret = new DescriptorUpdateTemplateCreateInfo {
+				SType = that.SType,
+				Next = that.Next,
+				Flags = that.Flags,
+				DescriptorUpdateEntryCount = that.DescriptorUpdateEntryCount,
+				DescriptorUpdateEntries = that.DescriptorUpdateEntries,
+				TemplateType = that.TemplateType,
+				DescriptorSetLayout = that.DescriptorSetLayout,
+				PipelineBindPoint = that.PipelineBindPoint,
+				PipelineLayout = that.PipelineLayout,
+				Set = that.Set,
+			};
+
+			return ret;
+		}
 	}
 
 	internal partial struct HdrMetadataExt
@@ -1715,6 +3085,20 @@ namespace Vulkan.Interop
 		internal float MinLuminance;
 		internal float MaxContentLightLevel;
 		internal float MaxFrameAverageLightLevel;
+	}
+
+	internal partial struct DisplayNativeHdrSurfaceCapabilitiesAmd
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal Bool32 LocalDimmingSupport;
+	}
+
+	internal partial struct SwapchainDisplayNativeHdrCreateInfoAmd
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal Bool32 LocalDimmingEnable;
 	}
 
 	internal partial struct PresentTimesInfoGoogle
@@ -1783,12 +3167,42 @@ namespace Vulkan.Interop
 		internal Bool32 PerViewPositionAllComponents;
 	}
 
+	internal partial struct RenderPassInputAttachmentAspectCreateInfo
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal UInt32 AspectReferenceCount;
+		internal IntPtr AspectReferences;
+	}
+
 	internal partial struct RenderPassInputAttachmentAspectCreateInfoKhr
 	{
 		internal StructureType SType;
 		internal IntPtr Next;
 		internal UInt32 AspectReferenceCount;
 		internal IntPtr AspectReferences;
+
+		public static implicit operator RenderPassInputAttachmentAspectCreateInfoKhr (RenderPassInputAttachmentAspectCreateInfo that) {
+			var ret = new RenderPassInputAttachmentAspectCreateInfoKhr {
+				SType = that.SType,
+				Next = that.Next,
+				AspectReferenceCount = that.AspectReferenceCount,
+				AspectReferences = that.AspectReferences,
+			};
+
+			return ret;
+		}
+
+		public static implicit operator RenderPassInputAttachmentAspectCreateInfo (RenderPassInputAttachmentAspectCreateInfoKhr that) {
+			var ret = new RenderPassInputAttachmentAspectCreateInfo {
+				SType = that.SType,
+				Next = that.Next,
+				AspectReferenceCount = that.AspectReferenceCount,
+				AspectReferences = that.AspectReferences,
+			};
+
+			return ret;
+		}
 	}
 
 	internal partial struct PhysicalDeviceSurfaceInfo2Khr
@@ -1812,11 +3226,57 @@ namespace Vulkan.Interop
 		internal SurfaceFormatKhr SurfaceFormat;
 	}
 
+	internal partial struct DisplayProperties2Khr
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal DisplayPropertiesKhr DisplayProperties;
+	}
+
+	internal partial struct DisplayPlaneProperties2Khr
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal DisplayPlanePropertiesKhr DisplayPlaneProperties;
+	}
+
+	internal partial struct DisplayModeProperties2Khr
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal DisplayModePropertiesKhr DisplayModeProperties;
+	}
+
+	internal partial struct DisplayPlaneInfo2Khr
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal UInt64 Mode;
+		internal UInt32 PlaneIndex;
+	}
+
+	internal partial struct DisplayPlaneCapabilities2Khr
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal DisplayPlaneCapabilitiesKhr Capabilities;
+	}
+
 	internal partial struct SharedPresentSurfaceCapabilitiesKhr
 	{
 		internal StructureType SType;
 		internal IntPtr Next;
 		internal ImageUsageFlags SharedPresentSupportedUsageFlags;
+	}
+
+	internal partial struct PhysicalDevice16BitStorageFeatures
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal Bool32 StorageBuffer16BitAccess;
+		internal Bool32 UniformAndStorageBuffer16BitAccess;
+		internal Bool32 StoragePushConstant16;
+		internal Bool32 StorageInputOutput16;
 	}
 
 	internal partial struct PhysicalDevice16BitStorageFeaturesKhr
@@ -1827,6 +3287,49 @@ namespace Vulkan.Interop
 		internal Bool32 UniformAndStorageBuffer16BitAccess;
 		internal Bool32 StoragePushConstant16;
 		internal Bool32 StorageInputOutput16;
+
+		public static implicit operator PhysicalDevice16BitStorageFeaturesKhr (PhysicalDevice16BitStorageFeatures that) {
+			var ret = new PhysicalDevice16BitStorageFeaturesKhr {
+				SType = that.SType,
+				Next = that.Next,
+				StorageBuffer16BitAccess = that.StorageBuffer16BitAccess,
+				UniformAndStorageBuffer16BitAccess = that.UniformAndStorageBuffer16BitAccess,
+				StoragePushConstant16 = that.StoragePushConstant16,
+				StorageInputOutput16 = that.StorageInputOutput16,
+			};
+
+			return ret;
+		}
+
+		public static implicit operator PhysicalDevice16BitStorageFeatures (PhysicalDevice16BitStorageFeaturesKhr that) {
+			var ret = new PhysicalDevice16BitStorageFeatures {
+				SType = that.SType,
+				Next = that.Next,
+				StorageBuffer16BitAccess = that.StorageBuffer16BitAccess,
+				UniformAndStorageBuffer16BitAccess = that.UniformAndStorageBuffer16BitAccess,
+				StoragePushConstant16 = that.StoragePushConstant16,
+				StorageInputOutput16 = that.StorageInputOutput16,
+			};
+
+			return ret;
+		}
+	}
+
+	internal partial struct PhysicalDeviceSubgroupProperties
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal UInt32 SubgroupSize;
+		internal ShaderStageFlags SupportedStages;
+		internal SubgroupFeatureFlags SupportedOperations;
+		internal Bool32 QuadOperationsInAllStages;
+	}
+
+	internal partial struct BufferMemoryRequirementsInfo2
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal UInt64 Buffer;
 	}
 
 	internal partial struct BufferMemoryRequirementsInfo2Khr
@@ -1834,9 +3337,63 @@ namespace Vulkan.Interop
 		internal StructureType SType;
 		internal IntPtr Next;
 		internal UInt64 Buffer;
+
+		public static implicit operator BufferMemoryRequirementsInfo2Khr (BufferMemoryRequirementsInfo2 that) {
+			var ret = new BufferMemoryRequirementsInfo2Khr {
+				SType = that.SType,
+				Next = that.Next,
+				Buffer = that.Buffer,
+			};
+
+			return ret;
+		}
+
+		public static implicit operator BufferMemoryRequirementsInfo2 (BufferMemoryRequirementsInfo2Khr that) {
+			var ret = new BufferMemoryRequirementsInfo2 {
+				SType = that.SType,
+				Next = that.Next,
+				Buffer = that.Buffer,
+			};
+
+			return ret;
+		}
+	}
+
+	internal partial struct ImageMemoryRequirementsInfo2
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal UInt64 Image;
 	}
 
 	internal partial struct ImageMemoryRequirementsInfo2Khr
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal UInt64 Image;
+
+		public static implicit operator ImageMemoryRequirementsInfo2Khr (ImageMemoryRequirementsInfo2 that) {
+			var ret = new ImageMemoryRequirementsInfo2Khr {
+				SType = that.SType,
+				Next = that.Next,
+				Image = that.Image,
+			};
+
+			return ret;
+		}
+
+		public static implicit operator ImageMemoryRequirementsInfo2 (ImageMemoryRequirementsInfo2Khr that) {
+			var ret = new ImageMemoryRequirementsInfo2 {
+				SType = that.SType,
+				Next = that.Next,
+				Image = that.Image,
+			};
+
+			return ret;
+		}
+	}
+
+	internal partial struct ImageSparseMemoryRequirementsInfo2
 	{
 		internal StructureType SType;
 		internal IntPtr Next;
@@ -1848,6 +3405,33 @@ namespace Vulkan.Interop
 		internal StructureType SType;
 		internal IntPtr Next;
 		internal UInt64 Image;
+
+		public static implicit operator ImageSparseMemoryRequirementsInfo2Khr (ImageSparseMemoryRequirementsInfo2 that) {
+			var ret = new ImageSparseMemoryRequirementsInfo2Khr {
+				SType = that.SType,
+				Next = that.Next,
+				Image = that.Image,
+			};
+
+			return ret;
+		}
+
+		public static implicit operator ImageSparseMemoryRequirementsInfo2 (ImageSparseMemoryRequirementsInfo2Khr that) {
+			var ret = new ImageSparseMemoryRequirementsInfo2 {
+				SType = that.SType,
+				Next = that.Next,
+				Image = that.Image,
+			};
+
+			return ret;
+		}
+	}
+
+	internal partial struct MemoryRequirements2
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal MemoryRequirements MemoryRequirements;
 	}
 
 	internal partial struct MemoryRequirements2Khr
@@ -1855,6 +3439,33 @@ namespace Vulkan.Interop
 		internal StructureType SType;
 		internal IntPtr Next;
 		internal MemoryRequirements MemoryRequirements;
+
+		public static implicit operator MemoryRequirements2Khr (MemoryRequirements2 that) {
+			var ret = new MemoryRequirements2Khr {
+				SType = that.SType,
+				Next = that.Next,
+				MemoryRequirements = that.MemoryRequirements,
+			};
+
+			return ret;
+		}
+
+		public static implicit operator MemoryRequirements2 (MemoryRequirements2Khr that) {
+			var ret = new MemoryRequirements2 {
+				SType = that.SType,
+				Next = that.Next,
+				MemoryRequirements = that.MemoryRequirements,
+			};
+
+			return ret;
+		}
+	}
+
+	internal partial struct SparseImageMemoryRequirements2
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal SparseImageMemoryRequirements MemoryRequirements;
 	}
 
 	internal partial struct SparseImageMemoryRequirements2Khr
@@ -1862,13 +3473,68 @@ namespace Vulkan.Interop
 		internal StructureType SType;
 		internal IntPtr Next;
 		internal SparseImageMemoryRequirements MemoryRequirements;
+
+		public static implicit operator SparseImageMemoryRequirements2Khr (SparseImageMemoryRequirements2 that) {
+			var ret = new SparseImageMemoryRequirements2Khr {
+				SType = that.SType,
+				Next = that.Next,
+				MemoryRequirements = that.MemoryRequirements,
+			};
+
+			return ret;
+		}
+
+		public static implicit operator SparseImageMemoryRequirements2 (SparseImageMemoryRequirements2Khr that) {
+			var ret = new SparseImageMemoryRequirements2 {
+				SType = that.SType,
+				Next = that.Next,
+				MemoryRequirements = that.MemoryRequirements,
+			};
+
+			return ret;
+		}
+	}
+
+	internal partial struct PhysicalDevicePointClippingProperties
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal PointClippingBehavior PointClippingBehavior;
 	}
 
 	internal partial struct PhysicalDevicePointClippingPropertiesKhr
 	{
 		internal StructureType SType;
 		internal IntPtr Next;
-		internal PointClippingBehaviorKhr PointClippingBehavior;
+		internal PointClippingBehavior PointClippingBehavior;
+
+		public static implicit operator PhysicalDevicePointClippingPropertiesKhr (PhysicalDevicePointClippingProperties that) {
+			var ret = new PhysicalDevicePointClippingPropertiesKhr {
+				SType = that.SType,
+				Next = that.Next,
+				PointClippingBehavior = that.PointClippingBehavior,
+			};
+
+			return ret;
+		}
+
+		public static implicit operator PhysicalDevicePointClippingProperties (PhysicalDevicePointClippingPropertiesKhr that) {
+			var ret = new PhysicalDevicePointClippingProperties {
+				SType = that.SType,
+				Next = that.Next,
+				PointClippingBehavior = that.PointClippingBehavior,
+			};
+
+			return ret;
+		}
+	}
+
+	internal partial struct MemoryDedicatedRequirements
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal Bool32 PrefersDedicatedAllocation;
+		internal Bool32 RequiresDedicatedAllocation;
 	}
 
 	internal partial struct MemoryDedicatedRequirementsKhr
@@ -1877,6 +3543,36 @@ namespace Vulkan.Interop
 		internal IntPtr Next;
 		internal Bool32 PrefersDedicatedAllocation;
 		internal Bool32 RequiresDedicatedAllocation;
+
+		public static implicit operator MemoryDedicatedRequirementsKhr (MemoryDedicatedRequirements that) {
+			var ret = new MemoryDedicatedRequirementsKhr {
+				SType = that.SType,
+				Next = that.Next,
+				PrefersDedicatedAllocation = that.PrefersDedicatedAllocation,
+				RequiresDedicatedAllocation = that.RequiresDedicatedAllocation,
+			};
+
+			return ret;
+		}
+
+		public static implicit operator MemoryDedicatedRequirements (MemoryDedicatedRequirementsKhr that) {
+			var ret = new MemoryDedicatedRequirements {
+				SType = that.SType,
+				Next = that.Next,
+				PrefersDedicatedAllocation = that.PrefersDedicatedAllocation,
+				RequiresDedicatedAllocation = that.RequiresDedicatedAllocation,
+			};
+
+			return ret;
+		}
+	}
+
+	internal partial struct MemoryDedicatedAllocateInfo
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal UInt64 Image;
+		internal UInt64 Buffer;
 	}
 
 	internal partial struct MemoryDedicatedAllocateInfoKhr
@@ -1885,6 +3581,35 @@ namespace Vulkan.Interop
 		internal IntPtr Next;
 		internal UInt64 Image;
 		internal UInt64 Buffer;
+
+		public static implicit operator MemoryDedicatedAllocateInfoKhr (MemoryDedicatedAllocateInfo that) {
+			var ret = new MemoryDedicatedAllocateInfoKhr {
+				SType = that.SType,
+				Next = that.Next,
+				Image = that.Image,
+				Buffer = that.Buffer,
+			};
+
+			return ret;
+		}
+
+		public static implicit operator MemoryDedicatedAllocateInfo (MemoryDedicatedAllocateInfoKhr that) {
+			var ret = new MemoryDedicatedAllocateInfo {
+				SType = that.SType,
+				Next = that.Next,
+				Image = that.Image,
+				Buffer = that.Buffer,
+			};
+
+			return ret;
+		}
+	}
+
+	internal partial struct ImageViewUsageCreateInfo
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal ImageUsageFlags Usage;
 	}
 
 	internal partial struct ImageViewUsageCreateInfoKhr
@@ -1892,13 +3617,67 @@ namespace Vulkan.Interop
 		internal StructureType SType;
 		internal IntPtr Next;
 		internal ImageUsageFlags Usage;
+
+		public static implicit operator ImageViewUsageCreateInfoKhr (ImageViewUsageCreateInfo that) {
+			var ret = new ImageViewUsageCreateInfoKhr {
+				SType = that.SType,
+				Next = that.Next,
+				Usage = that.Usage,
+			};
+
+			return ret;
+		}
+
+		public static implicit operator ImageViewUsageCreateInfo (ImageViewUsageCreateInfoKhr that) {
+			var ret = new ImageViewUsageCreateInfo {
+				SType = that.SType,
+				Next = that.Next,
+				Usage = that.Usage,
+			};
+
+			return ret;
+		}
+	}
+
+	internal partial struct PipelineTessellationDomainOriginStateCreateInfo
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal TessellationDomainOrigin DomainOrigin;
 	}
 
 	internal partial struct PipelineTessellationDomainOriginStateCreateInfoKhr
 	{
 		internal StructureType SType;
 		internal IntPtr Next;
-		internal TessellationDomainOriginKhr DomainOrigin;
+		internal TessellationDomainOrigin DomainOrigin;
+
+		public static implicit operator PipelineTessellationDomainOriginStateCreateInfoKhr (PipelineTessellationDomainOriginStateCreateInfo that) {
+			var ret = new PipelineTessellationDomainOriginStateCreateInfoKhr {
+				SType = that.SType,
+				Next = that.Next,
+				DomainOrigin = that.DomainOrigin,
+			};
+
+			return ret;
+		}
+
+		public static implicit operator PipelineTessellationDomainOriginStateCreateInfo (PipelineTessellationDomainOriginStateCreateInfoKhr that) {
+			var ret = new PipelineTessellationDomainOriginStateCreateInfo {
+				SType = that.SType,
+				Next = that.Next,
+				DomainOrigin = that.DomainOrigin,
+			};
+
+			return ret;
+		}
+	}
+
+	internal partial struct SamplerYcbcrConversionInfo
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal UInt64 Conversion;
 	}
 
 	internal partial struct SamplerYcbcrConversionInfoKhr
@@ -1906,6 +3685,40 @@ namespace Vulkan.Interop
 		internal StructureType SType;
 		internal IntPtr Next;
 		internal UInt64 Conversion;
+
+		public static implicit operator SamplerYcbcrConversionInfoKhr (SamplerYcbcrConversionInfo that) {
+			var ret = new SamplerYcbcrConversionInfoKhr {
+				SType = that.SType,
+				Next = that.Next,
+				Conversion = that.Conversion,
+			};
+
+			return ret;
+		}
+
+		public static implicit operator SamplerYcbcrConversionInfo (SamplerYcbcrConversionInfoKhr that) {
+			var ret = new SamplerYcbcrConversionInfo {
+				SType = that.SType,
+				Next = that.Next,
+				Conversion = that.Conversion,
+			};
+
+			return ret;
+		}
+	}
+
+	internal partial struct SamplerYcbcrConversionCreateInfo
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal Format Format;
+		internal SamplerYcbcrModelConversion YcbcrModel;
+		internal SamplerYcbcrRange YcbcrRange;
+		internal ComponentMapping Components;
+		internal ChromaLocation XChromaOffset;
+		internal ChromaLocation YChromaOffset;
+		internal Filter ChromaFilter;
+		internal Bool32 ForceExplicitReconstruction;
 	}
 
 	internal partial struct SamplerYcbcrConversionCreateInfoKhr
@@ -1913,16 +3726,84 @@ namespace Vulkan.Interop
 		internal StructureType SType;
 		internal IntPtr Next;
 		internal Format Format;
-		internal SamplerYcbcrModelConversionKhr YcbcrModel;
-		internal SamplerYcbcrRangeKhr YcbcrRange;
+		internal SamplerYcbcrModelConversion YcbcrModel;
+		internal SamplerYcbcrRange YcbcrRange;
 		internal ComponentMapping Components;
-		internal ChromaLocationKhr XChromaOffset;
-		internal ChromaLocationKhr YChromaOffset;
+		internal ChromaLocation XChromaOffset;
+		internal ChromaLocation YChromaOffset;
 		internal Filter ChromaFilter;
 		internal Bool32 ForceExplicitReconstruction;
+
+		public static implicit operator SamplerYcbcrConversionCreateInfoKhr (SamplerYcbcrConversionCreateInfo that) {
+			var ret = new SamplerYcbcrConversionCreateInfoKhr {
+				SType = that.SType,
+				Next = that.Next,
+				Format = that.Format,
+				YcbcrModel = that.YcbcrModel,
+				YcbcrRange = that.YcbcrRange,
+				Components = that.Components,
+				XChromaOffset = that.XChromaOffset,
+				YChromaOffset = that.YChromaOffset,
+				ChromaFilter = that.ChromaFilter,
+				ForceExplicitReconstruction = that.ForceExplicitReconstruction,
+			};
+
+			return ret;
+		}
+
+		public static implicit operator SamplerYcbcrConversionCreateInfo (SamplerYcbcrConversionCreateInfoKhr that) {
+			var ret = new SamplerYcbcrConversionCreateInfo {
+				SType = that.SType,
+				Next = that.Next,
+				Format = that.Format,
+				YcbcrModel = that.YcbcrModel,
+				YcbcrRange = that.YcbcrRange,
+				Components = that.Components,
+				XChromaOffset = that.XChromaOffset,
+				YChromaOffset = that.YChromaOffset,
+				ChromaFilter = that.ChromaFilter,
+				ForceExplicitReconstruction = that.ForceExplicitReconstruction,
+			};
+
+			return ret;
+		}
+	}
+
+	internal partial struct BindImagePlaneMemoryInfo
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal ImageAspectFlags PlaneAspect;
 	}
 
 	internal partial struct BindImagePlaneMemoryInfoKhr
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal ImageAspectFlags PlaneAspect;
+
+		public static implicit operator BindImagePlaneMemoryInfoKhr (BindImagePlaneMemoryInfo that) {
+			var ret = new BindImagePlaneMemoryInfoKhr {
+				SType = that.SType,
+				Next = that.Next,
+				PlaneAspect = that.PlaneAspect,
+			};
+
+			return ret;
+		}
+
+		public static implicit operator BindImagePlaneMemoryInfo (BindImagePlaneMemoryInfoKhr that) {
+			var ret = new BindImagePlaneMemoryInfo {
+				SType = that.SType,
+				Next = that.Next,
+				PlaneAspect = that.PlaneAspect,
+			};
+
+			return ret;
+		}
+	}
+
+	internal partial struct ImagePlaneMemoryRequirementsInfo
 	{
 		internal StructureType SType;
 		internal IntPtr Next;
@@ -1934,6 +3815,33 @@ namespace Vulkan.Interop
 		internal StructureType SType;
 		internal IntPtr Next;
 		internal ImageAspectFlags PlaneAspect;
+
+		public static implicit operator ImagePlaneMemoryRequirementsInfoKhr (ImagePlaneMemoryRequirementsInfo that) {
+			var ret = new ImagePlaneMemoryRequirementsInfoKhr {
+				SType = that.SType,
+				Next = that.Next,
+				PlaneAspect = that.PlaneAspect,
+			};
+
+			return ret;
+		}
+
+		public static implicit operator ImagePlaneMemoryRequirementsInfo (ImagePlaneMemoryRequirementsInfoKhr that) {
+			var ret = new ImagePlaneMemoryRequirementsInfo {
+				SType = that.SType,
+				Next = that.Next,
+				PlaneAspect = that.PlaneAspect,
+			};
+
+			return ret;
+		}
+	}
+
+	internal partial struct PhysicalDeviceSamplerYcbcrConversionFeatures
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal Bool32 SamplerYcbcrConversion;
 	}
 
 	internal partial struct PhysicalDeviceSamplerYcbcrConversionFeaturesKhr
@@ -1941,6 +3849,33 @@ namespace Vulkan.Interop
 		internal StructureType SType;
 		internal IntPtr Next;
 		internal Bool32 SamplerYcbcrConversion;
+
+		public static implicit operator PhysicalDeviceSamplerYcbcrConversionFeaturesKhr (PhysicalDeviceSamplerYcbcrConversionFeatures that) {
+			var ret = new PhysicalDeviceSamplerYcbcrConversionFeaturesKhr {
+				SType = that.SType,
+				Next = that.Next,
+				SamplerYcbcrConversion = that.SamplerYcbcrConversion,
+			};
+
+			return ret;
+		}
+
+		public static implicit operator PhysicalDeviceSamplerYcbcrConversionFeatures (PhysicalDeviceSamplerYcbcrConversionFeaturesKhr that) {
+			var ret = new PhysicalDeviceSamplerYcbcrConversionFeatures {
+				SType = that.SType,
+				Next = that.Next,
+				SamplerYcbcrConversion = that.SamplerYcbcrConversion,
+			};
+
+			return ret;
+		}
+	}
+
+	internal partial struct SamplerYcbcrConversionImageFormatProperties
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal UInt32 CombinedImageSamplerDescriptorCount;
 	}
 
 	internal partial struct SamplerYcbcrConversionImageFormatPropertiesKhr
@@ -1948,6 +3883,26 @@ namespace Vulkan.Interop
 		internal StructureType SType;
 		internal IntPtr Next;
 		internal UInt32 CombinedImageSamplerDescriptorCount;
+
+		public static implicit operator SamplerYcbcrConversionImageFormatPropertiesKhr (SamplerYcbcrConversionImageFormatProperties that) {
+			var ret = new SamplerYcbcrConversionImageFormatPropertiesKhr {
+				SType = that.SType,
+				Next = that.Next,
+				CombinedImageSamplerDescriptorCount = that.CombinedImageSamplerDescriptorCount,
+			};
+
+			return ret;
+		}
+
+		public static implicit operator SamplerYcbcrConversionImageFormatProperties (SamplerYcbcrConversionImageFormatPropertiesKhr that) {
+			var ret = new SamplerYcbcrConversionImageFormatProperties {
+				SType = that.SType,
+				Next = that.Next,
+				CombinedImageSamplerDescriptorCount = that.CombinedImageSamplerDescriptorCount,
+			};
+
+			return ret;
+		}
 	}
 
 	internal partial struct TextureLODGatherFormatPropertiesAmd
@@ -1955,6 +3910,45 @@ namespace Vulkan.Interop
 		internal StructureType SType;
 		internal IntPtr Next;
 		internal Bool32 SupportsTextureGatherLodbiasAmd;
+	}
+
+	internal partial struct ConditionalRenderingBeginInfoExt
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal UInt64 Buffer;
+		internal DeviceSize Offset;
+		internal ConditionalRenderingFlagsExt Flags;
+	}
+
+	internal partial struct ProtectedSubmitInfo
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal Bool32 ProtectedSubmit;
+	}
+
+	internal partial struct PhysicalDeviceProtectedMemoryFeatures
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal Bool32 ProtectedMemory;
+	}
+
+	internal partial struct PhysicalDeviceProtectedMemoryProperties
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal Bool32 ProtectedNoFault;
+	}
+
+	internal partial struct DeviceQueueInfo2
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal DeviceQueueCreateFlags Flags;
+		internal UInt32 QueueFamilyIndex;
+		internal UInt32 QueueIndex;
 	}
 
 	internal partial struct PipelineCoverageToColorStateCreateInfoNv
@@ -2067,6 +4061,40 @@ namespace Vulkan.Interop
 		internal BlendOverlapExt BlendOverlap;
 	}
 
+	internal partial struct PhysicalDeviceInlineUniformBlockFeaturesExt
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal Bool32 InlineUniformBlock;
+		internal Bool32 DescriptorBindingInlineUniformBlockUpdateAfterBind;
+	}
+
+	internal partial struct PhysicalDeviceInlineUniformBlockPropertiesExt
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal UInt32 MaxInlineUniformBlockSize;
+		internal UInt32 MaxPerStageDescriptorInlineUniformBlocks;
+		internal UInt32 MaxPerStageDescriptorUpdateAfterBindInlineUniformBlocks;
+		internal UInt32 MaxDescriptorSetInlineUniformBlocks;
+		internal UInt32 MaxDescriptorSetUpdateAfterBindInlineUniformBlocks;
+	}
+
+	internal partial struct WriteDescriptorSetInlineUniformBlockExt
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal UInt32 DataSize;
+		internal IntPtr Data;
+	}
+
+	internal partial struct DescriptorPoolInlineUniformBlockCreateInfoExt
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal UInt32 MaxInlineUniformBlockBindings;
+	}
+
 	internal partial struct PipelineCoverageModulationStateCreateInfoNv
 	{
 		internal StructureType SType;
@@ -2102,6 +4130,150 @@ namespace Vulkan.Interop
 		internal UInt64 ValidationCache;
 	}
 
+	internal partial struct PhysicalDeviceMaintenance3Properties
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal UInt32 MaxPerSetDescriptors;
+		internal DeviceSize MaxMemoryAllocationSize;
+	}
+
+	internal partial struct PhysicalDeviceMaintenance3PropertiesKhr
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal UInt32 MaxPerSetDescriptors;
+		internal DeviceSize MaxMemoryAllocationSize;
+
+		public static implicit operator PhysicalDeviceMaintenance3PropertiesKhr (PhysicalDeviceMaintenance3Properties that) {
+			var ret = new PhysicalDeviceMaintenance3PropertiesKhr {
+				SType = that.SType,
+				Next = that.Next,
+				MaxPerSetDescriptors = that.MaxPerSetDescriptors,
+				MaxMemoryAllocationSize = that.MaxMemoryAllocationSize,
+			};
+
+			return ret;
+		}
+
+		public static implicit operator PhysicalDeviceMaintenance3Properties (PhysicalDeviceMaintenance3PropertiesKhr that) {
+			var ret = new PhysicalDeviceMaintenance3Properties {
+				SType = that.SType,
+				Next = that.Next,
+				MaxPerSetDescriptors = that.MaxPerSetDescriptors,
+				MaxMemoryAllocationSize = that.MaxMemoryAllocationSize,
+			};
+
+			return ret;
+		}
+	}
+
+	internal partial struct DescriptorSetLayoutSupport
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal Bool32 Supported;
+	}
+
+	internal partial struct DescriptorSetLayoutSupportKhr
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal Bool32 Supported;
+
+		public static implicit operator DescriptorSetLayoutSupportKhr (DescriptorSetLayoutSupport that) {
+			var ret = new DescriptorSetLayoutSupportKhr {
+				SType = that.SType,
+				Next = that.Next,
+				Supported = that.Supported,
+			};
+
+			return ret;
+		}
+
+		public static implicit operator DescriptorSetLayoutSupport (DescriptorSetLayoutSupportKhr that) {
+			var ret = new DescriptorSetLayoutSupport {
+				SType = that.SType,
+				Next = that.Next,
+				Supported = that.Supported,
+			};
+
+			return ret;
+		}
+	}
+
+	internal partial struct PhysicalDeviceShaderDrawParametersFeatures
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal Bool32 ShaderDrawParameters;
+	}
+
+	internal partial struct PhysicalDeviceShaderDrawParameterFeatures
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal Bool32 ShaderDrawParameters;
+
+		public static implicit operator PhysicalDeviceShaderDrawParameterFeatures (PhysicalDeviceShaderDrawParametersFeatures that) {
+			var ret = new PhysicalDeviceShaderDrawParameterFeatures {
+				SType = that.SType,
+				Next = that.Next,
+				ShaderDrawParameters = that.ShaderDrawParameters,
+			};
+
+			return ret;
+		}
+
+		public static implicit operator PhysicalDeviceShaderDrawParametersFeatures (PhysicalDeviceShaderDrawParameterFeatures that) {
+			var ret = new PhysicalDeviceShaderDrawParametersFeatures {
+				SType = that.SType,
+				Next = that.Next,
+				ShaderDrawParameters = that.ShaderDrawParameters,
+			};
+
+			return ret;
+		}
+	}
+
+	internal partial struct PhysicalDeviceFloat16Int8FeaturesKhr
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal Bool32 ShaderFloat16;
+		internal Bool32 ShaderInt8;
+	}
+
+	internal partial struct PhysicalDeviceFloatControlsPropertiesKhr
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal Bool32 SeparateDenormSettings;
+		internal Bool32 SeparateRoundingModeSettings;
+		internal Bool32 ShaderSignedZeroInfNanPreserveFloat16;
+		internal Bool32 ShaderSignedZeroInfNanPreserveFloat32;
+		internal Bool32 ShaderSignedZeroInfNanPreserveFloat64;
+		internal Bool32 ShaderDenormPreserveFloat16;
+		internal Bool32 ShaderDenormPreserveFloat32;
+		internal Bool32 ShaderDenormPreserveFloat64;
+		internal Bool32 ShaderDenormFlushToZeroFloat16;
+		internal Bool32 ShaderDenormFlushToZeroFloat32;
+		internal Bool32 ShaderDenormFlushToZeroFloat64;
+		internal Bool32 ShaderRoundingModeRtefloat16;
+		internal Bool32 ShaderRoundingModeRtefloat32;
+		internal Bool32 ShaderRoundingModeRtefloat64;
+		internal Bool32 ShaderRoundingModeRtzfloat16;
+		internal Bool32 ShaderRoundingModeRtzfloat32;
+		internal Bool32 ShaderRoundingModeRtzfloat64;
+	}
+
+	internal partial struct PhysicalDeviceHostQueryResetFeaturesExt
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal Bool32 HostQueryReset;
+	}
+
 	internal partial struct ShaderStatisticsInfoAmd
 	{
 		internal ShaderStageFlags ShaderStageMask;
@@ -2120,11 +4292,66 @@ namespace Vulkan.Interop
 		internal QueueGlobalPriorityExt GlobalPriority;
 	}
 
+	internal partial struct DebugUtilsObjectNameInfoExt
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal ObjectType ObjectType;
+		internal UInt64 ObjectHandle;
+		internal IntPtr ObjectName;
+	}
+
+	internal partial struct DebugUtilsObjectTagInfoExt
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal ObjectType ObjectType;
+		internal UInt64 ObjectHandle;
+		internal UInt64 TagName;
+		internal UIntPtr TagSize;
+		internal IntPtr Tag;
+	}
+
+	internal partial struct DebugUtilsLabelExt
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal IntPtr LabelName;
+		internal unsafe fixed float Color[4];
+	}
+
+	internal partial struct DebugUtilsMessengerCreateInfoExt
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal UInt32 Flags;
+		internal DebugUtilsMessageSeverityFlagsExt MessageSeverity;
+		internal DebugUtilsMessageTypeFlagsExt MessageType;
+		internal IntPtr PfnUserCallback;
+		internal IntPtr UserData;
+	}
+
+	internal partial struct DebugUtilsMessengerCallbackDataExt
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal UInt32 Flags;
+		internal IntPtr MessageIdName;
+		internal Int32 MessageIdNumber;
+		internal IntPtr Message;
+		internal UInt32 QueueLabelCount;
+		internal IntPtr QueueLabels;
+		internal UInt32 CmdBufLabelCount;
+		internal IntPtr CmdBufLabels;
+		internal UInt32 ObjectCount;
+		internal IntPtr Objects;
+	}
+
 	internal partial struct ImportMemoryHostPointerInfoExt
 	{
 		internal StructureType SType;
 		internal IntPtr Next;
-		internal ExternalMemoryHandleTypeFlagsKhr HandleType;
+		internal ExternalMemoryHandleTypeFlags HandleType;
 		internal IntPtr HostPointer;
 	}
 
@@ -2157,6 +4384,33 @@ namespace Vulkan.Interop
 		internal Bool32 ConservativeRasterizationPostDepthCoverage;
 	}
 
+	internal partial struct CalibratedTimestampInfoExt
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal TimeDomainExt TimeDomain;
+	}
+
+	internal partial struct PhysicalDeviceShaderCorePropertiesAmd
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal UInt32 ShaderEngineCount;
+		internal UInt32 ShaderArraysPerEngineCount;
+		internal UInt32 ComputeUnitsPerShaderArray;
+		internal UInt32 SimdPerComputeUnit;
+		internal UInt32 WavefrontsPerSimd;
+		internal UInt32 WavefrontSize;
+		internal UInt32 SgprsPerSimd;
+		internal UInt32 MinSgprAllocation;
+		internal UInt32 MaxSgprAllocation;
+		internal UInt32 SgprAllocationGranularity;
+		internal UInt32 VgprsPerSimd;
+		internal UInt32 MinVgprAllocation;
+		internal UInt32 MaxVgprAllocation;
+		internal UInt32 VgprAllocationGranularity;
+	}
+
 	internal partial struct PipelineRasterizationConservativeStateCreateInfoExt
 	{
 		internal StructureType SType;
@@ -2164,5 +4418,1029 @@ namespace Vulkan.Interop
 		internal UInt32 Flags;
 		internal ConservativeRasterizationModeExt ConservativeRasterizationMode;
 		internal float ExtraPrimitiveOverestimationSize;
+	}
+
+	internal partial struct PhysicalDeviceDescriptorIndexingFeaturesExt
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal Bool32 ShaderInputAttachmentArrayDynamicIndexing;
+		internal Bool32 ShaderUniformTexelBufferArrayDynamicIndexing;
+		internal Bool32 ShaderStorageTexelBufferArrayDynamicIndexing;
+		internal Bool32 ShaderUniformBufferArrayNonUniformIndexing;
+		internal Bool32 ShaderSampledImageArrayNonUniformIndexing;
+		internal Bool32 ShaderStorageBufferArrayNonUniformIndexing;
+		internal Bool32 ShaderStorageImageArrayNonUniformIndexing;
+		internal Bool32 ShaderInputAttachmentArrayNonUniformIndexing;
+		internal Bool32 ShaderUniformTexelBufferArrayNonUniformIndexing;
+		internal Bool32 ShaderStorageTexelBufferArrayNonUniformIndexing;
+		internal Bool32 DescriptorBindingUniformBufferUpdateAfterBind;
+		internal Bool32 DescriptorBindingSampledImageUpdateAfterBind;
+		internal Bool32 DescriptorBindingStorageImageUpdateAfterBind;
+		internal Bool32 DescriptorBindingStorageBufferUpdateAfterBind;
+		internal Bool32 DescriptorBindingUniformTexelBufferUpdateAfterBind;
+		internal Bool32 DescriptorBindingStorageTexelBufferUpdateAfterBind;
+		internal Bool32 DescriptorBindingUpdateUnusedWhilePending;
+		internal Bool32 DescriptorBindingPartiallyBound;
+		internal Bool32 DescriptorBindingVariableDescriptorCount;
+		internal Bool32 RuntimeDescriptorArray;
+	}
+
+	internal partial struct PhysicalDeviceDescriptorIndexingPropertiesExt
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal UInt32 MaxUpdateAfterBindDescriptorsInAllPools;
+		internal Bool32 ShaderUniformBufferArrayNonUniformIndexingNative;
+		internal Bool32 ShaderSampledImageArrayNonUniformIndexingNative;
+		internal Bool32 ShaderStorageBufferArrayNonUniformIndexingNative;
+		internal Bool32 ShaderStorageImageArrayNonUniformIndexingNative;
+		internal Bool32 ShaderInputAttachmentArrayNonUniformIndexingNative;
+		internal Bool32 RobustBufferAccessUpdateAfterBind;
+		internal Bool32 QuadDivergentImplicitLod;
+		internal UInt32 MaxPerStageDescriptorUpdateAfterBindSamplers;
+		internal UInt32 MaxPerStageDescriptorUpdateAfterBindUniformBuffers;
+		internal UInt32 MaxPerStageDescriptorUpdateAfterBindStorageBuffers;
+		internal UInt32 MaxPerStageDescriptorUpdateAfterBindSampledImages;
+		internal UInt32 MaxPerStageDescriptorUpdateAfterBindStorageImages;
+		internal UInt32 MaxPerStageDescriptorUpdateAfterBindInputAttachments;
+		internal UInt32 MaxPerStageUpdateAfterBindResources;
+		internal UInt32 MaxDescriptorSetUpdateAfterBindSamplers;
+		internal UInt32 MaxDescriptorSetUpdateAfterBindUniformBuffers;
+		internal UInt32 MaxDescriptorSetUpdateAfterBindUniformBuffersDynamic;
+		internal UInt32 MaxDescriptorSetUpdateAfterBindStorageBuffers;
+		internal UInt32 MaxDescriptorSetUpdateAfterBindStorageBuffersDynamic;
+		internal UInt32 MaxDescriptorSetUpdateAfterBindSampledImages;
+		internal UInt32 MaxDescriptorSetUpdateAfterBindStorageImages;
+		internal UInt32 MaxDescriptorSetUpdateAfterBindInputAttachments;
+	}
+
+	internal partial struct DescriptorSetLayoutBindingFlagsCreateInfoExt
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal UInt32 BindingCount;
+		internal IntPtr BindingFlags;
+	}
+
+	internal partial struct DescriptorSetVariableDescriptorCountAllocateInfoExt
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal UInt32 DescriptorSetCount;
+		internal IntPtr DescriptorCounts;
+	}
+
+	internal partial struct DescriptorSetVariableDescriptorCountLayoutSupportExt
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal UInt32 MaxVariableDescriptorCount;
+	}
+
+	internal partial struct AttachmentDescription2Khr
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal AttachmentDescriptionFlags Flags;
+		internal Format Format;
+		internal SampleCountFlags Samples;
+		internal AttachmentLoadOp LoadOp;
+		internal AttachmentStoreOp StoreOp;
+		internal AttachmentLoadOp StencilLoadOp;
+		internal AttachmentStoreOp StencilStoreOp;
+		internal ImageLayout InitialLayout;
+		internal ImageLayout FinalLayout;
+	}
+
+	internal partial struct AttachmentReference2Khr
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal UInt32 Attachment;
+		internal ImageLayout Layout;
+		internal ImageAspectFlags AspectMask;
+	}
+
+	internal partial struct SubpassDescription2Khr
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal SubpassDescriptionFlags Flags;
+		internal PipelineBindPoint PipelineBindPoint;
+		internal UInt32 ViewMask;
+		internal UInt32 InputAttachmentCount;
+		internal IntPtr InputAttachments;
+		internal UInt32 ColorAttachmentCount;
+		internal IntPtr ColorAttachments;
+		internal IntPtr ResolveAttachments;
+		internal IntPtr DepthStencilAttachment;
+		internal UInt32 PreserveAttachmentCount;
+		internal IntPtr PreserveAttachments;
+	}
+
+	internal partial struct SubpassDependency2Khr
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal UInt32 SrcSubpass;
+		internal UInt32 DstSubpass;
+		internal PipelineStageFlags SrcStageMask;
+		internal PipelineStageFlags DstStageMask;
+		internal AccessFlags SrcAccessMask;
+		internal AccessFlags DstAccessMask;
+		internal DependencyFlags DependencyFlags;
+		internal Int32 ViewOffset;
+	}
+
+	internal partial struct RenderPassCreateInfo2Khr
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal UInt32 Flags;
+		internal UInt32 AttachmentCount;
+		internal IntPtr Attachments;
+		internal UInt32 SubpassCount;
+		internal IntPtr Subpasses;
+		internal UInt32 DependencyCount;
+		internal IntPtr Dependencies;
+		internal UInt32 CorrelatedViewMaskCount;
+		internal IntPtr CorrelatedViewMasks;
+	}
+
+	internal partial struct SubpassBeginInfoKhr
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal SubpassContents Contents;
+	}
+
+	internal partial struct SubpassEndInfoKhr
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+	}
+
+	internal partial struct PipelineVertexInputDivisorStateCreateInfoExt
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal UInt32 VertexBindingDivisorCount;
+		internal IntPtr VertexBindingDivisors;
+	}
+
+	internal partial struct PhysicalDeviceVertexAttributeDivisorPropertiesExt
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal UInt32 MaxVertexAttribDivisor;
+	}
+
+	internal partial struct PhysicalDevicePCIBusInfoPropertiesExt
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal UInt32 PciDomain;
+		internal UInt32 PciBus;
+		internal UInt32 PciDevice;
+		internal UInt32 PciFunction;
+	}
+
+	internal partial struct AndroidHardwareBufferUsageAndroid
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal UInt64 AndroidHardwareBufferUsage;
+	}
+
+	internal partial struct AndroidHardwareBufferPropertiesAndroid
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal DeviceSize AllocationSize;
+		internal UInt32 MemoryTypeBits;
+	}
+
+	internal partial struct MemoryGetAndroidHardwareBufferInfoAndroid
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal UInt64 Memory;
+	}
+
+	internal partial struct AndroidHardwareBufferFormatPropertiesAndroid
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal Format Format;
+		internal UInt64 ExternalFormat;
+		internal FormatFeatureFlags FormatFeatures;
+		internal ComponentMapping SamplerYcbcrConversionComponents;
+		internal SamplerYcbcrModelConversion SuggestedYcbcrModel;
+		internal SamplerYcbcrRange SuggestedYcbcrRange;
+		internal ChromaLocation SuggestedXchromaOffset;
+		internal ChromaLocation SuggestedYchromaOffset;
+	}
+
+	internal partial struct CommandBufferInheritanceConditionalRenderingInfoExt
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal Bool32 ConditionalRenderingEnable;
+	}
+
+	internal partial struct ExternalFormatAndroid
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal UInt64 ExternalFormat;
+	}
+
+	internal partial struct PhysicalDevice8BitStorageFeaturesKhr
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal Bool32 StorageBuffer8BitAccess;
+		internal Bool32 UniformAndStorageBuffer8BitAccess;
+		internal Bool32 StoragePushConstant8;
+	}
+
+	internal partial struct PhysicalDeviceConditionalRenderingFeaturesExt
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal Bool32 ConditionalRendering;
+		internal Bool32 InheritedConditionalRendering;
+	}
+
+	internal partial struct PhysicalDeviceVulkanMemoryModelFeaturesKhr
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal Bool32 VulkanMemoryModel;
+		internal Bool32 VulkanMemoryModelDeviceScope;
+		internal Bool32 VulkanMemoryModelAvailabilityVisibilityChains;
+	}
+
+	internal partial struct PhysicalDeviceShaderAtomicInt64FeaturesKhr
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal Bool32 ShaderBufferInt64Atomics;
+		internal Bool32 ShaderSharedInt64Atomics;
+	}
+
+	internal partial struct PhysicalDeviceVertexAttributeDivisorFeaturesExt
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal Bool32 VertexAttributeInstanceRateDivisor;
+		internal Bool32 VertexAttributeInstanceRateZeroDivisor;
+	}
+
+	internal partial struct QueueFamilyCheckpointPropertiesNv
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal PipelineStageFlags CheckpointExecutionStageMask;
+	}
+
+	internal partial struct CheckpointDataNv
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal PipelineStageFlags Stage;
+		internal IntPtr CheckpointMarker;
+	}
+
+	internal partial struct PhysicalDeviceDepthStencilResolvePropertiesKhr
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal ResolveModeFlagsKhr SupportedDepthResolveModes;
+		internal ResolveModeFlagsKhr SupportedStencilResolveModes;
+		internal Bool32 IndependentResolveNone;
+		internal Bool32 IndependentResolve;
+	}
+
+	internal partial struct SubpassDescriptionDepthStencilResolveKhr
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal ResolveModeFlagsKhr DepthResolveMode;
+		internal ResolveModeFlagsKhr StencilResolveMode;
+		internal IntPtr DepthStencilResolveAttachment;
+	}
+
+	internal partial struct ImageViewASTCDecodeModeExt
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal Format DecodeMode;
+	}
+
+	internal partial struct PhysicalDeviceASTCDecodeFeaturesExt
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal Bool32 DecodeModeSharedExponent;
+	}
+
+	internal partial struct PhysicalDeviceTransformFeedbackFeaturesExt
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal Bool32 TransformFeedback;
+		internal Bool32 GeometryStreams;
+	}
+
+	internal partial struct PhysicalDeviceTransformFeedbackPropertiesExt
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal UInt32 MaxTransformFeedbackStreams;
+		internal UInt32 MaxTransformFeedbackBuffers;
+		internal DeviceSize MaxTransformFeedbackBufferSize;
+		internal UInt32 MaxTransformFeedbackStreamDataSize;
+		internal UInt32 MaxTransformFeedbackBufferDataSize;
+		internal UInt32 MaxTransformFeedbackBufferDataStride;
+		internal Bool32 TransformFeedbackQueries;
+		internal Bool32 TransformFeedbackStreamsLinesTriangles;
+		internal Bool32 TransformFeedbackRasterizationStreamSelect;
+		internal Bool32 TransformFeedbackDraw;
+	}
+
+	internal partial struct PipelineRasterizationStateStreamCreateInfoExt
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal UInt32 Flags;
+		internal UInt32 RasterizationStream;
+	}
+
+	internal partial struct PhysicalDeviceRepresentativeFragmentTestFeaturesNv
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal Bool32 RepresentativeFragmentTest;
+	}
+
+	internal partial struct PipelineRepresentativeFragmentTestStateCreateInfoNv
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal Bool32 RepresentativeFragmentTestEnable;
+	}
+
+	internal partial struct PhysicalDeviceExclusiveScissorFeaturesNv
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal Bool32 ExclusiveScissor;
+	}
+
+	internal partial struct PipelineViewportExclusiveScissorStateCreateInfoNv
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal UInt32 ExclusiveScissorCount;
+		internal IntPtr ExclusiveScissors;
+	}
+
+	internal partial struct PhysicalDeviceCornerSampledImageFeaturesNv
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal Bool32 CornerSampledImage;
+	}
+
+	internal partial struct PhysicalDeviceComputeShaderDerivativesFeaturesNv
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal Bool32 ComputeDerivativeGroupQuads;
+		internal Bool32 ComputeDerivativeGroupLinear;
+	}
+
+	internal partial struct PhysicalDeviceFragmentShaderBarycentricFeaturesNv
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal Bool32 FragmentShaderBarycentric;
+	}
+
+	internal partial struct PhysicalDeviceShaderImageFootprintFeaturesNv
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal Bool32 ImageFootprint;
+	}
+
+	internal partial struct PhysicalDeviceDedicatedAllocationImageAliasingFeaturesNv
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal Bool32 DedicatedAllocationImageAliasing;
+	}
+
+	internal partial struct ShadingRatePaletteNv
+	{
+		internal UInt32 ShadingRatePaletteEntryCount;
+		internal IntPtr ShadingRatePaletteEntries;
+	}
+
+	internal partial struct PipelineViewportShadingRateImageStateCreateInfoNv
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal Bool32 ShadingRateImageEnable;
+		internal UInt32 ViewportCount;
+		internal IntPtr ShadingRatePalettes;
+	}
+
+	internal partial struct PhysicalDeviceShadingRateImageFeaturesNv
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal Bool32 ShadingRateImage;
+		internal Bool32 ShadingRateCoarseSampleOrder;
+	}
+
+	internal partial struct PhysicalDeviceShadingRateImagePropertiesNv
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal Extent2D ShadingRateTexelSize;
+		internal UInt32 ShadingRatePaletteSize;
+		internal UInt32 ShadingRateMaxCoarseSamples;
+	}
+
+	internal partial struct CoarseSampleOrderCustomNv
+	{
+		internal ShadingRatePaletteEntryNv ShadingRate;
+		internal UInt32 SampleCount;
+		internal UInt32 SampleLocationCount;
+		internal IntPtr SampleLocations;
+	}
+
+	internal partial struct PipelineViewportCoarseSampleOrderStateCreateInfoNv
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal CoarseSampleOrderTypeNv SampleOrderType;
+		internal UInt32 CustomSampleOrderCount;
+		internal IntPtr CustomSampleOrders;
+	}
+
+	internal partial struct PhysicalDeviceMeshShaderFeaturesNv
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal Bool32 TaskShader;
+		internal Bool32 MeshShader;
+	}
+
+	internal partial struct PhysicalDeviceMeshShaderPropertiesNv
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal UInt32 MaxDrawMeshTasksCount;
+		internal UInt32 MaxTaskWorkGroupInvocations;
+		internal unsafe fixed UInt32 MaxTaskWorkGroupSize[3];
+		internal UInt32 MaxTaskTotalMemorySize;
+		internal UInt32 MaxTaskOutputCount;
+		internal UInt32 MaxMeshWorkGroupInvocations;
+		internal unsafe fixed UInt32 MaxMeshWorkGroupSize[3];
+		internal UInt32 MaxMeshTotalMemorySize;
+		internal UInt32 MaxMeshOutputVertices;
+		internal UInt32 MaxMeshOutputPrimitives;
+		internal UInt32 MaxMeshMultiviewViewCount;
+		internal UInt32 MeshOutputPerVertexGranularity;
+		internal UInt32 MeshOutputPerPrimitiveGranularity;
+	}
+
+	internal partial struct RayTracingShaderGroupCreateInfoNv
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal RayTracingShaderGroupTypeNv Type;
+		internal UInt32 GeneralShader;
+		internal UInt32 ClosestHitShader;
+		internal UInt32 AnyHitShader;
+		internal UInt32 IntersectionShader;
+	}
+
+	internal partial struct RayTracingPipelineCreateInfoNv
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal PipelineCreateFlags Flags;
+		internal UInt32 StageCount;
+		internal IntPtr Stages;
+		internal UInt32 GroupCount;
+		internal IntPtr Groups;
+		internal UInt32 MaxRecursionDepth;
+		internal UInt64 Layout;
+		internal UInt64 BasePipelineHandle;
+		internal Int32 BasePipelineIndex;
+	}
+
+	internal partial struct GeometryTrianglesNv
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal UInt64 VertexData;
+		internal DeviceSize VertexOffset;
+		internal UInt32 VertexCount;
+		internal DeviceSize VertexStride;
+		internal Format VertexFormat;
+		internal UInt64 IndexData;
+		internal DeviceSize IndexOffset;
+		internal UInt32 IndexCount;
+		internal IndexType IndexType;
+		internal UInt64 TransformData;
+		internal DeviceSize TransformOffset;
+	}
+
+	internal partial struct GeometryAABBNv
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal UInt64 AabbData;
+		internal UInt32 NumAabbs;
+		internal UInt32 Stride;
+		internal DeviceSize Offset;
+	}
+
+	internal partial struct GeometryDataNv
+	{
+		internal GeometryTrianglesNv Triangles;
+		internal GeometryAABBNv Aabbs;
+	}
+
+	internal partial struct GeometryNv
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal GeometryTypeNv GeometryType;
+		internal GeometryDataNv Geometry;
+		internal GeometryFlagsNv Flags;
+	}
+
+	internal partial struct AccelerationStructureInfoNv
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal AccelerationStructureTypeNv Type;
+		internal BuildAccelerationStructureFlagsNv Flags;
+		internal UInt32 InstanceCount;
+		internal UInt32 GeometryCount;
+		internal IntPtr Geometries;
+	}
+
+	internal partial struct AccelerationStructureCreateInfoNv
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal DeviceSize CompactedSize;
+		internal AccelerationStructureInfoNv Info;
+	}
+
+	internal partial struct BindAccelerationStructureMemoryInfoNv
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal UInt64 AccelerationStructure;
+		internal UInt64 Memory;
+		internal DeviceSize MemoryOffset;
+		internal UInt32 DeviceIndexCount;
+		internal IntPtr DeviceIndices;
+	}
+
+	internal partial struct WriteDescriptorSetAccelerationStructureNv
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal UInt32 AccelerationStructureCount;
+		internal IntPtr AccelerationStructures;
+	}
+
+	internal partial struct AccelerationStructureMemoryRequirementsInfoNv
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal AccelerationStructureMemoryRequirementsTypeNv Type;
+		internal UInt64 AccelerationStructure;
+	}
+
+	internal partial struct PhysicalDeviceRayTracingPropertiesNv
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal UInt32 ShaderGroupHandleSize;
+		internal UInt32 MaxRecursionDepth;
+		internal UInt32 MaxShaderGroupStride;
+		internal UInt32 ShaderGroupBaseAlignment;
+		internal UInt64 MaxGeometryCount;
+		internal UInt64 MaxInstanceCount;
+		internal UInt64 MaxTriangleCount;
+		internal UInt32 MaxDescriptorSetAccelerationStructures;
+	}
+
+	internal partial struct DrmFormatModifierPropertiesListExt
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal UInt32 DrmFormatModifierCount;
+		internal IntPtr DrmFormatModifierProperties;
+	}
+
+	internal partial struct PhysicalDeviceImageDrmFormatModifierInfoExt
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal UInt64 DrmFormatModifier;
+		internal SharingMode SharingMode;
+		internal UInt32 QueueFamilyIndexCount;
+		internal IntPtr QueueFamilyIndices;
+	}
+
+	internal partial struct ImageDrmFormatModifierListCreateInfoExt
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal UInt32 DrmFormatModifierCount;
+		internal IntPtr DrmFormatModifiers;
+	}
+
+	internal partial struct ImageDrmFormatModifierExplicitCreateInfoExt
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal UInt64 DrmFormatModifier;
+		internal UInt32 DrmFormatModifierPlaneCount;
+		internal IntPtr PlaneLayouts;
+	}
+
+	internal partial struct ImageDrmFormatModifierPropertiesExt
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal UInt64 DrmFormatModifier;
+	}
+
+	internal partial struct ImageStencilUsageCreateInfoExt
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal ImageUsageFlags StencilUsage;
+	}
+
+	internal partial struct DeviceMemoryOverallocationCreateInfoAmd
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal MemoryOverallocationBehaviorAmd OverallocationBehavior;
+	}
+
+	internal partial struct PhysicalDeviceFragmentDensityMapFeaturesExt
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal Bool32 FragmentDensityMap;
+		internal Bool32 FragmentDensityMapDynamic;
+		internal Bool32 FragmentDensityMapNonSubsampledImages;
+	}
+
+	internal partial struct PhysicalDeviceFragmentDensityMapPropertiesExt
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal Extent2D MinFragmentDensityTexelSize;
+		internal Extent2D MaxFragmentDensityTexelSize;
+		internal Bool32 FragmentDensityInvocations;
+	}
+
+	internal partial struct RenderPassFragmentDensityMapCreateInfoExt
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal AttachmentReference FragmentDensityMapAttachment;
+	}
+
+	internal partial struct PhysicalDeviceScalarBlockLayoutFeaturesExt
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal Bool32 ScalarBlockLayout;
+	}
+
+	internal partial struct SurfaceProtectedCapabilitiesKhr
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal Bool32 SupportsProtected;
+	}
+
+	internal partial struct PhysicalDeviceUniformBufferStandardLayoutFeaturesKhr
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal Bool32 UniformBufferStandardLayout;
+	}
+
+	internal partial struct PhysicalDeviceDepthClipEnableFeaturesExt
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal Bool32 DepthClipEnable;
+	}
+
+	internal partial struct PipelineRasterizationDepthClipStateCreateInfoExt
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal UInt32 Flags;
+		internal Bool32 DepthClipEnable;
+	}
+
+	internal partial struct PhysicalDeviceMemoryPriorityFeaturesExt
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal Bool32 MemoryPriority;
+	}
+
+	internal partial struct MemoryPriorityAllocateInfoExt
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal float Priority;
+	}
+
+	internal partial struct PhysicalDeviceBufferDeviceAddressFeaturesExt
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal Bool32 BufferDeviceAddress;
+		internal Bool32 BufferDeviceAddressCaptureReplay;
+		internal Bool32 BufferDeviceAddressMultiDevice;
+	}
+
+	internal partial struct PhysicalDeviceBufferAddressFeaturesExt
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal Bool32 BufferDeviceAddress;
+		internal Bool32 BufferDeviceAddressCaptureReplay;
+		internal Bool32 BufferDeviceAddressMultiDevice;
+
+		public static implicit operator PhysicalDeviceBufferAddressFeaturesExt (PhysicalDeviceBufferDeviceAddressFeaturesExt that) {
+			var ret = new PhysicalDeviceBufferAddressFeaturesExt {
+				SType = that.SType,
+				Next = that.Next,
+				BufferDeviceAddress = that.BufferDeviceAddress,
+				BufferDeviceAddressCaptureReplay = that.BufferDeviceAddressCaptureReplay,
+				BufferDeviceAddressMultiDevice = that.BufferDeviceAddressMultiDevice,
+			};
+
+			return ret;
+		}
+
+		public static implicit operator PhysicalDeviceBufferDeviceAddressFeaturesExt (PhysicalDeviceBufferAddressFeaturesExt that) {
+			var ret = new PhysicalDeviceBufferDeviceAddressFeaturesExt {
+				SType = that.SType,
+				Next = that.Next,
+				BufferDeviceAddress = that.BufferDeviceAddress,
+				BufferDeviceAddressCaptureReplay = that.BufferDeviceAddressCaptureReplay,
+				BufferDeviceAddressMultiDevice = that.BufferDeviceAddressMultiDevice,
+			};
+
+			return ret;
+		}
+	}
+
+	internal partial struct BufferDeviceAddressInfoExt
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal UInt64 Buffer;
+	}
+
+	internal partial struct BufferDeviceAddressCreateInfoExt
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal DeviceAddress DeviceAddress;
+	}
+
+	internal partial struct PhysicalDeviceImageViewImageFormatInfoExt
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal ImageViewType ImageViewType;
+	}
+
+	internal partial struct FilterCubicImageViewImageFormatPropertiesExt
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal Bool32 FilterCubic;
+		internal Bool32 FilterCubicMinmax;
+	}
+
+	internal partial struct PhysicalDeviceCooperativeMatrixFeaturesNv
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal Bool32 CooperativeMatrix;
+		internal Bool32 CooperativeMatrixRobustBufferAccess;
+	}
+
+	internal partial struct PhysicalDeviceCooperativeMatrixPropertiesNv
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal ShaderStageFlags CooperativeMatrixSupportedStages;
+	}
+
+	internal partial struct CooperativeMatrixPropertiesNv
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal UInt32 Msize;
+		internal UInt32 Nsize;
+		internal UInt32 Ksize;
+		internal ComponentTypeNv Atype;
+		internal ComponentTypeNv Btype;
+		internal ComponentTypeNv Ctype;
+		internal ComponentTypeNv Dtype;
+		internal ScopeNv Scope;
+	}
+
+	internal partial struct PhysicalDeviceYcbcrImageArraysFeaturesExt
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal Bool32 YcbcrImageArrays;
+	}
+
+	internal partial struct ImageViewHandleInfoNvx
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal UInt64 ImageView;
+		internal DescriptorType DescriptorType;
+		internal UInt64 Sampler;
+	}
+
+	internal partial struct PresentFrameTokenGGP
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal int FrameToken;
+	}
+
+	internal partial struct PipelineCreationFeedbackCreateInfoExt
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal IntPtr PipelineCreationFeedback;
+		internal UInt32 PipelineStageCreationFeedbackCount;
+		internal IntPtr PipelineStageCreationFeedbacks;
+	}
+
+	internal partial struct SurfaceFullScreenExclusiveInfoExt
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal FullScreenExclusiveExt FullScreenExclusive;
+	}
+
+	internal partial struct SurfaceFullScreenExclusiveWin32InfoExt
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal IntPtr Hmonitor;
+	}
+
+	internal partial struct SurfaceCapabilitiesFullScreenExclusiveExt
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal Bool32 FullScreenExclusiveSupported;
+	}
+
+	internal partial struct HeadlessSurfaceCreateInfoExt
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal UInt32 Flags;
+	}
+
+	internal partial struct PhysicalDeviceCoverageReductionModeFeaturesNv
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal Bool32 CoverageReductionMode;
+	}
+
+	internal partial struct PipelineCoverageReductionStateCreateInfoNv
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal UInt32 Flags;
+		internal CoverageReductionModeNv CoverageReductionMode;
+	}
+
+	internal partial struct FramebufferMixedSamplesCombinationNv
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal CoverageReductionModeNv CoverageReductionMode;
+		internal SampleCountFlags RasterizationSamples;
+		internal SampleCountFlags DepthStencilSamples;
+		internal SampleCountFlags ColorSamples;
+	}
+
+	internal partial struct PhysicalDeviceShaderIntegerFunctions2Intel
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal Bool32 ShaderIntegerFunctions2;
+	}
+
+	internal partial struct PerformanceValueIntel
+	{
+		internal PerformanceValueTypeIntel Type;
+		internal PerformanceValueDataIntel Data;
+	}
+
+	internal partial struct InitializePerformanceApiInfoIntel
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal IntPtr UserData;
+	}
+
+	internal partial struct QueryPoolCreateInfoIntel
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal QueryPoolSamplingModeIntel PerformanceCountersSampling;
+	}
+
+	internal partial struct PerformanceMarkerInfoIntel
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal UInt64 Marker;
+	}
+
+	internal partial struct PerformanceStreamMarkerInfoIntel
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal UInt32 Marker;
+	}
+
+	internal partial struct PerformanceOverrideInfoIntel
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal PerformanceOverrideTypeIntel Type;
+		internal Bool32 Enable;
+		internal UInt64 Parameter;
+	}
+
+	internal partial struct PerformanceConfigurationAcquireInfoIntel
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal PerformanceConfigurationTypeIntel Type;
+	}
+
+	internal partial struct PhysicalDeviceShaderSMBuiltinsPropertiesNv
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal UInt32 ShaderSmcount;
+		internal UInt32 ShaderWarpsPerSm;
+	}
+
+	internal partial struct PhysicalDeviceShaderSMBuiltinsFeaturesNv
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal Bool32 ShaderSmbuiltins;
+	}
+
+	internal partial struct PhysicalDeviceFragmentShaderInterlockFeaturesExt
+	{
+		internal StructureType SType;
+		internal IntPtr Next;
+		internal Bool32 FragmentShaderSampleInterlock;
+		internal Bool32 FragmentShaderPixelInterlock;
+		internal Bool32 FragmentShaderShadingRateInterlock;
 	}
 }

--- a/src/Vulkan/Interop/MarshalUnions.cs
+++ b/src/Vulkan/Interop/MarshalUnions.cs
@@ -27,4 +27,14 @@ namespace Vulkan.Interop
 		[FieldOffset (0)] internal ClearColorValue Color;
 		[FieldOffset (0)] internal ClearDepthStencilValue DepthStencil;
 	}
+
+	[StructLayout (LayoutKind.Explicit)]
+	internal partial struct PerformanceValueDataIntel
+	{
+		[FieldOffset (0)] internal UInt32 Value32;
+		[FieldOffset (0)] internal UInt64 Value64;
+		[FieldOffset (0)] internal float ValueFloat;
+		[FieldOffset (0)] internal Bool32 ValueBool;
+		[FieldOffset (0)] internal IntPtr ValueString;
+	}
 }

--- a/src/Vulkan/Structs.cs
+++ b/src/Vulkan/Structs.cs
@@ -13,6 +13,72 @@ using System.Runtime.InteropServices;
 
 namespace Vulkan
 {
+	unsafe public partial class BaseOutStructure : MarshalledObject
+	{
+		BaseOutStructure lNext;
+		public BaseOutStructure Next {
+			get { return lNext; }
+			set { lNext = value; m->Next = value != null ? (IntPtr)value.m : default(IntPtr); }
+		}
+
+		internal Interop.BaseOutStructure* m {
+			get {
+				return (Interop.BaseOutStructure*)native.Handle;
+			}
+		}
+
+		public BaseOutStructure ()
+		{
+			native = Interop.Structure.Allocate (typeof (Interop.BaseOutStructure));
+			Initialize ();
+		}
+
+		internal BaseOutStructure (NativePointer pointer)
+		{
+			native = pointer;
+			Initialize ();
+		}
+
+
+		internal void Initialize ()
+		{
+		}
+
+	}
+
+	unsafe public partial class BaseInStructure : MarshalledObject
+	{
+		BaseInStructure lNext;
+		public BaseInStructure Next {
+			get { return lNext; }
+			set { lNext = value; m->Next = value != null ? (IntPtr)value.m : default(IntPtr); }
+		}
+
+		internal Interop.BaseInStructure* m {
+			get {
+				return (Interop.BaseInStructure*)native.Handle;
+			}
+		}
+
+		public BaseInStructure ()
+		{
+			native = Interop.Structure.Allocate (typeof (Interop.BaseInStructure));
+			Initialize ();
+		}
+
+		internal BaseInStructure (NativePointer pointer)
+		{
+			native = pointer;
+			Initialize ();
+		}
+
+
+		internal void Initialize ()
+		{
+		}
+
+	}
+
 	unsafe public partial struct Offset2D
 	{
 		public Int32 X;
@@ -130,8 +196,8 @@ namespace Vulkan
 			get { return m->SparseProperties; }
 			set { m->SparseProperties = value; }
 		}
-		internal Interop.PhysicalDeviceProperties* m {
 
+		internal Interop.PhysicalDeviceProperties* m {
 			get {
 				return (Interop.PhysicalDeviceProperties*)native.Handle;
 			}
@@ -168,8 +234,8 @@ namespace Vulkan
 			get { return m->SpecVersion; }
 			set { m->SpecVersion = value; }
 		}
-		internal Interop.ExtensionProperties* m {
 
+		internal Interop.ExtensionProperties* m {
 			get {
 				return (Interop.ExtensionProperties*)native.Handle;
 			}
@@ -208,8 +274,8 @@ namespace Vulkan
 			get { return Marshal.PtrToStringAnsi ((IntPtr)m->Description); }
 			set { Interop.Structure.MarshalFixedSizeString (m->Description, value, 256); }
 		}
-		internal Interop.LayerProperties* m {
 
+		internal Interop.LayerProperties* m {
 			get {
 				return (Interop.LayerProperties*)native.Handle;
 			}
@@ -253,8 +319,8 @@ namespace Vulkan
 			get { return m->ApiVersion; }
 			set { m->ApiVersion = value; }
 		}
-		internal Interop.ApplicationInfo* m {
 
+		internal Interop.ApplicationInfo* m {
 			get {
 				return (Interop.ApplicationInfo*)native.Handle;
 			}
@@ -311,8 +377,8 @@ namespace Vulkan
 			get { return m->PfnInternalFree; }
 			set { m->PfnInternalFree = value; }
 		}
-		internal Interop.AllocationCallbacks* m {
 
+		internal Interop.AllocationCallbacks* m {
 			get {
 				return (Interop.AllocationCallbacks*)native.Handle;
 			}
@@ -332,7 +398,7 @@ namespace Vulkan
 
 	unsafe public partial class DeviceQueueCreateInfo : MarshalledObject
 	{
-		public UInt32 Flags {
+		public DeviceQueueCreateFlags Flags {
 			get { return m->Flags; }
 			set { m->Flags = value; }
 		}
@@ -379,8 +445,8 @@ namespace Vulkan
 				}
 			}
 		}
-		internal Interop.DeviceQueueCreateInfo* m {
 
+		internal Interop.DeviceQueueCreateInfo* m {
 			get {
 				return (Interop.DeviceQueueCreateInfo*)native.Handle;
 			}
@@ -541,8 +607,8 @@ namespace Vulkan
 			get { return (PhysicalDeviceFeatures)Interop.Structure.MarshalPointerToObject (m->EnabledFeatures, typeof (PhysicalDeviceFeatures)); }
 			set { m->EnabledFeatures = Interop.Structure.MarshalObjectToPointer (m->EnabledFeatures, value); }
 		}
-		internal Interop.DeviceCreateInfo* m {
 
+		internal Interop.DeviceCreateInfo* m {
 			get {
 				return (Interop.DeviceCreateInfo*)native.Handle;
 			}
@@ -668,8 +734,8 @@ namespace Vulkan
 				}
 			}
 		}
-		internal Interop.InstanceCreateInfo* m {
 
+		internal Interop.InstanceCreateInfo* m {
 			get {
 				return (Interop.InstanceCreateInfo*)native.Handle;
 			}
@@ -770,8 +836,8 @@ namespace Vulkan
 					}
 			}
 		}
-		internal Interop.PhysicalDeviceMemoryProperties* m {
 
+		internal Interop.PhysicalDeviceMemoryProperties* m {
 			get {
 				return (Interop.PhysicalDeviceMemoryProperties*)native.Handle;
 			}
@@ -800,8 +866,8 @@ namespace Vulkan
 			get { return m->MemoryTypeIndex; }
 			set { m->MemoryTypeIndex = value; }
 		}
-		internal Interop.MemoryAllocateInfo* m {
 
+		internal Interop.MemoryAllocateInfo* m {
 			get {
 				return (Interop.MemoryAllocateInfo*)native.Handle;
 			}
@@ -879,8 +945,8 @@ namespace Vulkan
 			get { return m->Size; }
 			set { m->Size = value; }
 		}
-		internal Interop.MappedMemoryRange* m {
 
+		internal Interop.MappedMemoryRange* m {
 			get {
 				return (Interop.MappedMemoryRange*)native.Handle;
 			}
@@ -939,8 +1005,8 @@ namespace Vulkan
 			get { return m->Range; }
 			set { m->Range = value; }
 		}
-		internal Interop.DescriptorBufferInfo* m {
 
+		internal Interop.DescriptorBufferInfo* m {
 			get {
 				return (Interop.DescriptorBufferInfo*)native.Handle;
 			}
@@ -983,8 +1049,8 @@ namespace Vulkan
 			get { return m->ImageLayout; }
 			set { m->ImageLayout = value; }
 		}
-		internal Interop.DescriptorImageInfo* m {
 
+		internal Interop.DescriptorImageInfo* m {
 			get {
 				return (Interop.DescriptorImageInfo*)native.Handle;
 			}
@@ -1141,8 +1207,8 @@ namespace Vulkan
 				}
 			}
 		}
-		internal Interop.WriteDescriptorSet* m {
 
+		internal Interop.WriteDescriptorSet* m {
 			get {
 				return (Interop.WriteDescriptorSet*)native.Handle;
 			}
@@ -1218,8 +1284,8 @@ namespace Vulkan
 			get { return m->DescriptorCount; }
 			set { m->DescriptorCount = value; }
 		}
-		internal Interop.CopyDescriptorSet* m {
 
+		internal Interop.CopyDescriptorSet* m {
 			get {
 				return (Interop.CopyDescriptorSet*)native.Handle;
 			}
@@ -1304,8 +1370,8 @@ namespace Vulkan
 				}
 			}
 		}
-		internal Interop.BufferCreateInfo* m {
 
+		internal Interop.BufferCreateInfo* m {
 			get {
 				return (Interop.BufferCreateInfo*)native.Handle;
 			}
@@ -1366,8 +1432,8 @@ namespace Vulkan
 			get { return m->Range; }
 			set { m->Range = value; }
 		}
-		internal Interop.BufferViewCreateInfo* m {
 
+		internal Interop.BufferViewCreateInfo* m {
 			get {
 				return (Interop.BufferViewCreateInfo*)native.Handle;
 			}
@@ -1428,8 +1494,8 @@ namespace Vulkan
 			get { return m->DstAccessMask; }
 			set { m->DstAccessMask = value; }
 		}
-		internal Interop.MemoryBarrier* m {
 
+		internal Interop.MemoryBarrier* m {
 			get {
 				return (Interop.MemoryBarrier*)native.Handle;
 			}
@@ -1492,8 +1558,8 @@ namespace Vulkan
 			get { return m->Size; }
 			set { m->Size = value; }
 		}
-		internal Interop.BufferMemoryBarrier* m {
 
+		internal Interop.BufferMemoryBarrier* m {
 			get {
 				return (Interop.BufferMemoryBarrier*)native.Handle;
 			}
@@ -1561,8 +1627,8 @@ namespace Vulkan
 			get { return m->SubresourceRange; }
 			set { m->SubresourceRange = value; }
 		}
-		internal Interop.ImageMemoryBarrier* m {
 
+		internal Interop.ImageMemoryBarrier* m {
 			get {
 				return (Interop.ImageMemoryBarrier*)native.Handle;
 			}
@@ -1682,8 +1748,8 @@ namespace Vulkan
 			get { return m->InitialLayout; }
 			set { m->InitialLayout = value; }
 		}
-		internal Interop.ImageCreateInfo* m {
 
+		internal Interop.ImageCreateInfo* m {
 			get {
 				return (Interop.ImageCreateInfo*)native.Handle;
 			}
@@ -1728,7 +1794,7 @@ namespace Vulkan
 
 	unsafe public partial class ImageViewCreateInfo : MarshalledObject
 	{
-		public UInt32 Flags {
+		public ImageViewCreateFlags Flags {
 			get { return m->Flags; }
 			set { m->Flags = value; }
 		}
@@ -1758,8 +1824,8 @@ namespace Vulkan
 			get { return m->SubresourceRange; }
 			set { m->SubresourceRange = value; }
 		}
-		internal Interop.ImageViewCreateInfo* m {
 
+		internal Interop.ImageViewCreateInfo* m {
 			get {
 				return (Interop.ImageViewCreateInfo*)native.Handle;
 			}
@@ -1819,8 +1885,8 @@ namespace Vulkan
 			get { return m->Flags; }
 			set { m->Flags = value; }
 		}
-		internal Interop.SparseMemoryBind* m {
 
+		internal Interop.SparseMemoryBind* m {
 			get {
 				return (Interop.SparseMemoryBind*)native.Handle;
 			}
@@ -1877,8 +1943,8 @@ namespace Vulkan
 			get { return m->Flags; }
 			set { m->Flags = value; }
 		}
-		internal Interop.SparseImageMemoryBind* m {
 
+		internal Interop.SparseImageMemoryBind* m {
 			get {
 				return (Interop.SparseImageMemoryBind*)native.Handle;
 			}
@@ -1950,8 +2016,8 @@ namespace Vulkan
 				}
 			}
 		}
-		internal Interop.SparseBufferMemoryBindInfo* m {
 
+		internal Interop.SparseBufferMemoryBindInfo* m {
 			get {
 				return (Interop.SparseBufferMemoryBindInfo*)native.Handle;
 			}
@@ -2031,8 +2097,8 @@ namespace Vulkan
 				}
 			}
 		}
-		internal Interop.SparseImageOpaqueMemoryBindInfo* m {
 
+		internal Interop.SparseImageOpaqueMemoryBindInfo* m {
 			get {
 				return (Interop.SparseImageOpaqueMemoryBindInfo*)native.Handle;
 			}
@@ -2112,8 +2178,8 @@ namespace Vulkan
 				}
 			}
 		}
-		internal Interop.SparseImageMemoryBindInfo* m {
 
+		internal Interop.SparseImageMemoryBindInfo* m {
 			get {
 				return (Interop.SparseImageMemoryBindInfo*)native.Handle;
 			}
@@ -2347,8 +2413,8 @@ namespace Vulkan
 				}
 			}
 		}
-		internal Interop.BindSparseInfo* m {
 
+		internal Interop.BindSparseInfo* m {
 			get {
 				return (Interop.BindSparseInfo*)native.Handle;
 			}
@@ -2454,8 +2520,8 @@ namespace Vulkan
 					}
 			}
 		}
-		internal Interop.ImageBlit* m {
 
+		internal Interop.ImageBlit* m {
 			get {
 				return (Interop.ImageBlit*)native.Handle;
 			}
@@ -2536,8 +2602,8 @@ namespace Vulkan
 				}
 			}
 		}
-		internal Interop.ShaderModuleCreateInfo* m {
 
+		internal Interop.ShaderModuleCreateInfo* m {
 			get {
 				return (Interop.ShaderModuleCreateInfo*)native.Handle;
 			}
@@ -2627,8 +2693,8 @@ namespace Vulkan
 				}
 			}
 		}
-		internal Interop.DescriptorSetLayoutBinding* m {
 
+		internal Interop.DescriptorSetLayoutBinding* m {
 			get {
 				return (Interop.DescriptorSetLayoutBinding*)native.Handle;
 			}
@@ -2700,8 +2766,8 @@ namespace Vulkan
 				}
 			}
 		}
-		internal Interop.DescriptorSetLayoutCreateInfo* m {
 
+		internal Interop.DescriptorSetLayoutCreateInfo* m {
 			get {
 				return (Interop.DescriptorSetLayoutCreateInfo*)native.Handle;
 			}
@@ -2790,8 +2856,8 @@ namespace Vulkan
 				}
 			}
 		}
-		internal Interop.DescriptorPoolCreateInfo* m {
 
+		internal Interop.DescriptorPoolCreateInfo* m {
 			get {
 				return (Interop.DescriptorPoolCreateInfo*)native.Handle;
 			}
@@ -2872,8 +2938,8 @@ namespace Vulkan
 				}
 			}
 		}
-		internal Interop.DescriptorSetAllocateInfo* m {
 
+		internal Interop.DescriptorSetAllocateInfo* m {
 			get {
 				return (Interop.DescriptorSetAllocateInfo*)native.Handle;
 			}
@@ -2963,8 +3029,8 @@ namespace Vulkan
 			get { return m->Data; }
 			set { m->Data = value; }
 		}
-		internal Interop.SpecializationInfo* m {
 
+		internal Interop.SpecializationInfo* m {
 			get {
 				return (Interop.SpecializationInfo*)native.Handle;
 			}
@@ -3018,8 +3084,8 @@ namespace Vulkan
 			get { return lSpecializationInfo; }
 			set { lSpecializationInfo = value; m->SpecializationInfo = value != null ? (IntPtr)value.m : default(IntPtr); }
 		}
-		internal Interop.PipelineShaderStageCreateInfo* m {
 
+		internal Interop.PipelineShaderStageCreateInfo* m {
 			get {
 				return (Interop.PipelineShaderStageCreateInfo*)native.Handle;
 			}
@@ -3074,8 +3140,8 @@ namespace Vulkan
 			get { return m->BasePipelineIndex; }
 			set { m->BasePipelineIndex = value; }
 		}
-		internal Interop.ComputePipelineCreateInfo* m {
 
+		internal Interop.ComputePipelineCreateInfo* m {
 			get {
 				return (Interop.ComputePipelineCreateInfo*)native.Handle;
 			}
@@ -3199,8 +3265,8 @@ namespace Vulkan
 				}
 			}
 		}
-		internal Interop.PipelineVertexInputStateCreateInfo* m {
 
+		internal Interop.PipelineVertexInputStateCreateInfo* m {
 			get {
 				return (Interop.PipelineVertexInputStateCreateInfo*)native.Handle;
 			}
@@ -3252,8 +3318,8 @@ namespace Vulkan
 			get { return m->PrimitiveRestartEnable; }
 			set { m->PrimitiveRestartEnable = value; }
 		}
-		internal Interop.PipelineInputAssemblyStateCreateInfo* m {
 
+		internal Interop.PipelineInputAssemblyStateCreateInfo* m {
 			get {
 				return (Interop.PipelineInputAssemblyStateCreateInfo*)native.Handle;
 			}
@@ -3290,8 +3356,8 @@ namespace Vulkan
 			get { return m->PatchControlPoints; }
 			set { m->PatchControlPoints = value; }
 		}
-		internal Interop.PipelineTessellationStateCreateInfo* m {
 
+		internal Interop.PipelineTessellationStateCreateInfo* m {
 			get {
 				return (Interop.PipelineTessellationStateCreateInfo*)native.Handle;
 			}
@@ -3399,8 +3465,8 @@ namespace Vulkan
 				}
 			}
 		}
-		internal Interop.PipelineViewportStateCreateInfo* m {
 
+		internal Interop.PipelineViewportStateCreateInfo* m {
 			get {
 				return (Interop.PipelineViewportStateCreateInfo*)native.Handle;
 			}
@@ -3492,8 +3558,8 @@ namespace Vulkan
 			get { return m->LineWidth; }
 			set { m->LineWidth = value; }
 		}
-		internal Interop.PipelineRasterizationStateCreateInfo* m {
 
+		internal Interop.PipelineRasterizationStateCreateInfo* m {
 			get {
 				return (Interop.PipelineRasterizationStateCreateInfo*)native.Handle;
 			}
@@ -3583,8 +3649,8 @@ namespace Vulkan
 			get { return m->AlphaToOneEnable; }
 			set { m->AlphaToOneEnable = value; }
 		}
-		internal Interop.PipelineMultisampleStateCreateInfo* m {
 
+		internal Interop.PipelineMultisampleStateCreateInfo* m {
 			get {
 				return (Interop.PipelineMultisampleStateCreateInfo*)native.Handle;
 			}
@@ -3702,8 +3768,8 @@ namespace Vulkan
 					m->BlendConstants [i] = 0;
 			}
 		}
-		internal Interop.PipelineColorBlendStateCreateInfo* m {
 
+		internal Interop.PipelineColorBlendStateCreateInfo* m {
 			get {
 				return (Interop.PipelineColorBlendStateCreateInfo*)native.Handle;
 			}
@@ -3781,8 +3847,8 @@ namespace Vulkan
 				}
 			}
 		}
-		internal Interop.PipelineDynamicStateCreateInfo* m {
 
+		internal Interop.PipelineDynamicStateCreateInfo* m {
 			get {
 				return (Interop.PipelineDynamicStateCreateInfo*)native.Handle;
 			}
@@ -3878,8 +3944,8 @@ namespace Vulkan
 			get { return m->MaxDepthBounds; }
 			set { m->MaxDepthBounds = value; }
 		}
-		internal Interop.PipelineDepthStencilStateCreateInfo* m {
 
+		internal Interop.PipelineDepthStencilStateCreateInfo* m {
 			get {
 				return (Interop.PipelineDepthStencilStateCreateInfo*)native.Handle;
 			}
@@ -4033,8 +4099,8 @@ namespace Vulkan
 			get { return m->BasePipelineIndex; }
 			set { m->BasePipelineIndex = value; }
 		}
-		internal Interop.GraphicsPipelineCreateInfo* m {
 
+		internal Interop.GraphicsPipelineCreateInfo* m {
 			get {
 				return (Interop.GraphicsPipelineCreateInfo*)native.Handle;
 			}
@@ -4084,8 +4150,8 @@ namespace Vulkan
 			get { return m->InitialData; }
 			set { m->InitialData = value; }
 		}
-		internal Interop.PipelineCacheCreateInfo* m {
 
+		internal Interop.PipelineCacheCreateInfo* m {
 			get {
 				return (Interop.PipelineCacheCreateInfo*)native.Handle;
 			}
@@ -4202,8 +4268,8 @@ namespace Vulkan
 				}
 			}
 		}
-		internal Interop.PipelineLayoutCreateInfo* m {
 
+		internal Interop.PipelineLayoutCreateInfo* m {
 			get {
 				return (Interop.PipelineLayoutCreateInfo*)native.Handle;
 			}
@@ -4241,7 +4307,7 @@ namespace Vulkan
 
 	unsafe public partial class SamplerCreateInfo : MarshalledObject
 	{
-		public UInt32 Flags {
+		public SamplerCreateFlags Flags {
 			get { return m->Flags; }
 			set { m->Flags = value; }
 		}
@@ -4320,8 +4386,8 @@ namespace Vulkan
 			get { return m->UnnormalizedCoordinates; }
 			set { m->UnnormalizedCoordinates = value; }
 		}
-		internal Interop.SamplerCreateInfo* m {
 
+		internal Interop.SamplerCreateInfo* m {
 			get {
 				return (Interop.SamplerCreateInfo*)native.Handle;
 			}
@@ -4358,8 +4424,8 @@ namespace Vulkan
 			get { return m->QueueFamilyIndex; }
 			set { m->QueueFamilyIndex = value; }
 		}
-		internal Interop.CommandPoolCreateInfo* m {
 
+		internal Interop.CommandPoolCreateInfo* m {
 			get {
 				return (Interop.CommandPoolCreateInfo*)native.Handle;
 			}
@@ -4402,8 +4468,8 @@ namespace Vulkan
 			get { return m->CommandBufferCount; }
 			set { m->CommandBufferCount = value; }
 		}
-		internal Interop.CommandBufferAllocateInfo* m {
 
+		internal Interop.CommandBufferAllocateInfo* m {
 			get {
 				return (Interop.CommandBufferAllocateInfo*)native.Handle;
 			}
@@ -4462,8 +4528,8 @@ namespace Vulkan
 			get { return m->PipelineStatistics; }
 			set { m->PipelineStatistics = value; }
 		}
-		internal Interop.CommandBufferInheritanceInfo* m {
 
+		internal Interop.CommandBufferInheritanceInfo* m {
 			get {
 				return (Interop.CommandBufferInheritanceInfo*)native.Handle;
 			}
@@ -4501,8 +4567,8 @@ namespace Vulkan
 			get { return lInheritanceInfo; }
 			set { lInheritanceInfo = value; m->InheritanceInfo = value != null ? (IntPtr)value.m : default(IntPtr); }
 		}
-		internal Interop.CommandBufferBeginInfo* m {
 
+		internal Interop.CommandBufferBeginInfo* m {
 			get {
 				return (Interop.CommandBufferBeginInfo*)native.Handle;
 			}
@@ -4586,8 +4652,8 @@ namespace Vulkan
 				}
 			}
 		}
-		internal Interop.RenderPassBeginInfo* m {
 
+		internal Interop.RenderPassBeginInfo* m {
 			get {
 				return (Interop.RenderPassBeginInfo*)native.Handle;
 			}
@@ -4644,8 +4710,8 @@ namespace Vulkan
 			get { return lClearValue; }
 			set { lClearValue = value; m->ClearValue = value != null ? *value.m : default(Interop.ClearValue); }
 		}
-		internal Interop.ClearAttachment* m {
 
+		internal Interop.ClearAttachment* m {
 			get {
 				return (Interop.ClearAttachment*)native.Handle;
 			}
@@ -4853,8 +4919,8 @@ namespace Vulkan
 				}
 			}
 		}
-		internal Interop.SubpassDescription* m {
 
+		internal Interop.SubpassDescription* m {
 			get {
 				return (Interop.SubpassDescription*)native.Handle;
 			}
@@ -5019,8 +5085,8 @@ namespace Vulkan
 				}
 			}
 		}
-		internal Interop.RenderPassCreateInfo* m {
 
+		internal Interop.RenderPassCreateInfo* m {
 			get {
 				return (Interop.RenderPassCreateInfo*)native.Handle;
 			}
@@ -5064,8 +5130,8 @@ namespace Vulkan
 			get { return m->Flags; }
 			set { m->Flags = value; }
 		}
-		internal Interop.EventCreateInfo* m {
 
+		internal Interop.EventCreateInfo* m {
 			get {
 				return (Interop.EventCreateInfo*)native.Handle;
 			}
@@ -5097,8 +5163,8 @@ namespace Vulkan
 			get { return m->Flags; }
 			set { m->Flags = value; }
 		}
-		internal Interop.FenceCreateInfo* m {
 
+		internal Interop.FenceCreateInfo* m {
 			get {
 				return (Interop.FenceCreateInfo*)native.Handle;
 			}
@@ -5801,8 +5867,8 @@ namespace Vulkan
 			get { return m->NonCoherentAtomSize; }
 			set { m->NonCoherentAtomSize = value; }
 		}
-		internal Interop.PhysicalDeviceLimits* m {
 
+		internal Interop.PhysicalDeviceLimits* m {
 			get {
 				return (Interop.PhysicalDeviceLimits*)native.Handle;
 			}
@@ -5826,8 +5892,8 @@ namespace Vulkan
 			get { return m->Flags; }
 			set { m->Flags = value; }
 		}
-		internal Interop.SemaphoreCreateInfo* m {
 
+		internal Interop.SemaphoreCreateInfo* m {
 			get {
 				return (Interop.SemaphoreCreateInfo*)native.Handle;
 			}
@@ -5874,8 +5940,8 @@ namespace Vulkan
 			get { return m->PipelineStatistics; }
 			set { m->PipelineStatistics = value; }
 		}
-		internal Interop.QueryPoolCreateInfo* m {
 
+		internal Interop.QueryPoolCreateInfo* m {
 			get {
 				return (Interop.QueryPoolCreateInfo*)native.Handle;
 			}
@@ -5968,8 +6034,8 @@ namespace Vulkan
 			get { return m->Layers; }
 			set { m->Layers = value; }
 		}
-		internal Interop.FramebufferCreateInfo* m {
 
+		internal Interop.FramebufferCreateInfo* m {
 			get {
 				return (Interop.FramebufferCreateInfo*)native.Handle;
 			}
@@ -6181,8 +6247,8 @@ namespace Vulkan
 				}
 			}
 		}
-		internal Interop.SubmitInfo* m {
 
+		internal Interop.SubmitInfo* m {
 			get {
 				return (Interop.SubmitInfo*)native.Handle;
 			}
@@ -6259,8 +6325,8 @@ namespace Vulkan
 			get { return m->PersistentContent; }
 			set { m->PersistentContent = value; }
 		}
-		internal Interop.DisplayPropertiesKhr* m {
 
+		internal Interop.DisplayPropertiesKhr* m {
 			get {
 				return (Interop.DisplayPropertiesKhr*)native.Handle;
 			}
@@ -6297,8 +6363,8 @@ namespace Vulkan
 			get { return m->CurrentStackIndex; }
 			set { m->CurrentStackIndex = value; }
 		}
-		internal Interop.DisplayPlanePropertiesKhr* m {
 
+		internal Interop.DisplayPlanePropertiesKhr* m {
 			get {
 				return (Interop.DisplayPlanePropertiesKhr*)native.Handle;
 			}
@@ -6341,8 +6407,8 @@ namespace Vulkan
 			get { return m->Parameters; }
 			set { m->Parameters = value; }
 		}
-		internal Interop.DisplayModePropertiesKhr* m {
 
+		internal Interop.DisplayModePropertiesKhr* m {
 			get {
 				return (Interop.DisplayModePropertiesKhr*)native.Handle;
 			}
@@ -6378,8 +6444,8 @@ namespace Vulkan
 			get { return m->Parameters; }
 			set { m->Parameters = value; }
 		}
-		internal Interop.DisplayModeCreateInfoKhr* m {
 
+		internal Interop.DisplayModeCreateInfoKhr* m {
 			get {
 				return (Interop.DisplayModeCreateInfoKhr*)native.Handle;
 			}
@@ -6460,8 +6526,8 @@ namespace Vulkan
 			get { return m->ImageExtent; }
 			set { m->ImageExtent = value; }
 		}
-		internal Interop.DisplaySurfaceCreateInfoKhr* m {
 
+		internal Interop.DisplaySurfaceCreateInfoKhr* m {
 			get {
 				return (Interop.DisplaySurfaceCreateInfoKhr*)native.Handle;
 			}
@@ -6503,8 +6569,8 @@ namespace Vulkan
 			get { return m->Persistent; }
 			set { m->Persistent = value; }
 		}
-		internal Interop.DisplayPresentInfoKhr* m {
 
+		internal Interop.DisplayPresentInfoKhr* m {
 			get {
 				return (Interop.DisplayPresentInfoKhr*)native.Handle;
 			}
@@ -6555,8 +6621,8 @@ namespace Vulkan
 			get { return m->Window; }
 			set { m->Window = value; }
 		}
-		internal Interop.ViSurfaceCreateInfoNn* m {
 
+		internal Interop.ViSurfaceCreateInfoNn* m {
 			get {
 				return (Interop.ViSurfaceCreateInfoNn*)native.Handle;
 			}
@@ -6578,6 +6644,82 @@ namespace Vulkan
 		internal void Initialize ()
 		{
 			m->SType = StructureType.ViSurfaceCreateInfoNn;
+		}
+
+	}
+
+	unsafe public partial class ImagePipeSurfaceCreateInfoFUCHSIA : MarshalledObject
+	{
+		public UInt32 Flags {
+			get { return m->Flags; }
+			set { m->Flags = value; }
+		}
+
+		public UInt32 ImagePipeHandle {
+			get { return m->ImagePipeHandle; }
+			set { m->ImagePipeHandle = value; }
+		}
+
+		internal Interop.ImagePipeSurfaceCreateInfoFUCHSIA* m {
+			get {
+				return (Interop.ImagePipeSurfaceCreateInfoFUCHSIA*)native.Handle;
+			}
+		}
+
+		public ImagePipeSurfaceCreateInfoFUCHSIA ()
+		{
+			native = Interop.Structure.Allocate (typeof (Interop.ImagePipeSurfaceCreateInfoFUCHSIA));
+			Initialize ();
+		}
+
+		internal ImagePipeSurfaceCreateInfoFUCHSIA (NativePointer pointer)
+		{
+			native = pointer;
+			Initialize ();
+		}
+
+
+		internal void Initialize ()
+		{
+			m->SType = StructureType.ImagepipeSurfaceCreateInfoFuchsia;
+		}
+
+	}
+
+	unsafe public partial class StreamDescriptorSurfaceCreateInfoGGP : MarshalledObject
+	{
+		public UInt32 Flags {
+			get { return m->Flags; }
+			set { m->Flags = value; }
+		}
+
+		public int StreamDescriptor {
+			get { return m->StreamDescriptor; }
+			set { m->StreamDescriptor = value; }
+		}
+
+		internal Interop.StreamDescriptorSurfaceCreateInfoGGP* m {
+			get {
+				return (Interop.StreamDescriptorSurfaceCreateInfoGGP*)native.Handle;
+			}
+		}
+
+		public StreamDescriptorSurfaceCreateInfoGGP ()
+		{
+			native = Interop.Structure.Allocate (typeof (Interop.StreamDescriptorSurfaceCreateInfoGGP));
+			Initialize ();
+		}
+
+		internal StreamDescriptorSurfaceCreateInfoGGP (NativePointer pointer)
+		{
+			native = pointer;
+			Initialize ();
+		}
+
+
+		internal void Initialize ()
+		{
+			m->SType = StructureType.StreamDescriptorSurfaceCreateInfoGGP;
 		}
 
 	}
@@ -6699,8 +6841,8 @@ namespace Vulkan
 			get { return lOldSwapchain; }
 			set { lOldSwapchain = value; m->OldSwapchain = value != null ? (UInt64)value.m : default(UInt64); }
 		}
-		internal Interop.SwapchainCreateInfoKhr* m {
 
+		internal Interop.SwapchainCreateInfoKhr* m {
 			get {
 				return (Interop.SwapchainCreateInfoKhr*)native.Handle;
 			}
@@ -6881,8 +7023,8 @@ namespace Vulkan
 				}
 			}
 		}
-		internal Interop.PresentInfoKhr* m {
 
+		internal Interop.PresentInfoKhr* m {
 			get {
 				return (Interop.PresentInfoKhr*)native.Handle;
 			}
@@ -6938,8 +7080,8 @@ namespace Vulkan
 			get { return m->UserData; }
 			set { m->UserData = value; }
 		}
-		internal Interop.DebugReportCallbackCreateInfoExt* m {
 
+		internal Interop.DebugReportCallbackCreateInfoExt* m {
 			get {
 				return (Interop.DebugReportCallbackCreateInfoExt*)native.Handle;
 			}
@@ -7004,8 +7146,8 @@ namespace Vulkan
 				}
 			}
 		}
-		internal Interop.ValidationFlagsExt* m {
 
+		internal Interop.ValidationFlagsExt* m {
 			get {
 				return (Interop.ValidationFlagsExt*)native.Handle;
 			}
@@ -7039,14 +7181,128 @@ namespace Vulkan
 
 	}
 
+	unsafe public partial class ValidationFeaturesExt : MarshalledObject
+	{
+		public UInt32 EnabledValidationFeatureCount {
+			get { return m->EnabledValidationFeatureCount; }
+			set { m->EnabledValidationFeatureCount = value; }
+		}
+
+		NativeReference refEnabledValidationFeatures;
+		public ValidationFeatureEnableExt[] EnabledValidationFeatures {
+			get {
+				if (m->EnabledValidationFeatureCount == 0)
+					return null;
+				var values = new ValidationFeatureEnableExt [m->EnabledValidationFeatureCount];
+				unsafe
+				{
+					ValidationFeatureEnableExt* ptr = (ValidationFeatureEnableExt*)m->EnabledValidationFeatures;
+					for (int i = 0; i < values.Length; i++) 
+						values [i] = ptr [i];
+				}
+				return values;
+			}
+
+			set {
+				if (value == null) {
+					m->EnabledValidationFeatureCount = 0;
+					m->EnabledValidationFeatures = IntPtr.Zero;
+					return;
+				}
+				m->EnabledValidationFeatureCount = (uint)value.Length;
+				refEnabledValidationFeatures = new NativeReference ((int)(sizeof(ValidationFeatureEnableExt)*value.Length));
+				m->EnabledValidationFeatures = refEnabledValidationFeatures.Handle;
+				unsafe
+				{
+					ValidationFeatureEnableExt* ptr = (ValidationFeatureEnableExt*)m->EnabledValidationFeatures;
+					for (int i = 0; i < value.Length; i++)
+						ptr [i] = value [i];
+				}
+			}
+		}
+
+		public UInt32 DisabledValidationFeatureCount {
+			get { return m->DisabledValidationFeatureCount; }
+			set { m->DisabledValidationFeatureCount = value; }
+		}
+
+		NativeReference refDisabledValidationFeatures;
+		public ValidationFeatureDisableExt[] DisabledValidationFeatures {
+			get {
+				if (m->DisabledValidationFeatureCount == 0)
+					return null;
+				var values = new ValidationFeatureDisableExt [m->DisabledValidationFeatureCount];
+				unsafe
+				{
+					ValidationFeatureDisableExt* ptr = (ValidationFeatureDisableExt*)m->DisabledValidationFeatures;
+					for (int i = 0; i < values.Length; i++) 
+						values [i] = ptr [i];
+				}
+				return values;
+			}
+
+			set {
+				if (value == null) {
+					m->DisabledValidationFeatureCount = 0;
+					m->DisabledValidationFeatures = IntPtr.Zero;
+					return;
+				}
+				m->DisabledValidationFeatureCount = (uint)value.Length;
+				refDisabledValidationFeatures = new NativeReference ((int)(sizeof(ValidationFeatureDisableExt)*value.Length));
+				m->DisabledValidationFeatures = refDisabledValidationFeatures.Handle;
+				unsafe
+				{
+					ValidationFeatureDisableExt* ptr = (ValidationFeatureDisableExt*)m->DisabledValidationFeatures;
+					for (int i = 0; i < value.Length; i++)
+						ptr [i] = value [i];
+				}
+			}
+		}
+
+		internal Interop.ValidationFeaturesExt* m {
+			get {
+				return (Interop.ValidationFeaturesExt*)native.Handle;
+			}
+		}
+
+		public ValidationFeaturesExt ()
+		{
+			native = Interop.Structure.Allocate (typeof (Interop.ValidationFeaturesExt));
+			Initialize ();
+		}
+
+		internal ValidationFeaturesExt (NativePointer pointer)
+		{
+			native = pointer;
+			Initialize ();
+		}
+
+		override public void Dispose (bool disposing)
+		{
+			base.Dispose (disposing);
+			if (!disposing)
+				return;
+			refEnabledValidationFeatures.Dispose ();
+			refEnabledValidationFeatures = null;
+			refDisabledValidationFeatures.Dispose ();
+			refDisabledValidationFeatures = null;
+		}
+
+		internal void Initialize ()
+		{
+			m->SType = StructureType.ValidationFeaturesExt;
+		}
+
+	}
+
 	unsafe public partial class PipelineRasterizationStateRasterizationOrderAmd : MarshalledObject
 	{
 		public RasterizationOrderAmd RasterizationOrder {
 			get { return m->RasterizationOrder; }
 			set { m->RasterizationOrder = value; }
 		}
-		internal Interop.PipelineRasterizationStateRasterizationOrderAmd* m {
 
+		internal Interop.PipelineRasterizationStateRasterizationOrderAmd* m {
 			get {
 				return (Interop.PipelineRasterizationStateRasterizationOrderAmd*)native.Handle;
 			}
@@ -7088,8 +7344,8 @@ namespace Vulkan
 			get { return Marshal.PtrToStringAnsi (m->ObjectName); }
 			set { m->ObjectName = Marshal.StringToHGlobalAnsi (value); }
 		}
-		internal Interop.DebugMarkerObjectNameInfoExt* m {
 
+		internal Interop.DebugMarkerObjectNameInfoExt* m {
 			get {
 				return (Interop.DebugMarkerObjectNameInfoExt*)native.Handle;
 			}
@@ -7141,8 +7397,8 @@ namespace Vulkan
 			get { return m->Tag; }
 			set { m->Tag = value; }
 		}
-		internal Interop.DebugMarkerObjectTagInfoExt* m {
 
+		internal Interop.DebugMarkerObjectTagInfoExt* m {
 			get {
 				return (Interop.DebugMarkerObjectTagInfoExt*)native.Handle;
 			}
@@ -7192,8 +7448,8 @@ namespace Vulkan
 					m->Color [i] = 0;
 			}
 		}
-		internal Interop.DebugMarkerMarkerInfoExt* m {
 
+		internal Interop.DebugMarkerMarkerInfoExt* m {
 			get {
 				return (Interop.DebugMarkerMarkerInfoExt*)native.Handle;
 			}
@@ -7225,8 +7481,8 @@ namespace Vulkan
 			get { return m->DedicatedAllocation; }
 			set { m->DedicatedAllocation = value; }
 		}
-		internal Interop.DedicatedAllocationImageCreateInfoNv* m {
 
+		internal Interop.DedicatedAllocationImageCreateInfoNv* m {
 			get {
 				return (Interop.DedicatedAllocationImageCreateInfoNv*)native.Handle;
 			}
@@ -7258,8 +7514,8 @@ namespace Vulkan
 			get { return m->DedicatedAllocation; }
 			set { m->DedicatedAllocation = value; }
 		}
-		internal Interop.DedicatedAllocationBufferCreateInfoNv* m {
 
+		internal Interop.DedicatedAllocationBufferCreateInfoNv* m {
 			get {
 				return (Interop.DedicatedAllocationBufferCreateInfoNv*)native.Handle;
 			}
@@ -7298,8 +7554,8 @@ namespace Vulkan
 			get { return lBuffer; }
 			set { lBuffer = value; m->Buffer = value != null ? (UInt64)value.m : default(UInt64); }
 		}
-		internal Interop.DedicatedAllocationMemoryAllocateInfoNv* m {
 
+		internal Interop.DedicatedAllocationMemoryAllocateInfoNv* m {
 			get {
 				return (Interop.DedicatedAllocationMemoryAllocateInfoNv*)native.Handle;
 			}
@@ -7339,8 +7595,8 @@ namespace Vulkan
 			get { return m->HandleTypes; }
 			set { m->HandleTypes = value; }
 		}
-		internal Interop.ExternalMemoryImageCreateInfoNv* m {
 
+		internal Interop.ExternalMemoryImageCreateInfoNv* m {
 			get {
 				return (Interop.ExternalMemoryImageCreateInfoNv*)native.Handle;
 			}
@@ -7372,8 +7628,8 @@ namespace Vulkan
 			get { return m->HandleTypes; }
 			set { m->HandleTypes = value; }
 		}
-		internal Interop.ExportMemoryAllocateInfoNv* m {
 
+		internal Interop.ExportMemoryAllocateInfoNv* m {
 			get {
 				return (Interop.ExportMemoryAllocateInfoNv*)native.Handle;
 			}
@@ -7405,8 +7661,8 @@ namespace Vulkan
 			get { return m->ComputeBindingPointSupport; }
 			set { m->ComputeBindingPointSupport = value; }
 		}
-		internal Interop.DeviceGeneratedCommandsFeaturesNvx* m {
 
+		internal Interop.DeviceGeneratedCommandsFeaturesNvx* m {
 			get {
 				return (Interop.DeviceGeneratedCommandsFeaturesNvx*)native.Handle;
 			}
@@ -7458,8 +7714,8 @@ namespace Vulkan
 			get { return m->MinCommandsTokenBufferOffsetAlignment; }
 			set { m->MinCommandsTokenBufferOffsetAlignment = value; }
 		}
-		internal Interop.DeviceGeneratedCommandsLimitsNvx* m {
 
+		internal Interop.DeviceGeneratedCommandsLimitsNvx* m {
 			get {
 				return (Interop.DeviceGeneratedCommandsLimitsNvx*)native.Handle;
 			}
@@ -7502,8 +7758,8 @@ namespace Vulkan
 			get { return m->Offset; }
 			set { m->Offset = value; }
 		}
-		internal Interop.IndirectCommandsTokenNvx* m {
 
+		internal Interop.IndirectCommandsTokenNvx* m {
 			get {
 				return (Interop.IndirectCommandsTokenNvx*)native.Handle;
 			}
@@ -7585,8 +7841,8 @@ namespace Vulkan
 				}
 			}
 		}
-		internal Interop.IndirectCommandsLayoutCreateInfoNvx* m {
 
+		internal Interop.IndirectCommandsLayoutCreateInfoNvx* m {
 			get {
 				return (Interop.IndirectCommandsLayoutCreateInfoNvx*)native.Handle;
 			}
@@ -7706,8 +7962,8 @@ namespace Vulkan
 			get { return m->SequencesIndexOffset; }
 			set { m->SequencesIndexOffset = value; }
 		}
-		internal Interop.CmdProcessCommandsInfoNvx* m {
 
+		internal Interop.CmdProcessCommandsInfoNvx* m {
 			get {
 				return (Interop.CmdProcessCommandsInfoNvx*)native.Handle;
 			}
@@ -7759,8 +8015,8 @@ namespace Vulkan
 			get { return m->MaxSequencesCount; }
 			set { m->MaxSequencesCount = value; }
 		}
-		internal Interop.CmdReserveSpaceForCommandsInfoNvx* m {
 
+		internal Interop.CmdReserveSpaceForCommandsInfoNvx* m {
 			get {
 				return (Interop.CmdReserveSpaceForCommandsInfoNvx*)native.Handle;
 			}
@@ -7916,8 +8172,8 @@ namespace Vulkan
 			get { return m->MaxPipelineLayouts; }
 			set { m->MaxPipelineLayouts = value; }
 		}
-		internal Interop.ObjectTableCreateInfoNvx* m {
 
+		internal Interop.ObjectTableCreateInfoNvx* m {
 			get {
 				return (Interop.ObjectTableCreateInfoNvx*)native.Handle;
 			}
@@ -7978,8 +8234,8 @@ namespace Vulkan
 			get { return lPipeline; }
 			set { lPipeline = value; m->Pipeline = value != null ? (UInt64)value.m : default(UInt64); }
 		}
-		internal Interop.ObjectTablePipelineEntryNvx* m {
 
+		internal Interop.ObjectTablePipelineEntryNvx* m {
 			get {
 				return (Interop.ObjectTablePipelineEntryNvx*)native.Handle;
 			}
@@ -8027,8 +8283,8 @@ namespace Vulkan
 			get { return lDescriptorSet; }
 			set { lDescriptorSet = value; m->DescriptorSet = value != null ? (UInt64)value.m : default(UInt64); }
 		}
-		internal Interop.ObjectTableDescriptorSetEntryNvx* m {
 
+		internal Interop.ObjectTableDescriptorSetEntryNvx* m {
 			get {
 				return (Interop.ObjectTableDescriptorSetEntryNvx*)native.Handle;
 			}
@@ -8070,8 +8326,8 @@ namespace Vulkan
 			get { return lBuffer; }
 			set { lBuffer = value; m->Buffer = value != null ? (UInt64)value.m : default(UInt64); }
 		}
-		internal Interop.ObjectTableVertexBufferEntryNvx* m {
 
+		internal Interop.ObjectTableVertexBufferEntryNvx* m {
 			get {
 				return (Interop.ObjectTableVertexBufferEntryNvx*)native.Handle;
 			}
@@ -8118,8 +8374,8 @@ namespace Vulkan
 			get { return m->IndexType; }
 			set { m->IndexType = value; }
 		}
-		internal Interop.ObjectTableIndexBufferEntryNvx* m {
 
+		internal Interop.ObjectTableIndexBufferEntryNvx* m {
 			get {
 				return (Interop.ObjectTableIndexBufferEntryNvx*)native.Handle;
 			}
@@ -8166,8 +8422,8 @@ namespace Vulkan
 			get { return m->StageFlags; }
 			set { m->StageFlags = value; }
 		}
-		internal Interop.ObjectTablePushConstantEntryNvx* m {
 
+		internal Interop.ObjectTablePushConstantEntryNvx* m {
 			get {
 				return (Interop.ObjectTablePushConstantEntryNvx*)native.Handle;
 			}
@@ -8192,26 +8448,26 @@ namespace Vulkan
 
 	}
 
-	unsafe public partial class PhysicalDeviceFeatures2Khr : MarshalledObject
+	unsafe public partial class PhysicalDeviceFeatures2 : MarshalledObject
 	{
 		public PhysicalDeviceFeatures Features {
 			get { return m->Features; }
 			set { m->Features = value; }
 		}
-		internal Interop.PhysicalDeviceFeatures2Khr* m {
 
+		internal Interop.PhysicalDeviceFeatures2* m {
 			get {
-				return (Interop.PhysicalDeviceFeatures2Khr*)native.Handle;
+				return (Interop.PhysicalDeviceFeatures2*)native.Handle;
 			}
 		}
 
-		public PhysicalDeviceFeatures2Khr ()
+		public PhysicalDeviceFeatures2 ()
 		{
-			native = Interop.Structure.Allocate (typeof (Interop.PhysicalDeviceFeatures2Khr));
+			native = Interop.Structure.Allocate (typeof (Interop.PhysicalDeviceFeatures2));
 			Initialize ();
 		}
 
-		internal PhysicalDeviceFeatures2Khr (NativePointer pointer)
+		internal PhysicalDeviceFeatures2 (NativePointer pointer)
 		{
 			native = pointer;
 			Initialize ();
@@ -8220,32 +8476,42 @@ namespace Vulkan
 
 		internal void Initialize ()
 		{
-			m->SType = StructureType.PhysicalDeviceFeatures2Khr;
+			m->SType = StructureType.PhysicalDeviceFeatures2;
 		}
 
 	}
 
-	unsafe public partial class PhysicalDeviceProperties2Khr : MarshalledObject
+	unsafe public partial class PhysicalDeviceFeatures2Khr : PhysicalDeviceFeatures2
+	{
+		public PhysicalDeviceFeatures2Khr () : base () {
+		}
+
+		internal PhysicalDeviceFeatures2Khr (NativePointer pointer) : base (pointer) {
+		}
+
+	}
+
+	unsafe public partial class PhysicalDeviceProperties2 : MarshalledObject
 	{
 		PhysicalDeviceProperties lProperties;
 		public PhysicalDeviceProperties Properties {
 			get { return lProperties; }
 			set { lProperties = value; m->Properties = value != null ? *value.m : default(Interop.PhysicalDeviceProperties); }
 		}
-		internal Interop.PhysicalDeviceProperties2Khr* m {
 
+		internal Interop.PhysicalDeviceProperties2* m {
 			get {
-				return (Interop.PhysicalDeviceProperties2Khr*)native.Handle;
+				return (Interop.PhysicalDeviceProperties2*)native.Handle;
 			}
 		}
 
-		public PhysicalDeviceProperties2Khr ()
+		public PhysicalDeviceProperties2 ()
 		{
-			native = Interop.Structure.Allocate (typeof (Interop.PhysicalDeviceProperties2Khr));
+			native = Interop.Structure.Allocate (typeof (Interop.PhysicalDeviceProperties2));
 			Initialize ();
 		}
 
-		internal PhysicalDeviceProperties2Khr (NativePointer pointer)
+		internal PhysicalDeviceProperties2 (NativePointer pointer)
 		{
 			native = pointer;
 			Initialize ();
@@ -8254,32 +8520,42 @@ namespace Vulkan
 
 		internal void Initialize ()
 		{
-			m->SType = StructureType.PhysicalDeviceProperties2Khr;
+			m->SType = StructureType.PhysicalDeviceProperties2;
 			lProperties = new PhysicalDeviceProperties (new NativePointer (native.Reference, (IntPtr)(&m->Properties)));
 		}
 
 	}
 
-	unsafe public partial class FormatProperties2Khr : MarshalledObject
+	unsafe public partial class PhysicalDeviceProperties2Khr : PhysicalDeviceProperties2
+	{
+		public PhysicalDeviceProperties2Khr () : base () {
+		}
+
+		internal PhysicalDeviceProperties2Khr (NativePointer pointer) : base (pointer) {
+		}
+
+	}
+
+	unsafe public partial class FormatProperties2 : MarshalledObject
 	{
 		public FormatProperties FormatProperties {
 			get { return m->FormatProperties; }
 			set { m->FormatProperties = value; }
 		}
-		internal Interop.FormatProperties2Khr* m {
 
+		internal Interop.FormatProperties2* m {
 			get {
-				return (Interop.FormatProperties2Khr*)native.Handle;
+				return (Interop.FormatProperties2*)native.Handle;
 			}
 		}
 
-		public FormatProperties2Khr ()
+		public FormatProperties2 ()
 		{
-			native = Interop.Structure.Allocate (typeof (Interop.FormatProperties2Khr));
+			native = Interop.Structure.Allocate (typeof (Interop.FormatProperties2));
 			Initialize ();
 		}
 
-		internal FormatProperties2Khr (NativePointer pointer)
+		internal FormatProperties2 (NativePointer pointer)
 		{
 			native = pointer;
 			Initialize ();
@@ -8288,31 +8564,41 @@ namespace Vulkan
 
 		internal void Initialize ()
 		{
-			m->SType = StructureType.FormatProperties2Khr;
+			m->SType = StructureType.FormatProperties2;
 		}
 
 	}
 
-	unsafe public partial class ImageFormatProperties2Khr : MarshalledObject
+	unsafe public partial class FormatProperties2Khr : FormatProperties2
+	{
+		public FormatProperties2Khr () : base () {
+		}
+
+		internal FormatProperties2Khr (NativePointer pointer) : base (pointer) {
+		}
+
+	}
+
+	unsafe public partial class ImageFormatProperties2 : MarshalledObject
 	{
 		public ImageFormatProperties ImageFormatProperties {
 			get { return m->ImageFormatProperties; }
 			set { m->ImageFormatProperties = value; }
 		}
-		internal Interop.ImageFormatProperties2Khr* m {
 
+		internal Interop.ImageFormatProperties2* m {
 			get {
-				return (Interop.ImageFormatProperties2Khr*)native.Handle;
+				return (Interop.ImageFormatProperties2*)native.Handle;
 			}
 		}
 
-		public ImageFormatProperties2Khr ()
+		public ImageFormatProperties2 ()
 		{
-			native = Interop.Structure.Allocate (typeof (Interop.ImageFormatProperties2Khr));
+			native = Interop.Structure.Allocate (typeof (Interop.ImageFormatProperties2));
 			Initialize ();
 		}
 
-		internal ImageFormatProperties2Khr (NativePointer pointer)
+		internal ImageFormatProperties2 (NativePointer pointer)
 		{
 			native = pointer;
 			Initialize ();
@@ -8321,12 +8607,22 @@ namespace Vulkan
 
 		internal void Initialize ()
 		{
-			m->SType = StructureType.ImageFormatProperties2Khr;
+			m->SType = StructureType.ImageFormatProperties2;
 		}
 
 	}
 
-	unsafe public partial class PhysicalDeviceImageFormatInfo2Khr : MarshalledObject
+	unsafe public partial class ImageFormatProperties2Khr : ImageFormatProperties2
+	{
+		public ImageFormatProperties2Khr () : base () {
+		}
+
+		internal ImageFormatProperties2Khr (NativePointer pointer) : base (pointer) {
+		}
+
+	}
+
+	unsafe public partial class PhysicalDeviceImageFormatInfo2 : MarshalledObject
 	{
 		public Format Format {
 			get { return m->Format; }
@@ -8352,20 +8648,20 @@ namespace Vulkan
 			get { return m->Flags; }
 			set { m->Flags = value; }
 		}
-		internal Interop.PhysicalDeviceImageFormatInfo2Khr* m {
 
+		internal Interop.PhysicalDeviceImageFormatInfo2* m {
 			get {
-				return (Interop.PhysicalDeviceImageFormatInfo2Khr*)native.Handle;
+				return (Interop.PhysicalDeviceImageFormatInfo2*)native.Handle;
 			}
 		}
 
-		public PhysicalDeviceImageFormatInfo2Khr ()
+		public PhysicalDeviceImageFormatInfo2 ()
 		{
-			native = Interop.Structure.Allocate (typeof (Interop.PhysicalDeviceImageFormatInfo2Khr));
+			native = Interop.Structure.Allocate (typeof (Interop.PhysicalDeviceImageFormatInfo2));
 			Initialize ();
 		}
 
-		internal PhysicalDeviceImageFormatInfo2Khr (NativePointer pointer)
+		internal PhysicalDeviceImageFormatInfo2 (NativePointer pointer)
 		{
 			native = pointer;
 			Initialize ();
@@ -8374,31 +8670,41 @@ namespace Vulkan
 
 		internal void Initialize ()
 		{
-			m->SType = StructureType.PhysicalDeviceImageFormatInfo2Khr;
+			m->SType = StructureType.PhysicalDeviceImageFormatInfo2;
 		}
 
 	}
 
-	unsafe public partial class QueueFamilyProperties2Khr : MarshalledObject
+	unsafe public partial class PhysicalDeviceImageFormatInfo2Khr : PhysicalDeviceImageFormatInfo2
+	{
+		public PhysicalDeviceImageFormatInfo2Khr () : base () {
+		}
+
+		internal PhysicalDeviceImageFormatInfo2Khr (NativePointer pointer) : base (pointer) {
+		}
+
+	}
+
+	unsafe public partial class QueueFamilyProperties2 : MarshalledObject
 	{
 		public QueueFamilyProperties QueueFamilyProperties {
 			get { return m->QueueFamilyProperties; }
 			set { m->QueueFamilyProperties = value; }
 		}
-		internal Interop.QueueFamilyProperties2Khr* m {
 
+		internal Interop.QueueFamilyProperties2* m {
 			get {
-				return (Interop.QueueFamilyProperties2Khr*)native.Handle;
+				return (Interop.QueueFamilyProperties2*)native.Handle;
 			}
 		}
 
-		public QueueFamilyProperties2Khr ()
+		public QueueFamilyProperties2 ()
 		{
-			native = Interop.Structure.Allocate (typeof (Interop.QueueFamilyProperties2Khr));
+			native = Interop.Structure.Allocate (typeof (Interop.QueueFamilyProperties2));
 			Initialize ();
 		}
 
-		internal QueueFamilyProperties2Khr (NativePointer pointer)
+		internal QueueFamilyProperties2 (NativePointer pointer)
 		{
 			native = pointer;
 			Initialize ();
@@ -8407,32 +8713,42 @@ namespace Vulkan
 
 		internal void Initialize ()
 		{
-			m->SType = StructureType.QueueFamilyProperties2Khr;
+			m->SType = StructureType.QueueFamilyProperties2;
 		}
 
 	}
 
-	unsafe public partial class PhysicalDeviceMemoryProperties2Khr : MarshalledObject
+	unsafe public partial class QueueFamilyProperties2Khr : QueueFamilyProperties2
+	{
+		public QueueFamilyProperties2Khr () : base () {
+		}
+
+		internal QueueFamilyProperties2Khr (NativePointer pointer) : base (pointer) {
+		}
+
+	}
+
+	unsafe public partial class PhysicalDeviceMemoryProperties2 : MarshalledObject
 	{
 		PhysicalDeviceMemoryProperties lMemoryProperties;
 		public PhysicalDeviceMemoryProperties MemoryProperties {
 			get { return lMemoryProperties; }
 			set { lMemoryProperties = value; m->MemoryProperties = value != null ? *value.m : default(Interop.PhysicalDeviceMemoryProperties); }
 		}
-		internal Interop.PhysicalDeviceMemoryProperties2Khr* m {
 
+		internal Interop.PhysicalDeviceMemoryProperties2* m {
 			get {
-				return (Interop.PhysicalDeviceMemoryProperties2Khr*)native.Handle;
+				return (Interop.PhysicalDeviceMemoryProperties2*)native.Handle;
 			}
 		}
 
-		public PhysicalDeviceMemoryProperties2Khr ()
+		public PhysicalDeviceMemoryProperties2 ()
 		{
-			native = Interop.Structure.Allocate (typeof (Interop.PhysicalDeviceMemoryProperties2Khr));
+			native = Interop.Structure.Allocate (typeof (Interop.PhysicalDeviceMemoryProperties2));
 			Initialize ();
 		}
 
-		internal PhysicalDeviceMemoryProperties2Khr (NativePointer pointer)
+		internal PhysicalDeviceMemoryProperties2 (NativePointer pointer)
 		{
 			native = pointer;
 			Initialize ();
@@ -8441,32 +8757,42 @@ namespace Vulkan
 
 		internal void Initialize ()
 		{
-			m->SType = StructureType.PhysicalDeviceMemoryProperties2Khr;
+			m->SType = StructureType.PhysicalDeviceMemoryProperties2;
 			lMemoryProperties = new PhysicalDeviceMemoryProperties (new NativePointer (native.Reference, (IntPtr)(&m->MemoryProperties)));
 		}
 
 	}
 
-	unsafe public partial class SparseImageFormatProperties2Khr : MarshalledObject
+	unsafe public partial class PhysicalDeviceMemoryProperties2Khr : PhysicalDeviceMemoryProperties2
+	{
+		public PhysicalDeviceMemoryProperties2Khr () : base () {
+		}
+
+		internal PhysicalDeviceMemoryProperties2Khr (NativePointer pointer) : base (pointer) {
+		}
+
+	}
+
+	unsafe public partial class SparseImageFormatProperties2 : MarshalledObject
 	{
 		public SparseImageFormatProperties Properties {
 			get { return m->Properties; }
 			set { m->Properties = value; }
 		}
-		internal Interop.SparseImageFormatProperties2Khr* m {
 
+		internal Interop.SparseImageFormatProperties2* m {
 			get {
-				return (Interop.SparseImageFormatProperties2Khr*)native.Handle;
+				return (Interop.SparseImageFormatProperties2*)native.Handle;
 			}
 		}
 
-		public SparseImageFormatProperties2Khr ()
+		public SparseImageFormatProperties2 ()
 		{
-			native = Interop.Structure.Allocate (typeof (Interop.SparseImageFormatProperties2Khr));
+			native = Interop.Structure.Allocate (typeof (Interop.SparseImageFormatProperties2));
 			Initialize ();
 		}
 
-		internal SparseImageFormatProperties2Khr (NativePointer pointer)
+		internal SparseImageFormatProperties2 (NativePointer pointer)
 		{
 			native = pointer;
 			Initialize ();
@@ -8475,12 +8801,22 @@ namespace Vulkan
 
 		internal void Initialize ()
 		{
-			m->SType = StructureType.SparseImageFormatProperties2Khr;
+			m->SType = StructureType.SparseImageFormatProperties2;
 		}
 
 	}
 
-	unsafe public partial class PhysicalDeviceSparseImageFormatInfo2Khr : MarshalledObject
+	unsafe public partial class SparseImageFormatProperties2Khr : SparseImageFormatProperties2
+	{
+		public SparseImageFormatProperties2Khr () : base () {
+		}
+
+		internal SparseImageFormatProperties2Khr (NativePointer pointer) : base (pointer) {
+		}
+
+	}
+
+	unsafe public partial class PhysicalDeviceSparseImageFormatInfo2 : MarshalledObject
 	{
 		public Format Format {
 			get { return m->Format; }
@@ -8506,20 +8842,20 @@ namespace Vulkan
 			get { return m->Tiling; }
 			set { m->Tiling = value; }
 		}
-		internal Interop.PhysicalDeviceSparseImageFormatInfo2Khr* m {
 
+		internal Interop.PhysicalDeviceSparseImageFormatInfo2* m {
 			get {
-				return (Interop.PhysicalDeviceSparseImageFormatInfo2Khr*)native.Handle;
+				return (Interop.PhysicalDeviceSparseImageFormatInfo2*)native.Handle;
 			}
 		}
 
-		public PhysicalDeviceSparseImageFormatInfo2Khr ()
+		public PhysicalDeviceSparseImageFormatInfo2 ()
 		{
-			native = Interop.Structure.Allocate (typeof (Interop.PhysicalDeviceSparseImageFormatInfo2Khr));
+			native = Interop.Structure.Allocate (typeof (Interop.PhysicalDeviceSparseImageFormatInfo2));
 			Initialize ();
 		}
 
-		internal PhysicalDeviceSparseImageFormatInfo2Khr (NativePointer pointer)
+		internal PhysicalDeviceSparseImageFormatInfo2 (NativePointer pointer)
 		{
 			native = pointer;
 			Initialize ();
@@ -8528,7 +8864,17 @@ namespace Vulkan
 
 		internal void Initialize ()
 		{
-			m->SType = StructureType.PhysicalDeviceSparseImageFormatInfo2Khr;
+			m->SType = StructureType.PhysicalDeviceSparseImageFormatInfo2;
+		}
+
+	}
+
+	unsafe public partial class PhysicalDeviceSparseImageFormatInfo2Khr : PhysicalDeviceSparseImageFormatInfo2
+	{
+		public PhysicalDeviceSparseImageFormatInfo2Khr () : base () {
+		}
+
+		internal PhysicalDeviceSparseImageFormatInfo2Khr (NativePointer pointer) : base (pointer) {
 		}
 
 	}
@@ -8539,8 +8885,8 @@ namespace Vulkan
 			get { return m->MaxPushDescriptors; }
 			set { m->MaxPushDescriptors = value; }
 		}
-		internal Interop.PhysicalDevicePushDescriptorPropertiesKhr* m {
 
+		internal Interop.PhysicalDevicePushDescriptorPropertiesKhr* m {
 			get {
 				return (Interop.PhysicalDevicePushDescriptorPropertiesKhr*)native.Handle;
 			}
@@ -8562,6 +8908,62 @@ namespace Vulkan
 		internal void Initialize ()
 		{
 			m->SType = StructureType.PhysicalDevicePushDescriptorPropertiesKhr;
+		}
+
+	}
+
+	unsafe public partial struct ConformanceVersionKhr
+	{
+		public byte Major;
+		public byte Minor;
+		public byte Subminor;
+		public byte Patch;
+	}
+
+	unsafe public partial class PhysicalDeviceDriverPropertiesKhr : MarshalledObject
+	{
+		public DriverIdKhr DriverId {
+			get { return m->DriverId; }
+			set { m->DriverId = value; }
+		}
+
+		public string DriverName {
+			get { return Marshal.PtrToStringAnsi ((IntPtr)m->DriverName); }
+			set { Interop.Structure.MarshalFixedSizeString (m->DriverName, value, 256); }
+		}
+
+		public string DriverInfo {
+			get { return Marshal.PtrToStringAnsi ((IntPtr)m->DriverInfo); }
+			set { Interop.Structure.MarshalFixedSizeString (m->DriverInfo, value, 256); }
+		}
+
+		public ConformanceVersionKhr ConformanceVersion {
+			get { return m->ConformanceVersion; }
+			set { m->ConformanceVersion = value; }
+		}
+
+		internal Interop.PhysicalDeviceDriverPropertiesKhr* m {
+			get {
+				return (Interop.PhysicalDeviceDriverPropertiesKhr*)native.Handle;
+			}
+		}
+
+		public PhysicalDeviceDriverPropertiesKhr ()
+		{
+			native = Interop.Structure.Allocate (typeof (Interop.PhysicalDeviceDriverPropertiesKhr));
+			Initialize ();
+		}
+
+		internal PhysicalDeviceDriverPropertiesKhr (NativePointer pointer)
+		{
+			native = pointer;
+			Initialize ();
+		}
+
+
+		internal void Initialize ()
+		{
+			m->SType = StructureType.PhysicalDeviceDriverPropertiesKhr;
 		}
 
 	}
@@ -8607,8 +9009,8 @@ namespace Vulkan
 				}
 			}
 		}
-		internal Interop.PresentRegionsKhr* m {
 
+		internal Interop.PresentRegionsKhr* m {
 			get {
 				return (Interop.PresentRegionsKhr*)native.Handle;
 			}
@@ -8681,8 +9083,8 @@ namespace Vulkan
 				}
 			}
 		}
-		internal Interop.PresentRegionKhr* m {
 
+		internal Interop.PresentRegionKhr* m {
 			get {
 				return (Interop.PresentRegionKhr*)native.Handle;
 			}
@@ -8715,7 +9117,7 @@ namespace Vulkan
 		public UInt32 Layer;
 	}
 
-	unsafe public partial class PhysicalDeviceVariablePointerFeaturesKhr : MarshalledObject
+	unsafe public partial class PhysicalDeviceVariablePointersFeatures : MarshalledObject
 	{
 		public bool VariablePointersStorageBuffer {
 			get { return m->VariablePointersStorageBuffer; }
@@ -8726,20 +9128,20 @@ namespace Vulkan
 			get { return m->VariablePointers; }
 			set { m->VariablePointers = value; }
 		}
-		internal Interop.PhysicalDeviceVariablePointerFeaturesKhr* m {
 
+		internal Interop.PhysicalDeviceVariablePointersFeatures* m {
 			get {
-				return (Interop.PhysicalDeviceVariablePointerFeaturesKhr*)native.Handle;
+				return (Interop.PhysicalDeviceVariablePointersFeatures*)native.Handle;
 			}
 		}
 
-		public PhysicalDeviceVariablePointerFeaturesKhr ()
+		public PhysicalDeviceVariablePointersFeatures ()
 		{
-			native = Interop.Structure.Allocate (typeof (Interop.PhysicalDeviceVariablePointerFeaturesKhr));
+			native = Interop.Structure.Allocate (typeof (Interop.PhysicalDeviceVariablePointersFeatures));
 			Initialize ();
 		}
 
-		internal PhysicalDeviceVariablePointerFeaturesKhr (NativePointer pointer)
+		internal PhysicalDeviceVariablePointersFeatures (NativePointer pointer)
 		{
 			native = pointer;
 			Initialize ();
@@ -8748,38 +9150,95 @@ namespace Vulkan
 
 		internal void Initialize ()
 		{
-			m->SType = StructureType.PhysicalDeviceVariablePointerFeaturesKhr;
+			m->SType = StructureType.PhysicalDeviceVariablePointersFeatures;
 		}
 
+	}
+
+	unsafe public partial class PhysicalDeviceVariablePointersFeaturesKhr : PhysicalDeviceVariablePointersFeatures
+	{
+		public PhysicalDeviceVariablePointersFeaturesKhr () : base () {
+		}
+
+		internal PhysicalDeviceVariablePointersFeaturesKhr (NativePointer pointer) : base (pointer) {
+		}
+
+	}
+
+	unsafe public partial class PhysicalDeviceVariablePointerFeaturesKhr : PhysicalDeviceVariablePointersFeatures
+	{
+		public PhysicalDeviceVariablePointerFeaturesKhr () : base () {
+		}
+
+		internal PhysicalDeviceVariablePointerFeaturesKhr (NativePointer pointer) : base (pointer) {
+		}
+
+	}
+
+	unsafe public partial class PhysicalDeviceVariablePointerFeatures : PhysicalDeviceVariablePointersFeatures
+	{
+		public PhysicalDeviceVariablePointerFeatures () : base () {
+		}
+
+		internal PhysicalDeviceVariablePointerFeatures (NativePointer pointer) : base (pointer) {
+		}
+
+	}
+
+	unsafe public partial struct ExternalMemoryProperties
+	{
+		public ExternalMemoryFeatureFlags ExternalMemoryFeatures;
+		public ExternalMemoryHandleTypeFlags ExportFromImportedHandleTypes;
+		public ExternalMemoryHandleTypeFlags CompatibleHandleTypes;
 	}
 
 	unsafe public partial struct ExternalMemoryPropertiesKhr
 	{
-		public ExternalMemoryFeatureFlagsKhr ExternalMemoryFeatures;
-		public ExternalMemoryHandleTypeFlagsKhr ExportFromImportedHandleTypes;
-		public ExternalMemoryHandleTypeFlagsKhr CompatibleHandleTypes;
+		public ExternalMemoryFeatureFlags ExternalMemoryFeatures;
+		public ExternalMemoryHandleTypeFlags ExportFromImportedHandleTypes;
+		public ExternalMemoryHandleTypeFlags CompatibleHandleTypes;
+
+		public static implicit operator ExternalMemoryPropertiesKhr (ExternalMemoryProperties that) {
+			var ret = new ExternalMemoryPropertiesKhr {
+				ExternalMemoryFeatures = that.ExternalMemoryFeatures,
+				ExportFromImportedHandleTypes = that.ExportFromImportedHandleTypes,
+				CompatibleHandleTypes = that.CompatibleHandleTypes,
+			};
+
+			return ret;
+		}
+
+		public static implicit operator ExternalMemoryProperties (ExternalMemoryPropertiesKhr that) {
+			var ret = new ExternalMemoryProperties {
+				ExternalMemoryFeatures = that.ExternalMemoryFeatures,
+				ExportFromImportedHandleTypes = that.ExportFromImportedHandleTypes,
+				CompatibleHandleTypes = that.CompatibleHandleTypes,
+			};
+
+			return ret;
+		}
 	}
 
-	unsafe public partial class PhysicalDeviceExternalImageFormatInfoKhr : MarshalledObject
+	unsafe public partial class PhysicalDeviceExternalImageFormatInfo : MarshalledObject
 	{
-		public ExternalMemoryHandleTypeFlagsKhr HandleType {
+		public ExternalMemoryHandleTypeFlags HandleType {
 			get { return m->HandleType; }
 			set { m->HandleType = value; }
 		}
-		internal Interop.PhysicalDeviceExternalImageFormatInfoKhr* m {
 
+		internal Interop.PhysicalDeviceExternalImageFormatInfo* m {
 			get {
-				return (Interop.PhysicalDeviceExternalImageFormatInfoKhr*)native.Handle;
+				return (Interop.PhysicalDeviceExternalImageFormatInfo*)native.Handle;
 			}
 		}
 
-		public PhysicalDeviceExternalImageFormatInfoKhr ()
+		public PhysicalDeviceExternalImageFormatInfo ()
 		{
-			native = Interop.Structure.Allocate (typeof (Interop.PhysicalDeviceExternalImageFormatInfoKhr));
+			native = Interop.Structure.Allocate (typeof (Interop.PhysicalDeviceExternalImageFormatInfo));
 			Initialize ();
 		}
 
-		internal PhysicalDeviceExternalImageFormatInfoKhr (NativePointer pointer)
+		internal PhysicalDeviceExternalImageFormatInfo (NativePointer pointer)
 		{
 			native = pointer;
 			Initialize ();
@@ -8788,31 +9247,41 @@ namespace Vulkan
 
 		internal void Initialize ()
 		{
-			m->SType = StructureType.PhysicalDeviceExternalImageFormatInfoKhr;
+			m->SType = StructureType.PhysicalDeviceExternalImageFormatInfo;
 		}
 
 	}
 
-	unsafe public partial class ExternalImageFormatPropertiesKhr : MarshalledObject
+	unsafe public partial class PhysicalDeviceExternalImageFormatInfoKhr : PhysicalDeviceExternalImageFormatInfo
 	{
-		public ExternalMemoryPropertiesKhr ExternalMemoryProperties {
+		public PhysicalDeviceExternalImageFormatInfoKhr () : base () {
+		}
+
+		internal PhysicalDeviceExternalImageFormatInfoKhr (NativePointer pointer) : base (pointer) {
+		}
+
+	}
+
+	unsafe public partial class ExternalImageFormatProperties : MarshalledObject
+	{
+		public ExternalMemoryProperties ExternalMemoryProperties {
 			get { return m->ExternalMemoryProperties; }
 			set { m->ExternalMemoryProperties = value; }
 		}
-		internal Interop.ExternalImageFormatPropertiesKhr* m {
 
+		internal Interop.ExternalImageFormatProperties* m {
 			get {
-				return (Interop.ExternalImageFormatPropertiesKhr*)native.Handle;
+				return (Interop.ExternalImageFormatProperties*)native.Handle;
 			}
 		}
 
-		public ExternalImageFormatPropertiesKhr ()
+		public ExternalImageFormatProperties ()
 		{
-			native = Interop.Structure.Allocate (typeof (Interop.ExternalImageFormatPropertiesKhr));
+			native = Interop.Structure.Allocate (typeof (Interop.ExternalImageFormatProperties));
 			Initialize ();
 		}
 
-		internal ExternalImageFormatPropertiesKhr (NativePointer pointer)
+		internal ExternalImageFormatProperties (NativePointer pointer)
 		{
 			native = pointer;
 			Initialize ();
@@ -8821,12 +9290,22 @@ namespace Vulkan
 
 		internal void Initialize ()
 		{
-			m->SType = StructureType.ExternalImageFormatPropertiesKhr;
+			m->SType = StructureType.ExternalImageFormatProperties;
 		}
 
 	}
 
-	unsafe public partial class PhysicalDeviceExternalBufferInfoKhr : MarshalledObject
+	unsafe public partial class ExternalImageFormatPropertiesKhr : ExternalImageFormatProperties
+	{
+		public ExternalImageFormatPropertiesKhr () : base () {
+		}
+
+		internal ExternalImageFormatPropertiesKhr (NativePointer pointer) : base (pointer) {
+		}
+
+	}
+
+	unsafe public partial class PhysicalDeviceExternalBufferInfo : MarshalledObject
 	{
 		public BufferCreateFlags Flags {
 			get { return m->Flags; }
@@ -8838,24 +9317,24 @@ namespace Vulkan
 			set { m->Usage = value; }
 		}
 
-		public ExternalMemoryHandleTypeFlagsKhr HandleType {
+		public ExternalMemoryHandleTypeFlags HandleType {
 			get { return m->HandleType; }
 			set { m->HandleType = value; }
 		}
-		internal Interop.PhysicalDeviceExternalBufferInfoKhr* m {
 
+		internal Interop.PhysicalDeviceExternalBufferInfo* m {
 			get {
-				return (Interop.PhysicalDeviceExternalBufferInfoKhr*)native.Handle;
+				return (Interop.PhysicalDeviceExternalBufferInfo*)native.Handle;
 			}
 		}
 
-		public PhysicalDeviceExternalBufferInfoKhr ()
+		public PhysicalDeviceExternalBufferInfo ()
 		{
-			native = Interop.Structure.Allocate (typeof (Interop.PhysicalDeviceExternalBufferInfoKhr));
+			native = Interop.Structure.Allocate (typeof (Interop.PhysicalDeviceExternalBufferInfo));
 			Initialize ();
 		}
 
-		internal PhysicalDeviceExternalBufferInfoKhr (NativePointer pointer)
+		internal PhysicalDeviceExternalBufferInfo (NativePointer pointer)
 		{
 			native = pointer;
 			Initialize ();
@@ -8864,31 +9343,41 @@ namespace Vulkan
 
 		internal void Initialize ()
 		{
-			m->SType = StructureType.PhysicalDeviceExternalBufferInfoKhr;
+			m->SType = StructureType.PhysicalDeviceExternalBufferInfo;
 		}
 
 	}
 
-	unsafe public partial class ExternalBufferPropertiesKhr : MarshalledObject
+	unsafe public partial class PhysicalDeviceExternalBufferInfoKhr : PhysicalDeviceExternalBufferInfo
 	{
-		public ExternalMemoryPropertiesKhr ExternalMemoryProperties {
+		public PhysicalDeviceExternalBufferInfoKhr () : base () {
+		}
+
+		internal PhysicalDeviceExternalBufferInfoKhr (NativePointer pointer) : base (pointer) {
+		}
+
+	}
+
+	unsafe public partial class ExternalBufferProperties : MarshalledObject
+	{
+		public ExternalMemoryProperties ExternalMemoryProperties {
 			get { return m->ExternalMemoryProperties; }
 			set { m->ExternalMemoryProperties = value; }
 		}
-		internal Interop.ExternalBufferPropertiesKhr* m {
 
+		internal Interop.ExternalBufferProperties* m {
 			get {
-				return (Interop.ExternalBufferPropertiesKhr*)native.Handle;
+				return (Interop.ExternalBufferProperties*)native.Handle;
 			}
 		}
 
-		public ExternalBufferPropertiesKhr ()
+		public ExternalBufferProperties ()
 		{
-			native = Interop.Structure.Allocate (typeof (Interop.ExternalBufferPropertiesKhr));
+			native = Interop.Structure.Allocate (typeof (Interop.ExternalBufferProperties));
 			Initialize ();
 		}
 
-		internal ExternalBufferPropertiesKhr (NativePointer pointer)
+		internal ExternalBufferProperties (NativePointer pointer)
 		{
 			native = pointer;
 			Initialize ();
@@ -8897,12 +9386,22 @@ namespace Vulkan
 
 		internal void Initialize ()
 		{
-			m->SType = StructureType.ExternalBufferPropertiesKhr;
+			m->SType = StructureType.ExternalBufferProperties;
 		}
 
 	}
 
-	unsafe public partial class PhysicalDeviceIDPropertiesKhr : MarshalledObject
+	unsafe public partial class ExternalBufferPropertiesKhr : ExternalBufferProperties
+	{
+		public ExternalBufferPropertiesKhr () : base () {
+		}
+
+		internal ExternalBufferPropertiesKhr (NativePointer pointer) : base (pointer) {
+		}
+
+	}
+
+	unsafe public partial class PhysicalDeviceIDProperties : MarshalledObject
 	{
 		public byte[] DeviceUuid {
 			get {
@@ -8967,20 +9466,20 @@ namespace Vulkan
 			get { return m->DeviceLuidvalid; }
 			set { m->DeviceLuidvalid = value; }
 		}
-		internal Interop.PhysicalDeviceIDPropertiesKhr* m {
 
+		internal Interop.PhysicalDeviceIDProperties* m {
 			get {
-				return (Interop.PhysicalDeviceIDPropertiesKhr*)native.Handle;
+				return (Interop.PhysicalDeviceIDProperties*)native.Handle;
 			}
 		}
 
-		public PhysicalDeviceIDPropertiesKhr ()
+		public PhysicalDeviceIDProperties ()
 		{
-			native = Interop.Structure.Allocate (typeof (Interop.PhysicalDeviceIDPropertiesKhr));
+			native = Interop.Structure.Allocate (typeof (Interop.PhysicalDeviceIDProperties));
 			Initialize ();
 		}
 
-		internal PhysicalDeviceIDPropertiesKhr (NativePointer pointer)
+		internal PhysicalDeviceIDProperties (NativePointer pointer)
 		{
 			native = pointer;
 			Initialize ();
@@ -8989,64 +9488,41 @@ namespace Vulkan
 
 		internal void Initialize ()
 		{
-			m->SType = StructureType.PhysicalDeviceIDPropertiesKhr;
+			m->SType = StructureType.PhysicalDeviceIDProperties;
 		}
 
 	}
 
-	unsafe public partial class ExternalMemoryImageCreateInfoKhr : MarshalledObject
+	unsafe public partial class PhysicalDeviceIDPropertiesKhr : PhysicalDeviceIDProperties
 	{
-		public ExternalMemoryHandleTypeFlagsKhr HandleTypes {
-			get { return m->HandleTypes; }
-			set { m->HandleTypes = value; }
-		}
-		internal Interop.ExternalMemoryImageCreateInfoKhr* m {
-
-			get {
-				return (Interop.ExternalMemoryImageCreateInfoKhr*)native.Handle;
-			}
+		public PhysicalDeviceIDPropertiesKhr () : base () {
 		}
 
-		public ExternalMemoryImageCreateInfoKhr ()
-		{
-			native = Interop.Structure.Allocate (typeof (Interop.ExternalMemoryImageCreateInfoKhr));
-			Initialize ();
-		}
-
-		internal ExternalMemoryImageCreateInfoKhr (NativePointer pointer)
-		{
-			native = pointer;
-			Initialize ();
-		}
-
-
-		internal void Initialize ()
-		{
-			m->SType = StructureType.ExternalMemoryImageCreateInfoKhr;
+		internal PhysicalDeviceIDPropertiesKhr (NativePointer pointer) : base (pointer) {
 		}
 
 	}
 
-	unsafe public partial class ExternalMemoryBufferCreateInfoKhr : MarshalledObject
+	unsafe public partial class ExternalMemoryImageCreateInfo : MarshalledObject
 	{
-		public ExternalMemoryHandleTypeFlagsKhr HandleTypes {
+		public ExternalMemoryHandleTypeFlags HandleTypes {
 			get { return m->HandleTypes; }
 			set { m->HandleTypes = value; }
 		}
-		internal Interop.ExternalMemoryBufferCreateInfoKhr* m {
 
+		internal Interop.ExternalMemoryImageCreateInfo* m {
 			get {
-				return (Interop.ExternalMemoryBufferCreateInfoKhr*)native.Handle;
+				return (Interop.ExternalMemoryImageCreateInfo*)native.Handle;
 			}
 		}
 
-		public ExternalMemoryBufferCreateInfoKhr ()
+		public ExternalMemoryImageCreateInfo ()
 		{
-			native = Interop.Structure.Allocate (typeof (Interop.ExternalMemoryBufferCreateInfoKhr));
+			native = Interop.Structure.Allocate (typeof (Interop.ExternalMemoryImageCreateInfo));
 			Initialize ();
 		}
 
-		internal ExternalMemoryBufferCreateInfoKhr (NativePointer pointer)
+		internal ExternalMemoryImageCreateInfo (NativePointer pointer)
 		{
 			native = pointer;
 			Initialize ();
@@ -9055,31 +9531,41 @@ namespace Vulkan
 
 		internal void Initialize ()
 		{
-			m->SType = StructureType.ExternalMemoryBufferCreateInfoKhr;
+			m->SType = StructureType.ExternalMemoryImageCreateInfo;
 		}
 
 	}
 
-	unsafe public partial class ExportMemoryAllocateInfoKhr : MarshalledObject
+	unsafe public partial class ExternalMemoryImageCreateInfoKhr : ExternalMemoryImageCreateInfo
 	{
-		public ExternalMemoryHandleTypeFlagsKhr HandleTypes {
+		public ExternalMemoryImageCreateInfoKhr () : base () {
+		}
+
+		internal ExternalMemoryImageCreateInfoKhr (NativePointer pointer) : base (pointer) {
+		}
+
+	}
+
+	unsafe public partial class ExternalMemoryBufferCreateInfo : MarshalledObject
+	{
+		public ExternalMemoryHandleTypeFlags HandleTypes {
 			get { return m->HandleTypes; }
 			set { m->HandleTypes = value; }
 		}
-		internal Interop.ExportMemoryAllocateInfoKhr* m {
 
+		internal Interop.ExternalMemoryBufferCreateInfo* m {
 			get {
-				return (Interop.ExportMemoryAllocateInfoKhr*)native.Handle;
+				return (Interop.ExternalMemoryBufferCreateInfo*)native.Handle;
 			}
 		}
 
-		public ExportMemoryAllocateInfoKhr ()
+		public ExternalMemoryBufferCreateInfo ()
 		{
-			native = Interop.Structure.Allocate (typeof (Interop.ExportMemoryAllocateInfoKhr));
+			native = Interop.Structure.Allocate (typeof (Interop.ExternalMemoryBufferCreateInfo));
 			Initialize ();
 		}
 
-		internal ExportMemoryAllocateInfoKhr (NativePointer pointer)
+		internal ExternalMemoryBufferCreateInfo (NativePointer pointer)
 		{
 			native = pointer;
 			Initialize ();
@@ -9088,7 +9574,60 @@ namespace Vulkan
 
 		internal void Initialize ()
 		{
-			m->SType = StructureType.ExportMemoryAllocateInfoKhr;
+			m->SType = StructureType.ExternalMemoryBufferCreateInfo;
+		}
+
+	}
+
+	unsafe public partial class ExternalMemoryBufferCreateInfoKhr : ExternalMemoryBufferCreateInfo
+	{
+		public ExternalMemoryBufferCreateInfoKhr () : base () {
+		}
+
+		internal ExternalMemoryBufferCreateInfoKhr (NativePointer pointer) : base (pointer) {
+		}
+
+	}
+
+	unsafe public partial class ExportMemoryAllocateInfo : MarshalledObject
+	{
+		public ExternalMemoryHandleTypeFlags HandleTypes {
+			get { return m->HandleTypes; }
+			set { m->HandleTypes = value; }
+		}
+
+		internal Interop.ExportMemoryAllocateInfo* m {
+			get {
+				return (Interop.ExportMemoryAllocateInfo*)native.Handle;
+			}
+		}
+
+		public ExportMemoryAllocateInfo ()
+		{
+			native = Interop.Structure.Allocate (typeof (Interop.ExportMemoryAllocateInfo));
+			Initialize ();
+		}
+
+		internal ExportMemoryAllocateInfo (NativePointer pointer)
+		{
+			native = pointer;
+			Initialize ();
+		}
+
+
+		internal void Initialize ()
+		{
+			m->SType = StructureType.ExportMemoryAllocateInfo;
+		}
+
+	}
+
+	unsafe public partial class ExportMemoryAllocateInfoKhr : ExportMemoryAllocateInfo
+	{
+		public ExportMemoryAllocateInfoKhr () : base () {
+		}
+
+		internal ExportMemoryAllocateInfoKhr (NativePointer pointer) : base (pointer) {
 		}
 
 	}
@@ -9099,8 +9638,8 @@ namespace Vulkan
 			get { return m->MemoryTypeBits; }
 			set { m->MemoryTypeBits = value; }
 		}
-		internal Interop.MemoryWin32HandlePropertiesKhr* m {
 
+		internal Interop.MemoryWin32HandlePropertiesKhr* m {
 			get {
 				return (Interop.MemoryWin32HandlePropertiesKhr*)native.Handle;
 			}
@@ -9134,12 +9673,12 @@ namespace Vulkan
 			set { lMemory = value; m->Memory = value != null ? (UInt64)value.m : default(UInt64); }
 		}
 
-		public ExternalMemoryHandleTypeFlagsKhr HandleType {
+		public ExternalMemoryHandleTypeFlags HandleType {
 			get { return m->HandleType; }
 			set { m->HandleType = value; }
 		}
-		internal Interop.MemoryGetWin32HandleInfoKhr* m {
 
+		internal Interop.MemoryGetWin32HandleInfoKhr* m {
 			get {
 				return (Interop.MemoryGetWin32HandleInfoKhr*)native.Handle;
 			}
@@ -9167,7 +9706,7 @@ namespace Vulkan
 
 	unsafe public partial class ImportMemoryFdInfoKhr : MarshalledObject
 	{
-		public ExternalMemoryHandleTypeFlagsKhr HandleType {
+		public ExternalMemoryHandleTypeFlags HandleType {
 			get { return m->HandleType; }
 			set { m->HandleType = value; }
 		}
@@ -9176,8 +9715,8 @@ namespace Vulkan
 			get { return m->Fd; }
 			set { m->Fd = value; }
 		}
-		internal Interop.ImportMemoryFdInfoKhr* m {
 
+		internal Interop.ImportMemoryFdInfoKhr* m {
 			get {
 				return (Interop.ImportMemoryFdInfoKhr*)native.Handle;
 			}
@@ -9209,8 +9748,8 @@ namespace Vulkan
 			get { return m->MemoryTypeBits; }
 			set { m->MemoryTypeBits = value; }
 		}
-		internal Interop.MemoryFdPropertiesKhr* m {
 
+		internal Interop.MemoryFdPropertiesKhr* m {
 			get {
 				return (Interop.MemoryFdPropertiesKhr*)native.Handle;
 			}
@@ -9244,12 +9783,12 @@ namespace Vulkan
 			set { lMemory = value; m->Memory = value != null ? (UInt64)value.m : default(UInt64); }
 		}
 
-		public ExternalMemoryHandleTypeFlagsKhr HandleType {
+		public ExternalMemoryHandleTypeFlags HandleType {
 			get { return m->HandleType; }
 			set { m->HandleType = value; }
 		}
-		internal Interop.MemoryGetFdInfoKhr* m {
 
+		internal Interop.MemoryGetFdInfoKhr* m {
 			get {
 				return (Interop.MemoryGetFdInfoKhr*)native.Handle;
 			}
@@ -9455,8 +9994,8 @@ namespace Vulkan
 				}
 			}
 		}
-		internal Interop.Win32KeyedMutexAcquireReleaseInfoKhr* m {
 
+		internal Interop.Win32KeyedMutexAcquireReleaseInfoKhr* m {
 			get {
 				return (Interop.Win32KeyedMutexAcquireReleaseInfoKhr*)native.Handle;
 			}
@@ -9498,26 +10037,26 @@ namespace Vulkan
 
 	}
 
-	unsafe public partial class PhysicalDeviceExternalSemaphoreInfoKhr : MarshalledObject
+	unsafe public partial class PhysicalDeviceExternalSemaphoreInfo : MarshalledObject
 	{
-		public ExternalSemaphoreHandleTypeFlagsKhr HandleType {
+		public ExternalSemaphoreHandleTypeFlags HandleType {
 			get { return m->HandleType; }
 			set { m->HandleType = value; }
 		}
-		internal Interop.PhysicalDeviceExternalSemaphoreInfoKhr* m {
 
+		internal Interop.PhysicalDeviceExternalSemaphoreInfo* m {
 			get {
-				return (Interop.PhysicalDeviceExternalSemaphoreInfoKhr*)native.Handle;
+				return (Interop.PhysicalDeviceExternalSemaphoreInfo*)native.Handle;
 			}
 		}
 
-		public PhysicalDeviceExternalSemaphoreInfoKhr ()
+		public PhysicalDeviceExternalSemaphoreInfo ()
 		{
-			native = Interop.Structure.Allocate (typeof (Interop.PhysicalDeviceExternalSemaphoreInfoKhr));
+			native = Interop.Structure.Allocate (typeof (Interop.PhysicalDeviceExternalSemaphoreInfo));
 			Initialize ();
 		}
 
-		internal PhysicalDeviceExternalSemaphoreInfoKhr (NativePointer pointer)
+		internal PhysicalDeviceExternalSemaphoreInfo (NativePointer pointer)
 		{
 			native = pointer;
 			Initialize ();
@@ -9526,41 +10065,51 @@ namespace Vulkan
 
 		internal void Initialize ()
 		{
-			m->SType = StructureType.PhysicalDeviceExternalSemaphoreInfoKhr;
+			m->SType = StructureType.PhysicalDeviceExternalSemaphoreInfo;
 		}
 
 	}
 
-	unsafe public partial class ExternalSemaphorePropertiesKhr : MarshalledObject
+	unsafe public partial class PhysicalDeviceExternalSemaphoreInfoKhr : PhysicalDeviceExternalSemaphoreInfo
 	{
-		public ExternalSemaphoreHandleTypeFlagsKhr ExportFromImportedHandleTypes {
+		public PhysicalDeviceExternalSemaphoreInfoKhr () : base () {
+		}
+
+		internal PhysicalDeviceExternalSemaphoreInfoKhr (NativePointer pointer) : base (pointer) {
+		}
+
+	}
+
+	unsafe public partial class ExternalSemaphoreProperties : MarshalledObject
+	{
+		public ExternalSemaphoreHandleTypeFlags ExportFromImportedHandleTypes {
 			get { return m->ExportFromImportedHandleTypes; }
 			set { m->ExportFromImportedHandleTypes = value; }
 		}
 
-		public ExternalSemaphoreHandleTypeFlagsKhr CompatibleHandleTypes {
+		public ExternalSemaphoreHandleTypeFlags CompatibleHandleTypes {
 			get { return m->CompatibleHandleTypes; }
 			set { m->CompatibleHandleTypes = value; }
 		}
 
-		public ExternalSemaphoreFeatureFlagsKhr ExternalSemaphoreFeatures {
+		public ExternalSemaphoreFeatureFlags ExternalSemaphoreFeatures {
 			get { return m->ExternalSemaphoreFeatures; }
 			set { m->ExternalSemaphoreFeatures = value; }
 		}
-		internal Interop.ExternalSemaphorePropertiesKhr* m {
 
+		internal Interop.ExternalSemaphoreProperties* m {
 			get {
-				return (Interop.ExternalSemaphorePropertiesKhr*)native.Handle;
+				return (Interop.ExternalSemaphoreProperties*)native.Handle;
 			}
 		}
 
-		public ExternalSemaphorePropertiesKhr ()
+		public ExternalSemaphoreProperties ()
 		{
-			native = Interop.Structure.Allocate (typeof (Interop.ExternalSemaphorePropertiesKhr));
+			native = Interop.Structure.Allocate (typeof (Interop.ExternalSemaphoreProperties));
 			Initialize ();
 		}
 
-		internal ExternalSemaphorePropertiesKhr (NativePointer pointer)
+		internal ExternalSemaphoreProperties (NativePointer pointer)
 		{
 			native = pointer;
 			Initialize ();
@@ -9569,31 +10118,41 @@ namespace Vulkan
 
 		internal void Initialize ()
 		{
-			m->SType = StructureType.ExternalSemaphorePropertiesKhr;
+			m->SType = StructureType.ExternalSemaphoreProperties;
 		}
 
 	}
 
-	unsafe public partial class ExportSemaphoreCreateInfoKhr : MarshalledObject
+	unsafe public partial class ExternalSemaphorePropertiesKhr : ExternalSemaphoreProperties
 	{
-		public ExternalSemaphoreHandleTypeFlagsKhr HandleTypes {
+		public ExternalSemaphorePropertiesKhr () : base () {
+		}
+
+		internal ExternalSemaphorePropertiesKhr (NativePointer pointer) : base (pointer) {
+		}
+
+	}
+
+	unsafe public partial class ExportSemaphoreCreateInfo : MarshalledObject
+	{
+		public ExternalSemaphoreHandleTypeFlags HandleTypes {
 			get { return m->HandleTypes; }
 			set { m->HandleTypes = value; }
 		}
-		internal Interop.ExportSemaphoreCreateInfoKhr* m {
 
+		internal Interop.ExportSemaphoreCreateInfo* m {
 			get {
-				return (Interop.ExportSemaphoreCreateInfoKhr*)native.Handle;
+				return (Interop.ExportSemaphoreCreateInfo*)native.Handle;
 			}
 		}
 
-		public ExportSemaphoreCreateInfoKhr ()
+		public ExportSemaphoreCreateInfo ()
 		{
-			native = Interop.Structure.Allocate (typeof (Interop.ExportSemaphoreCreateInfoKhr));
+			native = Interop.Structure.Allocate (typeof (Interop.ExportSemaphoreCreateInfo));
 			Initialize ();
 		}
 
-		internal ExportSemaphoreCreateInfoKhr (NativePointer pointer)
+		internal ExportSemaphoreCreateInfo (NativePointer pointer)
 		{
 			native = pointer;
 			Initialize ();
@@ -9602,7 +10161,17 @@ namespace Vulkan
 
 		internal void Initialize ()
 		{
-			m->SType = StructureType.ExportSemaphoreCreateInfoKhr;
+			m->SType = StructureType.ExportSemaphoreCreateInfo;
+		}
+
+	}
+
+	unsafe public partial class ExportSemaphoreCreateInfoKhr : ExportSemaphoreCreateInfo
+	{
+		public ExportSemaphoreCreateInfoKhr () : base () {
+		}
+
+		internal ExportSemaphoreCreateInfoKhr (NativePointer pointer) : base (pointer) {
 		}
 
 	}
@@ -9684,8 +10253,8 @@ namespace Vulkan
 				}
 			}
 		}
-		internal Interop.D3D12FenceSubmitInfoKhr* m {
 
+		internal Interop.D3D12FenceSubmitInfoKhr* m {
 			get {
 				return (Interop.D3D12FenceSubmitInfoKhr*)native.Handle;
 			}
@@ -9729,12 +10298,12 @@ namespace Vulkan
 			set { lSemaphore = value; m->Semaphore = value != null ? (UInt64)value.m : default(UInt64); }
 		}
 
-		public ExternalSemaphoreHandleTypeFlagsKhr HandleType {
+		public ExternalSemaphoreHandleTypeFlags HandleType {
 			get { return m->HandleType; }
 			set { m->HandleType = value; }
 		}
-		internal Interop.SemaphoreGetWin32HandleInfoKhr* m {
 
+		internal Interop.SemaphoreGetWin32HandleInfoKhr* m {
 			get {
 				return (Interop.SemaphoreGetWin32HandleInfoKhr*)native.Handle;
 			}
@@ -9768,12 +10337,12 @@ namespace Vulkan
 			set { lSemaphore = value; m->Semaphore = value != null ? (UInt64)value.m : default(UInt64); }
 		}
 
-		public SemaphoreImportFlagsKhr Flags {
+		public SemaphoreImportFlags Flags {
 			get { return m->Flags; }
 			set { m->Flags = value; }
 		}
 
-		public ExternalSemaphoreHandleTypeFlagsKhr HandleType {
+		public ExternalSemaphoreHandleTypeFlags HandleType {
 			get { return m->HandleType; }
 			set { m->HandleType = value; }
 		}
@@ -9782,8 +10351,8 @@ namespace Vulkan
 			get { return m->Fd; }
 			set { m->Fd = value; }
 		}
-		internal Interop.ImportSemaphoreFdInfoKhr* m {
 
+		internal Interop.ImportSemaphoreFdInfoKhr* m {
 			get {
 				return (Interop.ImportSemaphoreFdInfoKhr*)native.Handle;
 			}
@@ -9817,12 +10386,12 @@ namespace Vulkan
 			set { lSemaphore = value; m->Semaphore = value != null ? (UInt64)value.m : default(UInt64); }
 		}
 
-		public ExternalSemaphoreHandleTypeFlagsKhr HandleType {
+		public ExternalSemaphoreHandleTypeFlags HandleType {
 			get { return m->HandleType; }
 			set { m->HandleType = value; }
 		}
-		internal Interop.SemaphoreGetFdInfoKhr* m {
 
+		internal Interop.SemaphoreGetFdInfoKhr* m {
 			get {
 				return (Interop.SemaphoreGetFdInfoKhr*)native.Handle;
 			}
@@ -9848,26 +10417,26 @@ namespace Vulkan
 
 	}
 
-	unsafe public partial class PhysicalDeviceExternalFenceInfoKhr : MarshalledObject
+	unsafe public partial class PhysicalDeviceExternalFenceInfo : MarshalledObject
 	{
-		public ExternalFenceHandleTypeFlagsKhr HandleType {
+		public ExternalFenceHandleTypeFlags HandleType {
 			get { return m->HandleType; }
 			set { m->HandleType = value; }
 		}
-		internal Interop.PhysicalDeviceExternalFenceInfoKhr* m {
 
+		internal Interop.PhysicalDeviceExternalFenceInfo* m {
 			get {
-				return (Interop.PhysicalDeviceExternalFenceInfoKhr*)native.Handle;
+				return (Interop.PhysicalDeviceExternalFenceInfo*)native.Handle;
 			}
 		}
 
-		public PhysicalDeviceExternalFenceInfoKhr ()
+		public PhysicalDeviceExternalFenceInfo ()
 		{
-			native = Interop.Structure.Allocate (typeof (Interop.PhysicalDeviceExternalFenceInfoKhr));
+			native = Interop.Structure.Allocate (typeof (Interop.PhysicalDeviceExternalFenceInfo));
 			Initialize ();
 		}
 
-		internal PhysicalDeviceExternalFenceInfoKhr (NativePointer pointer)
+		internal PhysicalDeviceExternalFenceInfo (NativePointer pointer)
 		{
 			native = pointer;
 			Initialize ();
@@ -9876,41 +10445,51 @@ namespace Vulkan
 
 		internal void Initialize ()
 		{
-			m->SType = StructureType.PhysicalDeviceExternalFenceInfoKhr;
+			m->SType = StructureType.PhysicalDeviceExternalFenceInfo;
 		}
 
 	}
 
-	unsafe public partial class ExternalFencePropertiesKhr : MarshalledObject
+	unsafe public partial class PhysicalDeviceExternalFenceInfoKhr : PhysicalDeviceExternalFenceInfo
 	{
-		public ExternalFenceHandleTypeFlagsKhr ExportFromImportedHandleTypes {
+		public PhysicalDeviceExternalFenceInfoKhr () : base () {
+		}
+
+		internal PhysicalDeviceExternalFenceInfoKhr (NativePointer pointer) : base (pointer) {
+		}
+
+	}
+
+	unsafe public partial class ExternalFenceProperties : MarshalledObject
+	{
+		public ExternalFenceHandleTypeFlags ExportFromImportedHandleTypes {
 			get { return m->ExportFromImportedHandleTypes; }
 			set { m->ExportFromImportedHandleTypes = value; }
 		}
 
-		public ExternalFenceHandleTypeFlagsKhr CompatibleHandleTypes {
+		public ExternalFenceHandleTypeFlags CompatibleHandleTypes {
 			get { return m->CompatibleHandleTypes; }
 			set { m->CompatibleHandleTypes = value; }
 		}
 
-		public ExternalFenceFeatureFlagsKhr ExternalFenceFeatures {
+		public ExternalFenceFeatureFlags ExternalFenceFeatures {
 			get { return m->ExternalFenceFeatures; }
 			set { m->ExternalFenceFeatures = value; }
 		}
-		internal Interop.ExternalFencePropertiesKhr* m {
 
+		internal Interop.ExternalFenceProperties* m {
 			get {
-				return (Interop.ExternalFencePropertiesKhr*)native.Handle;
+				return (Interop.ExternalFenceProperties*)native.Handle;
 			}
 		}
 
-		public ExternalFencePropertiesKhr ()
+		public ExternalFenceProperties ()
 		{
-			native = Interop.Structure.Allocate (typeof (Interop.ExternalFencePropertiesKhr));
+			native = Interop.Structure.Allocate (typeof (Interop.ExternalFenceProperties));
 			Initialize ();
 		}
 
-		internal ExternalFencePropertiesKhr (NativePointer pointer)
+		internal ExternalFenceProperties (NativePointer pointer)
 		{
 			native = pointer;
 			Initialize ();
@@ -9919,31 +10498,41 @@ namespace Vulkan
 
 		internal void Initialize ()
 		{
-			m->SType = StructureType.ExternalFencePropertiesKhr;
+			m->SType = StructureType.ExternalFenceProperties;
 		}
 
 	}
 
-	unsafe public partial class ExportFenceCreateInfoKhr : MarshalledObject
+	unsafe public partial class ExternalFencePropertiesKhr : ExternalFenceProperties
 	{
-		public ExternalFenceHandleTypeFlagsKhr HandleTypes {
+		public ExternalFencePropertiesKhr () : base () {
+		}
+
+		internal ExternalFencePropertiesKhr (NativePointer pointer) : base (pointer) {
+		}
+
+	}
+
+	unsafe public partial class ExportFenceCreateInfo : MarshalledObject
+	{
+		public ExternalFenceHandleTypeFlags HandleTypes {
 			get { return m->HandleTypes; }
 			set { m->HandleTypes = value; }
 		}
-		internal Interop.ExportFenceCreateInfoKhr* m {
 
+		internal Interop.ExportFenceCreateInfo* m {
 			get {
-				return (Interop.ExportFenceCreateInfoKhr*)native.Handle;
+				return (Interop.ExportFenceCreateInfo*)native.Handle;
 			}
 		}
 
-		public ExportFenceCreateInfoKhr ()
+		public ExportFenceCreateInfo ()
 		{
-			native = Interop.Structure.Allocate (typeof (Interop.ExportFenceCreateInfoKhr));
+			native = Interop.Structure.Allocate (typeof (Interop.ExportFenceCreateInfo));
 			Initialize ();
 		}
 
-		internal ExportFenceCreateInfoKhr (NativePointer pointer)
+		internal ExportFenceCreateInfo (NativePointer pointer)
 		{
 			native = pointer;
 			Initialize ();
@@ -9952,7 +10541,17 @@ namespace Vulkan
 
 		internal void Initialize ()
 		{
-			m->SType = StructureType.ExportFenceCreateInfoKhr;
+			m->SType = StructureType.ExportFenceCreateInfo;
+		}
+
+	}
+
+	unsafe public partial class ExportFenceCreateInfoKhr : ExportFenceCreateInfo
+	{
+		public ExportFenceCreateInfoKhr () : base () {
+		}
+
+		internal ExportFenceCreateInfoKhr (NativePointer pointer) : base (pointer) {
 		}
 
 	}
@@ -9965,12 +10564,12 @@ namespace Vulkan
 			set { lFence = value; m->Fence = value != null ? (UInt64)value.m : default(UInt64); }
 		}
 
-		public ExternalFenceHandleTypeFlagsKhr HandleType {
+		public ExternalFenceHandleTypeFlags HandleType {
 			get { return m->HandleType; }
 			set { m->HandleType = value; }
 		}
-		internal Interop.FenceGetWin32HandleInfoKhr* m {
 
+		internal Interop.FenceGetWin32HandleInfoKhr* m {
 			get {
 				return (Interop.FenceGetWin32HandleInfoKhr*)native.Handle;
 			}
@@ -10004,12 +10603,12 @@ namespace Vulkan
 			set { lFence = value; m->Fence = value != null ? (UInt64)value.m : default(UInt64); }
 		}
 
-		public FenceImportFlagsKhr Flags {
+		public FenceImportFlags Flags {
 			get { return m->Flags; }
 			set { m->Flags = value; }
 		}
 
-		public ExternalFenceHandleTypeFlagsKhr HandleType {
+		public ExternalFenceHandleTypeFlags HandleType {
 			get { return m->HandleType; }
 			set { m->HandleType = value; }
 		}
@@ -10018,8 +10617,8 @@ namespace Vulkan
 			get { return m->Fd; }
 			set { m->Fd = value; }
 		}
-		internal Interop.ImportFenceFdInfoKhr* m {
 
+		internal Interop.ImportFenceFdInfoKhr* m {
 			get {
 				return (Interop.ImportFenceFdInfoKhr*)native.Handle;
 			}
@@ -10053,12 +10652,12 @@ namespace Vulkan
 			set { lFence = value; m->Fence = value != null ? (UInt64)value.m : default(UInt64); }
 		}
 
-		public ExternalFenceHandleTypeFlagsKhr HandleType {
+		public ExternalFenceHandleTypeFlags HandleType {
 			get { return m->HandleType; }
 			set { m->HandleType = value; }
 		}
-		internal Interop.FenceGetFdInfoKhr* m {
 
+		internal Interop.FenceGetFdInfoKhr* m {
 			get {
 				return (Interop.FenceGetFdInfoKhr*)native.Handle;
 			}
@@ -10084,7 +10683,7 @@ namespace Vulkan
 
 	}
 
-	unsafe public partial class PhysicalDeviceMultiviewFeaturesKhx : MarshalledObject
+	unsafe public partial class PhysicalDeviceMultiviewFeatures : MarshalledObject
 	{
 		public bool Multiview {
 			get { return m->Multiview; }
@@ -10100,20 +10699,20 @@ namespace Vulkan
 			get { return m->MultiviewTessellationShader; }
 			set { m->MultiviewTessellationShader = value; }
 		}
-		internal Interop.PhysicalDeviceMultiviewFeaturesKhx* m {
 
+		internal Interop.PhysicalDeviceMultiviewFeatures* m {
 			get {
-				return (Interop.PhysicalDeviceMultiviewFeaturesKhx*)native.Handle;
+				return (Interop.PhysicalDeviceMultiviewFeatures*)native.Handle;
 			}
 		}
 
-		public PhysicalDeviceMultiviewFeaturesKhx ()
+		public PhysicalDeviceMultiviewFeatures ()
 		{
-			native = Interop.Structure.Allocate (typeof (Interop.PhysicalDeviceMultiviewFeaturesKhx));
+			native = Interop.Structure.Allocate (typeof (Interop.PhysicalDeviceMultiviewFeatures));
 			Initialize ();
 		}
 
-		internal PhysicalDeviceMultiviewFeaturesKhx (NativePointer pointer)
+		internal PhysicalDeviceMultiviewFeatures (NativePointer pointer)
 		{
 			native = pointer;
 			Initialize ();
@@ -10122,12 +10721,22 @@ namespace Vulkan
 
 		internal void Initialize ()
 		{
-			m->SType = StructureType.PhysicalDeviceMultiviewFeaturesKhx;
+			m->SType = StructureType.PhysicalDeviceMultiviewFeatures;
 		}
 
 	}
 
-	unsafe public partial class PhysicalDeviceMultiviewPropertiesKhx : MarshalledObject
+	unsafe public partial class PhysicalDeviceMultiviewFeaturesKhr : PhysicalDeviceMultiviewFeatures
+	{
+		public PhysicalDeviceMultiviewFeaturesKhr () : base () {
+		}
+
+		internal PhysicalDeviceMultiviewFeaturesKhr (NativePointer pointer) : base (pointer) {
+		}
+
+	}
+
+	unsafe public partial class PhysicalDeviceMultiviewProperties : MarshalledObject
 	{
 		public UInt32 MaxMultiviewViewCount {
 			get { return m->MaxMultiviewViewCount; }
@@ -10138,20 +10747,20 @@ namespace Vulkan
 			get { return m->MaxMultiviewInstanceIndex; }
 			set { m->MaxMultiviewInstanceIndex = value; }
 		}
-		internal Interop.PhysicalDeviceMultiviewPropertiesKhx* m {
 
+		internal Interop.PhysicalDeviceMultiviewProperties* m {
 			get {
-				return (Interop.PhysicalDeviceMultiviewPropertiesKhx*)native.Handle;
+				return (Interop.PhysicalDeviceMultiviewProperties*)native.Handle;
 			}
 		}
 
-		public PhysicalDeviceMultiviewPropertiesKhx ()
+		public PhysicalDeviceMultiviewProperties ()
 		{
-			native = Interop.Structure.Allocate (typeof (Interop.PhysicalDeviceMultiviewPropertiesKhx));
+			native = Interop.Structure.Allocate (typeof (Interop.PhysicalDeviceMultiviewProperties));
 			Initialize ();
 		}
 
-		internal PhysicalDeviceMultiviewPropertiesKhx (NativePointer pointer)
+		internal PhysicalDeviceMultiviewProperties (NativePointer pointer)
 		{
 			native = pointer;
 			Initialize ();
@@ -10160,12 +10769,22 @@ namespace Vulkan
 
 		internal void Initialize ()
 		{
-			m->SType = StructureType.PhysicalDeviceMultiviewPropertiesKhx;
+			m->SType = StructureType.PhysicalDeviceMultiviewProperties;
 		}
 
 	}
 
-	unsafe public partial class RenderPassMultiviewCreateInfoKhx : MarshalledObject
+	unsafe public partial class PhysicalDeviceMultiviewPropertiesKhr : PhysicalDeviceMultiviewProperties
+	{
+		public PhysicalDeviceMultiviewPropertiesKhr () : base () {
+		}
+
+		internal PhysicalDeviceMultiviewPropertiesKhr (NativePointer pointer) : base (pointer) {
+		}
+
+	}
+
+	unsafe public partial class RenderPassMultiviewCreateInfo : MarshalledObject
 	{
 		public UInt32 SubpassCount {
 			get { return m->SubpassCount; }
@@ -10280,20 +10899,20 @@ namespace Vulkan
 				}
 			}
 		}
-		internal Interop.RenderPassMultiviewCreateInfoKhx* m {
 
+		internal Interop.RenderPassMultiviewCreateInfo* m {
 			get {
-				return (Interop.RenderPassMultiviewCreateInfoKhx*)native.Handle;
+				return (Interop.RenderPassMultiviewCreateInfo*)native.Handle;
 			}
 		}
 
-		public RenderPassMultiviewCreateInfoKhx ()
+		public RenderPassMultiviewCreateInfo ()
 		{
-			native = Interop.Structure.Allocate (typeof (Interop.RenderPassMultiviewCreateInfoKhx));
+			native = Interop.Structure.Allocate (typeof (Interop.RenderPassMultiviewCreateInfo));
 			Initialize ();
 		}
 
-		internal RenderPassMultiviewCreateInfoKhx (NativePointer pointer)
+		internal RenderPassMultiviewCreateInfo (NativePointer pointer)
 		{
 			native = pointer;
 			Initialize ();
@@ -10314,7 +10933,17 @@ namespace Vulkan
 
 		internal void Initialize ()
 		{
-			m->SType = StructureType.RenderPassMultiviewCreateInfoKhx;
+			m->SType = StructureType.RenderPassMultiviewCreateInfo;
+		}
+
+	}
+
+	unsafe public partial class RenderPassMultiviewCreateInfoKhr : RenderPassMultiviewCreateInfo
+	{
+		public RenderPassMultiviewCreateInfoKhr () : base () {
+		}
+
+		internal RenderPassMultiviewCreateInfoKhr (NativePointer pointer) : base (pointer) {
 		}
 
 	}
@@ -10375,8 +11004,8 @@ namespace Vulkan
 			get { return m->SupportedSurfaceCounters; }
 			set { m->SupportedSurfaceCounters = value; }
 		}
-		internal Interop.SurfaceCapabilities2Ext* m {
 
+		internal Interop.SurfaceCapabilities2Ext* m {
 			get {
 				return (Interop.SurfaceCapabilities2Ext*)native.Handle;
 			}
@@ -10408,8 +11037,8 @@ namespace Vulkan
 			get { return m->PowerState; }
 			set { m->PowerState = value; }
 		}
-		internal Interop.DisplayPowerInfoExt* m {
 
+		internal Interop.DisplayPowerInfoExt* m {
 			get {
 				return (Interop.DisplayPowerInfoExt*)native.Handle;
 			}
@@ -10441,8 +11070,8 @@ namespace Vulkan
 			get { return m->DeviceEvent; }
 			set { m->DeviceEvent = value; }
 		}
-		internal Interop.DeviceEventInfoExt* m {
 
+		internal Interop.DeviceEventInfoExt* m {
 			get {
 				return (Interop.DeviceEventInfoExt*)native.Handle;
 			}
@@ -10474,8 +11103,8 @@ namespace Vulkan
 			get { return m->DisplayEvent; }
 			set { m->DisplayEvent = value; }
 		}
-		internal Interop.DisplayEventInfoExt* m {
 
+		internal Interop.DisplayEventInfoExt* m {
 			get {
 				return (Interop.DisplayEventInfoExt*)native.Handle;
 			}
@@ -10507,8 +11136,8 @@ namespace Vulkan
 			get { return m->SurfaceCounters; }
 			set { m->SurfaceCounters = value; }
 		}
-		internal Interop.SwapchainCounterCreateInfoExt* m {
 
+		internal Interop.SwapchainCounterCreateInfoExt* m {
 			get {
 				return (Interop.SwapchainCounterCreateInfoExt*)native.Handle;
 			}
@@ -10534,9 +11163,9 @@ namespace Vulkan
 
 	}
 
-	unsafe public partial class MemoryAllocateFlagsInfoKhx : MarshalledObject
+	unsafe public partial class MemoryAllocateFlagsInfo : MarshalledObject
 	{
-		public MemoryAllocateFlagsKhx Flags {
+		public MemoryAllocateFlags Flags {
 			get { return m->Flags; }
 			set { m->Flags = value; }
 		}
@@ -10545,20 +11174,20 @@ namespace Vulkan
 			get { return m->DeviceMask; }
 			set { m->DeviceMask = value; }
 		}
-		internal Interop.MemoryAllocateFlagsInfoKhx* m {
 
+		internal Interop.MemoryAllocateFlagsInfo* m {
 			get {
-				return (Interop.MemoryAllocateFlagsInfoKhx*)native.Handle;
+				return (Interop.MemoryAllocateFlagsInfo*)native.Handle;
 			}
 		}
 
-		public MemoryAllocateFlagsInfoKhx ()
+		public MemoryAllocateFlagsInfo ()
 		{
-			native = Interop.Structure.Allocate (typeof (Interop.MemoryAllocateFlagsInfoKhx));
+			native = Interop.Structure.Allocate (typeof (Interop.MemoryAllocateFlagsInfo));
 			Initialize ();
 		}
 
-		internal MemoryAllocateFlagsInfoKhx (NativePointer pointer)
+		internal MemoryAllocateFlagsInfo (NativePointer pointer)
 		{
 			native = pointer;
 			Initialize ();
@@ -10567,12 +11196,22 @@ namespace Vulkan
 
 		internal void Initialize ()
 		{
-			m->SType = StructureType.MemoryAllocateFlagsInfoKhx;
+			m->SType = StructureType.MemoryAllocateFlagsInfo;
 		}
 
 	}
 
-	unsafe public partial class BindBufferMemoryInfoKhr : MarshalledObject
+	unsafe public partial class MemoryAllocateFlagsInfoKhr : MemoryAllocateFlagsInfo
+	{
+		public MemoryAllocateFlagsInfoKhr () : base () {
+		}
+
+		internal MemoryAllocateFlagsInfoKhr (NativePointer pointer) : base (pointer) {
+		}
+
+	}
+
+	unsafe public partial class BindBufferMemoryInfo : MarshalledObject
 	{
 		Buffer lBuffer;
 		public Buffer Buffer {
@@ -10590,20 +11229,20 @@ namespace Vulkan
 			get { return m->MemoryOffset; }
 			set { m->MemoryOffset = value; }
 		}
-		internal Interop.BindBufferMemoryInfoKhr* m {
 
+		internal Interop.BindBufferMemoryInfo* m {
 			get {
-				return (Interop.BindBufferMemoryInfoKhr*)native.Handle;
+				return (Interop.BindBufferMemoryInfo*)native.Handle;
 			}
 		}
 
-		public BindBufferMemoryInfoKhr ()
+		public BindBufferMemoryInfo ()
 		{
-			native = Interop.Structure.Allocate (typeof (Interop.BindBufferMemoryInfoKhr));
+			native = Interop.Structure.Allocate (typeof (Interop.BindBufferMemoryInfo));
 			Initialize ();
 		}
 
-		internal BindBufferMemoryInfoKhr (NativePointer pointer)
+		internal BindBufferMemoryInfo (NativePointer pointer)
 		{
 			native = pointer;
 			Initialize ();
@@ -10612,12 +11251,22 @@ namespace Vulkan
 
 		internal void Initialize ()
 		{
-			m->SType = StructureType.BindBufferMemoryInfoKhr;
+			m->SType = StructureType.BindBufferMemoryInfo;
 		}
 
 	}
 
-	unsafe public partial class BindBufferMemoryDeviceGroupInfoKhx : MarshalledObject
+	unsafe public partial class BindBufferMemoryInfoKhr : BindBufferMemoryInfo
+	{
+		public BindBufferMemoryInfoKhr () : base () {
+		}
+
+		internal BindBufferMemoryInfoKhr (NativePointer pointer) : base (pointer) {
+		}
+
+	}
+
+	unsafe public partial class BindBufferMemoryDeviceGroupInfo : MarshalledObject
 	{
 		public UInt32 DeviceIndexCount {
 			get { return m->DeviceIndexCount; }
@@ -10656,20 +11305,20 @@ namespace Vulkan
 				}
 			}
 		}
-		internal Interop.BindBufferMemoryDeviceGroupInfoKhx* m {
 
+		internal Interop.BindBufferMemoryDeviceGroupInfo* m {
 			get {
-				return (Interop.BindBufferMemoryDeviceGroupInfoKhx*)native.Handle;
+				return (Interop.BindBufferMemoryDeviceGroupInfo*)native.Handle;
 			}
 		}
 
-		public BindBufferMemoryDeviceGroupInfoKhx ()
+		public BindBufferMemoryDeviceGroupInfo ()
 		{
-			native = Interop.Structure.Allocate (typeof (Interop.BindBufferMemoryDeviceGroupInfoKhx));
+			native = Interop.Structure.Allocate (typeof (Interop.BindBufferMemoryDeviceGroupInfo));
 			Initialize ();
 		}
 
-		internal BindBufferMemoryDeviceGroupInfoKhx (NativePointer pointer)
+		internal BindBufferMemoryDeviceGroupInfo (NativePointer pointer)
 		{
 			native = pointer;
 			Initialize ();
@@ -10686,12 +11335,22 @@ namespace Vulkan
 
 		internal void Initialize ()
 		{
-			m->SType = StructureType.BindBufferMemoryDeviceGroupInfoKhx;
+			m->SType = StructureType.BindBufferMemoryDeviceGroupInfo;
 		}
 
 	}
 
-	unsafe public partial class BindImageMemoryInfoKhr : MarshalledObject
+	unsafe public partial class BindBufferMemoryDeviceGroupInfoKhr : BindBufferMemoryDeviceGroupInfo
+	{
+		public BindBufferMemoryDeviceGroupInfoKhr () : base () {
+		}
+
+		internal BindBufferMemoryDeviceGroupInfoKhr (NativePointer pointer) : base (pointer) {
+		}
+
+	}
+
+	unsafe public partial class BindImageMemoryInfo : MarshalledObject
 	{
 		Image lImage;
 		public Image Image {
@@ -10709,20 +11368,20 @@ namespace Vulkan
 			get { return m->MemoryOffset; }
 			set { m->MemoryOffset = value; }
 		}
-		internal Interop.BindImageMemoryInfoKhr* m {
 
+		internal Interop.BindImageMemoryInfo* m {
 			get {
-				return (Interop.BindImageMemoryInfoKhr*)native.Handle;
+				return (Interop.BindImageMemoryInfo*)native.Handle;
 			}
 		}
 
-		public BindImageMemoryInfoKhr ()
+		public BindImageMemoryInfo ()
 		{
-			native = Interop.Structure.Allocate (typeof (Interop.BindImageMemoryInfoKhr));
+			native = Interop.Structure.Allocate (typeof (Interop.BindImageMemoryInfo));
 			Initialize ();
 		}
 
-		internal BindImageMemoryInfoKhr (NativePointer pointer)
+		internal BindImageMemoryInfo (NativePointer pointer)
 		{
 			native = pointer;
 			Initialize ();
@@ -10731,12 +11390,22 @@ namespace Vulkan
 
 		internal void Initialize ()
 		{
-			m->SType = StructureType.BindImageMemoryInfoKhr;
+			m->SType = StructureType.BindImageMemoryInfo;
 		}
 
 	}
 
-	unsafe public partial class BindImageMemoryDeviceGroupInfoKhx : MarshalledObject
+	unsafe public partial class BindImageMemoryInfoKhr : BindImageMemoryInfo
+	{
+		public BindImageMemoryInfoKhr () : base () {
+		}
+
+		internal BindImageMemoryInfoKhr (NativePointer pointer) : base (pointer) {
+		}
+
+	}
+
+	unsafe public partial class BindImageMemoryDeviceGroupInfo : MarshalledObject
 	{
 		public UInt32 DeviceIndexCount {
 			get { return m->DeviceIndexCount; }
@@ -10776,20 +11445,20 @@ namespace Vulkan
 			}
 		}
 
-		public UInt32 SfrrectCount {
-			get { return m->SfrrectCount; }
-			set { m->SfrrectCount = value; }
+		public UInt32 SplitInstanceBindRegionCount {
+			get { return m->SplitInstanceBindRegionCount; }
+			set { m->SplitInstanceBindRegionCount = value; }
 		}
 
-		NativeReference refSfrrects;
-		public Rect2D[] Sfrrects {
+		NativeReference refSplitInstanceBindRegions;
+		public Rect2D[] SplitInstanceBindRegions {
 			get {
-				if (m->SfrrectCount == 0)
+				if (m->SplitInstanceBindRegionCount == 0)
 					return null;
-				var values = new Rect2D [m->SfrrectCount];
+				var values = new Rect2D [m->SplitInstanceBindRegionCount];
 				unsafe
 				{
-					Rect2D* ptr = (Rect2D*)m->Sfrrects;
+					Rect2D* ptr = (Rect2D*)m->SplitInstanceBindRegions;
 					for (int i = 0; i < values.Length; i++) 
 						values [i] = ptr [i];
 				}
@@ -10798,35 +11467,35 @@ namespace Vulkan
 
 			set {
 				if (value == null) {
-					m->SfrrectCount = 0;
-					m->Sfrrects = IntPtr.Zero;
+					m->SplitInstanceBindRegionCount = 0;
+					m->SplitInstanceBindRegions = IntPtr.Zero;
 					return;
 				}
-				m->SfrrectCount = (uint)value.Length;
-				refSfrrects = new NativeReference ((int)(sizeof(Rect2D)*value.Length));
-				m->Sfrrects = refSfrrects.Handle;
+				m->SplitInstanceBindRegionCount = (uint)value.Length;
+				refSplitInstanceBindRegions = new NativeReference ((int)(sizeof(Rect2D)*value.Length));
+				m->SplitInstanceBindRegions = refSplitInstanceBindRegions.Handle;
 				unsafe
 				{
-					Rect2D* ptr = (Rect2D*)m->Sfrrects;
+					Rect2D* ptr = (Rect2D*)m->SplitInstanceBindRegions;
 					for (int i = 0; i < value.Length; i++)
 						ptr [i] = value [i];
 				}
 			}
 		}
-		internal Interop.BindImageMemoryDeviceGroupInfoKhx* m {
 
+		internal Interop.BindImageMemoryDeviceGroupInfo* m {
 			get {
-				return (Interop.BindImageMemoryDeviceGroupInfoKhx*)native.Handle;
+				return (Interop.BindImageMemoryDeviceGroupInfo*)native.Handle;
 			}
 		}
 
-		public BindImageMemoryDeviceGroupInfoKhx ()
+		public BindImageMemoryDeviceGroupInfo ()
 		{
-			native = Interop.Structure.Allocate (typeof (Interop.BindImageMemoryDeviceGroupInfoKhx));
+			native = Interop.Structure.Allocate (typeof (Interop.BindImageMemoryDeviceGroupInfo));
 			Initialize ();
 		}
 
-		internal BindImageMemoryDeviceGroupInfoKhx (NativePointer pointer)
+		internal BindImageMemoryDeviceGroupInfo (NativePointer pointer)
 		{
 			native = pointer;
 			Initialize ();
@@ -10839,18 +11508,28 @@ namespace Vulkan
 				return;
 			refDeviceIndices.Dispose ();
 			refDeviceIndices = null;
-			refSfrrects.Dispose ();
-			refSfrrects = null;
+			refSplitInstanceBindRegions.Dispose ();
+			refSplitInstanceBindRegions = null;
 		}
 
 		internal void Initialize ()
 		{
-			m->SType = StructureType.BindImageMemoryDeviceGroupInfoKhx;
+			m->SType = StructureType.BindImageMemoryDeviceGroupInfo;
 		}
 
 	}
 
-	unsafe public partial class DeviceGroupRenderPassBeginInfoKhx : MarshalledObject
+	unsafe public partial class BindImageMemoryDeviceGroupInfoKhr : BindImageMemoryDeviceGroupInfo
+	{
+		public BindImageMemoryDeviceGroupInfoKhr () : base () {
+		}
+
+		internal BindImageMemoryDeviceGroupInfoKhr (NativePointer pointer) : base (pointer) {
+		}
+
+	}
+
+	unsafe public partial class DeviceGroupRenderPassBeginInfo : MarshalledObject
 	{
 		public UInt32 DeviceMask {
 			get { return m->DeviceMask; }
@@ -10894,20 +11573,20 @@ namespace Vulkan
 				}
 			}
 		}
-		internal Interop.DeviceGroupRenderPassBeginInfoKhx* m {
 
+		internal Interop.DeviceGroupRenderPassBeginInfo* m {
 			get {
-				return (Interop.DeviceGroupRenderPassBeginInfoKhx*)native.Handle;
+				return (Interop.DeviceGroupRenderPassBeginInfo*)native.Handle;
 			}
 		}
 
-		public DeviceGroupRenderPassBeginInfoKhx ()
+		public DeviceGroupRenderPassBeginInfo ()
 		{
-			native = Interop.Structure.Allocate (typeof (Interop.DeviceGroupRenderPassBeginInfoKhx));
+			native = Interop.Structure.Allocate (typeof (Interop.DeviceGroupRenderPassBeginInfo));
 			Initialize ();
 		}
 
-		internal DeviceGroupRenderPassBeginInfoKhx (NativePointer pointer)
+		internal DeviceGroupRenderPassBeginInfo (NativePointer pointer)
 		{
 			native = pointer;
 			Initialize ();
@@ -10924,31 +11603,41 @@ namespace Vulkan
 
 		internal void Initialize ()
 		{
-			m->SType = StructureType.DeviceGroupRenderPassBeginInfoKhx;
+			m->SType = StructureType.DeviceGroupRenderPassBeginInfo;
 		}
 
 	}
 
-	unsafe public partial class DeviceGroupCommandBufferBeginInfoKhx : MarshalledObject
+	unsafe public partial class DeviceGroupRenderPassBeginInfoKhr : DeviceGroupRenderPassBeginInfo
+	{
+		public DeviceGroupRenderPassBeginInfoKhr () : base () {
+		}
+
+		internal DeviceGroupRenderPassBeginInfoKhr (NativePointer pointer) : base (pointer) {
+		}
+
+	}
+
+	unsafe public partial class DeviceGroupCommandBufferBeginInfo : MarshalledObject
 	{
 		public UInt32 DeviceMask {
 			get { return m->DeviceMask; }
 			set { m->DeviceMask = value; }
 		}
-		internal Interop.DeviceGroupCommandBufferBeginInfoKhx* m {
 
+		internal Interop.DeviceGroupCommandBufferBeginInfo* m {
 			get {
-				return (Interop.DeviceGroupCommandBufferBeginInfoKhx*)native.Handle;
+				return (Interop.DeviceGroupCommandBufferBeginInfo*)native.Handle;
 			}
 		}
 
-		public DeviceGroupCommandBufferBeginInfoKhx ()
+		public DeviceGroupCommandBufferBeginInfo ()
 		{
-			native = Interop.Structure.Allocate (typeof (Interop.DeviceGroupCommandBufferBeginInfoKhx));
+			native = Interop.Structure.Allocate (typeof (Interop.DeviceGroupCommandBufferBeginInfo));
 			Initialize ();
 		}
 
-		internal DeviceGroupCommandBufferBeginInfoKhx (NativePointer pointer)
+		internal DeviceGroupCommandBufferBeginInfo (NativePointer pointer)
 		{
 			native = pointer;
 			Initialize ();
@@ -10957,12 +11646,22 @@ namespace Vulkan
 
 		internal void Initialize ()
 		{
-			m->SType = StructureType.DeviceGroupCommandBufferBeginInfoKhx;
+			m->SType = StructureType.DeviceGroupCommandBufferBeginInfo;
 		}
 
 	}
 
-	unsafe public partial class DeviceGroupSubmitInfoKhx : MarshalledObject
+	unsafe public partial class DeviceGroupCommandBufferBeginInfoKhr : DeviceGroupCommandBufferBeginInfo
+	{
+		public DeviceGroupCommandBufferBeginInfoKhr () : base () {
+		}
+
+		internal DeviceGroupCommandBufferBeginInfoKhr (NativePointer pointer) : base (pointer) {
+		}
+
+	}
+
+	unsafe public partial class DeviceGroupSubmitInfo : MarshalledObject
 	{
 		public UInt32 WaitSemaphoreCount {
 			get { return m->WaitSemaphoreCount; }
@@ -11077,20 +11776,20 @@ namespace Vulkan
 				}
 			}
 		}
-		internal Interop.DeviceGroupSubmitInfoKhx* m {
 
+		internal Interop.DeviceGroupSubmitInfo* m {
 			get {
-				return (Interop.DeviceGroupSubmitInfoKhx*)native.Handle;
+				return (Interop.DeviceGroupSubmitInfo*)native.Handle;
 			}
 		}
 
-		public DeviceGroupSubmitInfoKhx ()
+		public DeviceGroupSubmitInfo ()
 		{
-			native = Interop.Structure.Allocate (typeof (Interop.DeviceGroupSubmitInfoKhx));
+			native = Interop.Structure.Allocate (typeof (Interop.DeviceGroupSubmitInfo));
 			Initialize ();
 		}
 
-		internal DeviceGroupSubmitInfoKhx (NativePointer pointer)
+		internal DeviceGroupSubmitInfo (NativePointer pointer)
 		{
 			native = pointer;
 			Initialize ();
@@ -11111,12 +11810,22 @@ namespace Vulkan
 
 		internal void Initialize ()
 		{
-			m->SType = StructureType.DeviceGroupSubmitInfoKhx;
+			m->SType = StructureType.DeviceGroupSubmitInfo;
 		}
 
 	}
 
-	unsafe public partial class DeviceGroupBindSparseInfoKhx : MarshalledObject
+	unsafe public partial class DeviceGroupSubmitInfoKhr : DeviceGroupSubmitInfo
+	{
+		public DeviceGroupSubmitInfoKhr () : base () {
+		}
+
+		internal DeviceGroupSubmitInfoKhr (NativePointer pointer) : base (pointer) {
+		}
+
+	}
+
+	unsafe public partial class DeviceGroupBindSparseInfo : MarshalledObject
 	{
 		public UInt32 ResourceDeviceIndex {
 			get { return m->ResourceDeviceIndex; }
@@ -11127,20 +11836,20 @@ namespace Vulkan
 			get { return m->MemoryDeviceIndex; }
 			set { m->MemoryDeviceIndex = value; }
 		}
-		internal Interop.DeviceGroupBindSparseInfoKhx* m {
 
+		internal Interop.DeviceGroupBindSparseInfo* m {
 			get {
-				return (Interop.DeviceGroupBindSparseInfoKhx*)native.Handle;
+				return (Interop.DeviceGroupBindSparseInfo*)native.Handle;
 			}
 		}
 
-		public DeviceGroupBindSparseInfoKhx ()
+		public DeviceGroupBindSparseInfo ()
 		{
-			native = Interop.Structure.Allocate (typeof (Interop.DeviceGroupBindSparseInfoKhx));
+			native = Interop.Structure.Allocate (typeof (Interop.DeviceGroupBindSparseInfo));
 			Initialize ();
 		}
 
-		internal DeviceGroupBindSparseInfoKhx (NativePointer pointer)
+		internal DeviceGroupBindSparseInfo (NativePointer pointer)
 		{
 			native = pointer;
 			Initialize ();
@@ -11149,12 +11858,22 @@ namespace Vulkan
 
 		internal void Initialize ()
 		{
-			m->SType = StructureType.DeviceGroupBindSparseInfoKhx;
+			m->SType = StructureType.DeviceGroupBindSparseInfo;
 		}
 
 	}
 
-	unsafe public partial class DeviceGroupPresentCapabilitiesKhx : MarshalledObject
+	unsafe public partial class DeviceGroupBindSparseInfoKhr : DeviceGroupBindSparseInfo
+	{
+		public DeviceGroupBindSparseInfoKhr () : base () {
+		}
+
+		internal DeviceGroupBindSparseInfoKhr (NativePointer pointer) : base (pointer) {
+		}
+
+	}
+
+	unsafe public partial class DeviceGroupPresentCapabilitiesKhr : MarshalledObject
 	{
 		public UInt32[] PresentMask {
 			get {
@@ -11174,24 +11893,24 @@ namespace Vulkan
 			}
 		}
 
-		public DeviceGroupPresentModeFlagsKhx Modes {
+		public DeviceGroupPresentModeFlagsKhr Modes {
 			get { return m->Modes; }
 			set { m->Modes = value; }
 		}
-		internal Interop.DeviceGroupPresentCapabilitiesKhx* m {
 
+		internal Interop.DeviceGroupPresentCapabilitiesKhr* m {
 			get {
-				return (Interop.DeviceGroupPresentCapabilitiesKhx*)native.Handle;
+				return (Interop.DeviceGroupPresentCapabilitiesKhr*)native.Handle;
 			}
 		}
 
-		public DeviceGroupPresentCapabilitiesKhx ()
+		public DeviceGroupPresentCapabilitiesKhr ()
 		{
-			native = Interop.Structure.Allocate (typeof (Interop.DeviceGroupPresentCapabilitiesKhx));
+			native = Interop.Structure.Allocate (typeof (Interop.DeviceGroupPresentCapabilitiesKhr));
 			Initialize ();
 		}
 
-		internal DeviceGroupPresentCapabilitiesKhx (NativePointer pointer)
+		internal DeviceGroupPresentCapabilitiesKhr (NativePointer pointer)
 		{
 			native = pointer;
 			Initialize ();
@@ -11200,32 +11919,32 @@ namespace Vulkan
 
 		internal void Initialize ()
 		{
-			m->SType = StructureType.DeviceGroupPresentCapabilitiesKhx;
+			m->SType = StructureType.DeviceGroupPresentCapabilitiesKhr;
 		}
 
 	}
 
-	unsafe public partial class ImageSwapchainCreateInfoKhx : MarshalledObject
+	unsafe public partial class ImageSwapchainCreateInfoKhr : MarshalledObject
 	{
 		SwapchainKhr lSwapchain;
 		public SwapchainKhr Swapchain {
 			get { return lSwapchain; }
 			set { lSwapchain = value; m->Swapchain = value != null ? (UInt64)value.m : default(UInt64); }
 		}
-		internal Interop.ImageSwapchainCreateInfoKhx* m {
 
+		internal Interop.ImageSwapchainCreateInfoKhr* m {
 			get {
-				return (Interop.ImageSwapchainCreateInfoKhx*)native.Handle;
+				return (Interop.ImageSwapchainCreateInfoKhr*)native.Handle;
 			}
 		}
 
-		public ImageSwapchainCreateInfoKhx ()
+		public ImageSwapchainCreateInfoKhr ()
 		{
-			native = Interop.Structure.Allocate (typeof (Interop.ImageSwapchainCreateInfoKhx));
+			native = Interop.Structure.Allocate (typeof (Interop.ImageSwapchainCreateInfoKhr));
 			Initialize ();
 		}
 
-		internal ImageSwapchainCreateInfoKhx (NativePointer pointer)
+		internal ImageSwapchainCreateInfoKhr (NativePointer pointer)
 		{
 			native = pointer;
 			Initialize ();
@@ -11234,12 +11953,12 @@ namespace Vulkan
 
 		internal void Initialize ()
 		{
-			m->SType = StructureType.ImageSwapchainCreateInfoKhx;
+			m->SType = StructureType.ImageSwapchainCreateInfoKhr;
 		}
 
 	}
 
-	unsafe public partial class BindImageMemorySwapchainInfoKhx : MarshalledObject
+	unsafe public partial class BindImageMemorySwapchainInfoKhr : MarshalledObject
 	{
 		SwapchainKhr lSwapchain;
 		public SwapchainKhr Swapchain {
@@ -11251,20 +11970,20 @@ namespace Vulkan
 			get { return m->ImageIndex; }
 			set { m->ImageIndex = value; }
 		}
-		internal Interop.BindImageMemorySwapchainInfoKhx* m {
 
+		internal Interop.BindImageMemorySwapchainInfoKhr* m {
 			get {
-				return (Interop.BindImageMemorySwapchainInfoKhx*)native.Handle;
+				return (Interop.BindImageMemorySwapchainInfoKhr*)native.Handle;
 			}
 		}
 
-		public BindImageMemorySwapchainInfoKhx ()
+		public BindImageMemorySwapchainInfoKhr ()
 		{
-			native = Interop.Structure.Allocate (typeof (Interop.BindImageMemorySwapchainInfoKhx));
+			native = Interop.Structure.Allocate (typeof (Interop.BindImageMemorySwapchainInfoKhr));
 			Initialize ();
 		}
 
-		internal BindImageMemorySwapchainInfoKhx (NativePointer pointer)
+		internal BindImageMemorySwapchainInfoKhr (NativePointer pointer)
 		{
 			native = pointer;
 			Initialize ();
@@ -11273,12 +11992,12 @@ namespace Vulkan
 
 		internal void Initialize ()
 		{
-			m->SType = StructureType.BindImageMemorySwapchainInfoKhx;
+			m->SType = StructureType.BindImageMemorySwapchainInfoKhr;
 		}
 
 	}
 
-	unsafe public partial class AcquireNextImageInfoKhx : MarshalledObject
+	unsafe public partial class AcquireNextImageInfoKhr : MarshalledObject
 	{
 		SwapchainKhr lSwapchain;
 		public SwapchainKhr Swapchain {
@@ -11307,20 +12026,20 @@ namespace Vulkan
 			get { return m->DeviceMask; }
 			set { m->DeviceMask = value; }
 		}
-		internal Interop.AcquireNextImageInfoKhx* m {
 
+		internal Interop.AcquireNextImageInfoKhr* m {
 			get {
-				return (Interop.AcquireNextImageInfoKhx*)native.Handle;
+				return (Interop.AcquireNextImageInfoKhr*)native.Handle;
 			}
 		}
 
-		public AcquireNextImageInfoKhx ()
+		public AcquireNextImageInfoKhr ()
 		{
-			native = Interop.Structure.Allocate (typeof (Interop.AcquireNextImageInfoKhx));
+			native = Interop.Structure.Allocate (typeof (Interop.AcquireNextImageInfoKhr));
 			Initialize ();
 		}
 
-		internal AcquireNextImageInfoKhx (NativePointer pointer)
+		internal AcquireNextImageInfoKhr (NativePointer pointer)
 		{
 			native = pointer;
 			Initialize ();
@@ -11329,12 +12048,12 @@ namespace Vulkan
 
 		internal void Initialize ()
 		{
-			m->SType = StructureType.AcquireNextImageInfoKhx;
+			m->SType = StructureType.AcquireNextImageInfoKhr;
 		}
 
 	}
 
-	unsafe public partial class DeviceGroupPresentInfoKhx : MarshalledObject
+	unsafe public partial class DeviceGroupPresentInfoKhr : MarshalledObject
 	{
 		public UInt32 SwapchainCount {
 			get { return m->SwapchainCount; }
@@ -11374,24 +12093,24 @@ namespace Vulkan
 			}
 		}
 
-		public DeviceGroupPresentModeFlagsKhx Mode {
+		public DeviceGroupPresentModeFlagsKhr Mode {
 			get { return m->Mode; }
 			set { m->Mode = value; }
 		}
-		internal Interop.DeviceGroupPresentInfoKhx* m {
 
+		internal Interop.DeviceGroupPresentInfoKhr* m {
 			get {
-				return (Interop.DeviceGroupPresentInfoKhx*)native.Handle;
+				return (Interop.DeviceGroupPresentInfoKhr*)native.Handle;
 			}
 		}
 
-		public DeviceGroupPresentInfoKhx ()
+		public DeviceGroupPresentInfoKhr ()
 		{
-			native = Interop.Structure.Allocate (typeof (Interop.DeviceGroupPresentInfoKhx));
+			native = Interop.Structure.Allocate (typeof (Interop.DeviceGroupPresentInfoKhr));
 			Initialize ();
 		}
 
-		internal DeviceGroupPresentInfoKhx (NativePointer pointer)
+		internal DeviceGroupPresentInfoKhr (NativePointer pointer)
 		{
 			native = pointer;
 			Initialize ();
@@ -11408,12 +12127,12 @@ namespace Vulkan
 
 		internal void Initialize ()
 		{
-			m->SType = StructureType.DeviceGroupPresentInfoKhx;
+			m->SType = StructureType.DeviceGroupPresentInfoKhr;
 		}
 
 	}
 
-	unsafe public partial class DeviceGroupDeviceCreateInfoKhx : MarshalledObject
+	unsafe public partial class DeviceGroupDeviceCreateInfo : MarshalledObject
 	{
 		public UInt32 PhysicalDeviceCount {
 			get { return m->PhysicalDeviceCount; }
@@ -11454,20 +12173,20 @@ namespace Vulkan
 				}
 			}
 		}
-		internal Interop.DeviceGroupDeviceCreateInfoKhx* m {
 
+		internal Interop.DeviceGroupDeviceCreateInfo* m {
 			get {
-				return (Interop.DeviceGroupDeviceCreateInfoKhx*)native.Handle;
+				return (Interop.DeviceGroupDeviceCreateInfo*)native.Handle;
 			}
 		}
 
-		public DeviceGroupDeviceCreateInfoKhx ()
+		public DeviceGroupDeviceCreateInfo ()
 		{
-			native = Interop.Structure.Allocate (typeof (Interop.DeviceGroupDeviceCreateInfoKhx));
+			native = Interop.Structure.Allocate (typeof (Interop.DeviceGroupDeviceCreateInfo));
 			Initialize ();
 		}
 
-		internal DeviceGroupDeviceCreateInfoKhx (NativePointer pointer)
+		internal DeviceGroupDeviceCreateInfo (NativePointer pointer)
 		{
 			native = pointer;
 			Initialize ();
@@ -11484,31 +12203,41 @@ namespace Vulkan
 
 		internal void Initialize ()
 		{
-			m->SType = StructureType.DeviceGroupDeviceCreateInfoKhx;
+			m->SType = StructureType.DeviceGroupDeviceCreateInfo;
 		}
 
 	}
 
-	unsafe public partial class DeviceGroupSwapchainCreateInfoKhx : MarshalledObject
+	unsafe public partial class DeviceGroupDeviceCreateInfoKhr : DeviceGroupDeviceCreateInfo
 	{
-		public DeviceGroupPresentModeFlagsKhx Modes {
+		public DeviceGroupDeviceCreateInfoKhr () : base () {
+		}
+
+		internal DeviceGroupDeviceCreateInfoKhr (NativePointer pointer) : base (pointer) {
+		}
+
+	}
+
+	unsafe public partial class DeviceGroupSwapchainCreateInfoKhr : MarshalledObject
+	{
+		public DeviceGroupPresentModeFlagsKhr Modes {
 			get { return m->Modes; }
 			set { m->Modes = value; }
 		}
-		internal Interop.DeviceGroupSwapchainCreateInfoKhx* m {
 
+		internal Interop.DeviceGroupSwapchainCreateInfoKhr* m {
 			get {
-				return (Interop.DeviceGroupSwapchainCreateInfoKhx*)native.Handle;
+				return (Interop.DeviceGroupSwapchainCreateInfoKhr*)native.Handle;
 			}
 		}
 
-		public DeviceGroupSwapchainCreateInfoKhx ()
+		public DeviceGroupSwapchainCreateInfoKhr ()
 		{
-			native = Interop.Structure.Allocate (typeof (Interop.DeviceGroupSwapchainCreateInfoKhx));
+			native = Interop.Structure.Allocate (typeof (Interop.DeviceGroupSwapchainCreateInfoKhr));
 			Initialize ();
 		}
 
-		internal DeviceGroupSwapchainCreateInfoKhx (NativePointer pointer)
+		internal DeviceGroupSwapchainCreateInfoKhr (NativePointer pointer)
 		{
 			native = pointer;
 			Initialize ();
@@ -11517,9 +12246,19 @@ namespace Vulkan
 
 		internal void Initialize ()
 		{
-			m->SType = StructureType.DeviceGroupSwapchainCreateInfoKhx;
+			m->SType = StructureType.DeviceGroupSwapchainCreateInfoKhr;
 		}
 
+	}
+
+	unsafe public partial struct DescriptorUpdateTemplateEntry
+	{
+		public UInt32 DstBinding;
+		public UInt32 DstArrayElement;
+		public UInt32 DescriptorCount;
+		public DescriptorType DescriptorType;
+		public UIntPtr Offset;
+		public UIntPtr Stride;
 	}
 
 	unsafe public partial struct DescriptorUpdateTemplateEntryKhr
@@ -11530,9 +12269,35 @@ namespace Vulkan
 		public DescriptorType DescriptorType;
 		public UIntPtr Offset;
 		public UIntPtr Stride;
+
+		public static implicit operator DescriptorUpdateTemplateEntryKhr (DescriptorUpdateTemplateEntry that) {
+			var ret = new DescriptorUpdateTemplateEntryKhr {
+				DstBinding = that.DstBinding,
+				DstArrayElement = that.DstArrayElement,
+				DescriptorCount = that.DescriptorCount,
+				DescriptorType = that.DescriptorType,
+				Offset = that.Offset,
+				Stride = that.Stride,
+			};
+
+			return ret;
+		}
+
+		public static implicit operator DescriptorUpdateTemplateEntry (DescriptorUpdateTemplateEntryKhr that) {
+			var ret = new DescriptorUpdateTemplateEntry {
+				DstBinding = that.DstBinding,
+				DstArrayElement = that.DstArrayElement,
+				DescriptorCount = that.DescriptorCount,
+				DescriptorType = that.DescriptorType,
+				Offset = that.Offset,
+				Stride = that.Stride,
+			};
+
+			return ret;
+		}
 	}
 
-	unsafe public partial class DescriptorUpdateTemplateCreateInfoKhr : MarshalledObject
+	unsafe public partial class DescriptorUpdateTemplateCreateInfo : MarshalledObject
 	{
 		public UInt32 Flags {
 			get { return m->Flags; }
@@ -11545,14 +12310,14 @@ namespace Vulkan
 		}
 
 		NativeReference refDescriptorUpdateEntries;
-		public DescriptorUpdateTemplateEntryKhr[] DescriptorUpdateEntries {
+		public DescriptorUpdateTemplateEntry[] DescriptorUpdateEntries {
 			get {
 				if (m->DescriptorUpdateEntryCount == 0)
 					return null;
-				var values = new DescriptorUpdateTemplateEntryKhr [m->DescriptorUpdateEntryCount];
+				var values = new DescriptorUpdateTemplateEntry [m->DescriptorUpdateEntryCount];
 				unsafe
 				{
-					DescriptorUpdateTemplateEntryKhr* ptr = (DescriptorUpdateTemplateEntryKhr*)m->DescriptorUpdateEntries;
+					DescriptorUpdateTemplateEntry* ptr = (DescriptorUpdateTemplateEntry*)m->DescriptorUpdateEntries;
 					for (int i = 0; i < values.Length; i++) 
 						values [i] = ptr [i];
 				}
@@ -11566,18 +12331,18 @@ namespace Vulkan
 					return;
 				}
 				m->DescriptorUpdateEntryCount = (uint)value.Length;
-				refDescriptorUpdateEntries = new NativeReference ((int)(sizeof(DescriptorUpdateTemplateEntryKhr)*value.Length));
+				refDescriptorUpdateEntries = new NativeReference ((int)(sizeof(DescriptorUpdateTemplateEntry)*value.Length));
 				m->DescriptorUpdateEntries = refDescriptorUpdateEntries.Handle;
 				unsafe
 				{
-					DescriptorUpdateTemplateEntryKhr* ptr = (DescriptorUpdateTemplateEntryKhr*)m->DescriptorUpdateEntries;
+					DescriptorUpdateTemplateEntry* ptr = (DescriptorUpdateTemplateEntry*)m->DescriptorUpdateEntries;
 					for (int i = 0; i < value.Length; i++)
 						ptr [i] = value [i];
 				}
 			}
 		}
 
-		public DescriptorUpdateTemplateTypeKhr TemplateType {
+		public DescriptorUpdateTemplateType TemplateType {
 			get { return m->TemplateType; }
 			set { m->TemplateType = value; }
 		}
@@ -11603,20 +12368,20 @@ namespace Vulkan
 			get { return m->Set; }
 			set { m->Set = value; }
 		}
-		internal Interop.DescriptorUpdateTemplateCreateInfoKhr* m {
 
+		internal Interop.DescriptorUpdateTemplateCreateInfo* m {
 			get {
-				return (Interop.DescriptorUpdateTemplateCreateInfoKhr*)native.Handle;
+				return (Interop.DescriptorUpdateTemplateCreateInfo*)native.Handle;
 			}
 		}
 
-		public DescriptorUpdateTemplateCreateInfoKhr ()
+		public DescriptorUpdateTemplateCreateInfo ()
 		{
-			native = Interop.Structure.Allocate (typeof (Interop.DescriptorUpdateTemplateCreateInfoKhr));
+			native = Interop.Structure.Allocate (typeof (Interop.DescriptorUpdateTemplateCreateInfo));
 			Initialize ();
 		}
 
-		internal DescriptorUpdateTemplateCreateInfoKhr (NativePointer pointer)
+		internal DescriptorUpdateTemplateCreateInfo (NativePointer pointer)
 		{
 			native = pointer;
 			Initialize ();
@@ -11633,7 +12398,17 @@ namespace Vulkan
 
 		internal void Initialize ()
 		{
-			m->SType = StructureType.DescriptorUpdateTemplateCreateInfoKhr;
+			m->SType = StructureType.DescriptorUpdateTemplateCreateInfo;
+		}
+
+	}
+
+	unsafe public partial class DescriptorUpdateTemplateCreateInfoKhr : DescriptorUpdateTemplateCreateInfo
+	{
+		public DescriptorUpdateTemplateCreateInfoKhr () : base () {
+		}
+
+		internal DescriptorUpdateTemplateCreateInfoKhr (NativePointer pointer) : base (pointer) {
 		}
 
 	}
@@ -11685,8 +12460,8 @@ namespace Vulkan
 			get { return m->MaxFrameAverageLightLevel; }
 			set { m->MaxFrameAverageLightLevel = value; }
 		}
-		internal Interop.HdrMetadataExt* m {
 
+		internal Interop.HdrMetadataExt* m {
 			get {
 				return (Interop.HdrMetadataExt*)native.Handle;
 			}
@@ -11708,6 +12483,72 @@ namespace Vulkan
 		internal void Initialize ()
 		{
 			m->SType = StructureType.HdrMetadataExt;
+		}
+
+	}
+
+	unsafe public partial class DisplayNativeHdrSurfaceCapabilitiesAmd : MarshalledObject
+	{
+		public bool LocalDimmingSupport {
+			get { return m->LocalDimmingSupport; }
+			set { m->LocalDimmingSupport = value; }
+		}
+
+		internal Interop.DisplayNativeHdrSurfaceCapabilitiesAmd* m {
+			get {
+				return (Interop.DisplayNativeHdrSurfaceCapabilitiesAmd*)native.Handle;
+			}
+		}
+
+		public DisplayNativeHdrSurfaceCapabilitiesAmd ()
+		{
+			native = Interop.Structure.Allocate (typeof (Interop.DisplayNativeHdrSurfaceCapabilitiesAmd));
+			Initialize ();
+		}
+
+		internal DisplayNativeHdrSurfaceCapabilitiesAmd (NativePointer pointer)
+		{
+			native = pointer;
+			Initialize ();
+		}
+
+
+		internal void Initialize ()
+		{
+			m->SType = StructureType.DisplayNativeHdrSurfaceCapabilitiesAmd;
+		}
+
+	}
+
+	unsafe public partial class SwapchainDisplayNativeHdrCreateInfoAmd : MarshalledObject
+	{
+		public bool LocalDimmingEnable {
+			get { return m->LocalDimmingEnable; }
+			set { m->LocalDimmingEnable = value; }
+		}
+
+		internal Interop.SwapchainDisplayNativeHdrCreateInfoAmd* m {
+			get {
+				return (Interop.SwapchainDisplayNativeHdrCreateInfoAmd*)native.Handle;
+			}
+		}
+
+		public SwapchainDisplayNativeHdrCreateInfoAmd ()
+		{
+			native = Interop.Structure.Allocate (typeof (Interop.SwapchainDisplayNativeHdrCreateInfoAmd));
+			Initialize ();
+		}
+
+		internal SwapchainDisplayNativeHdrCreateInfoAmd (NativePointer pointer)
+		{
+			native = pointer;
+			Initialize ();
+		}
+
+
+		internal void Initialize ()
+		{
+			m->SType = StructureType.SwapchainDisplayNativeHdrCreateInfoAmd;
 		}
 
 	}
@@ -11765,8 +12606,8 @@ namespace Vulkan
 				}
 			}
 		}
-		internal Interop.PresentTimesInfoGoogle* m {
 
+		internal Interop.PresentTimesInfoGoogle* m {
 			get {
 				return (Interop.PresentTimesInfoGoogle*)native.Handle;
 			}
@@ -11817,8 +12658,8 @@ namespace Vulkan
 			get { return m->View; }
 			set { m->View = value; }
 		}
-		internal Interop.IOSSurfaceCreateInfoMvk* m {
 
+		internal Interop.IOSSurfaceCreateInfoMvk* m {
 			get {
 				return (Interop.IOSSurfaceCreateInfoMvk*)native.Handle;
 			}
@@ -11855,8 +12696,8 @@ namespace Vulkan
 			get { return m->View; }
 			set { m->View = value; }
 		}
-		internal Interop.MacOSSurfaceCreateInfoMvk* m {
 
+		internal Interop.MacOSSurfaceCreateInfoMvk* m {
 			get {
 				return (Interop.MacOSSurfaceCreateInfoMvk*)native.Handle;
 			}
@@ -11932,8 +12773,8 @@ namespace Vulkan
 				}
 			}
 		}
-		internal Interop.PipelineViewportWScalingStateCreateInfoNv* m {
 
+		internal Interop.PipelineViewportWScalingStateCreateInfoNv* m {
 			get {
 				return (Interop.PipelineViewportWScalingStateCreateInfoNv*)native.Handle;
 			}
@@ -12019,8 +12860,8 @@ namespace Vulkan
 				}
 			}
 		}
-		internal Interop.PipelineViewportSwizzleStateCreateInfoNv* m {
 
+		internal Interop.PipelineViewportSwizzleStateCreateInfoNv* m {
 			get {
 				return (Interop.PipelineViewportSwizzleStateCreateInfoNv*)native.Handle;
 			}
@@ -12060,8 +12901,8 @@ namespace Vulkan
 			get { return m->MaxDiscardRectangles; }
 			set { m->MaxDiscardRectangles = value; }
 		}
-		internal Interop.PhysicalDeviceDiscardRectanglePropertiesExt* m {
 
+		internal Interop.PhysicalDeviceDiscardRectanglePropertiesExt* m {
 			get {
 				return (Interop.PhysicalDeviceDiscardRectanglePropertiesExt*)native.Handle;
 			}
@@ -12136,8 +12977,8 @@ namespace Vulkan
 				}
 			}
 		}
-		internal Interop.PipelineDiscardRectangleStateCreateInfoExt* m {
 
+		internal Interop.PipelineDiscardRectangleStateCreateInfoExt* m {
 			get {
 				return (Interop.PipelineDiscardRectangleStateCreateInfoExt*)native.Handle;
 			}
@@ -12177,8 +13018,8 @@ namespace Vulkan
 			get { return m->PerViewPositionAllComponents; }
 			set { m->PerViewPositionAllComponents = value; }
 		}
-		internal Interop.PhysicalDeviceMultiviewPerViewAttributesPropertiesNvx* m {
 
+		internal Interop.PhysicalDeviceMultiviewPerViewAttributesPropertiesNvx* m {
 			get {
 				return (Interop.PhysicalDeviceMultiviewPerViewAttributesPropertiesNvx*)native.Handle;
 			}
@@ -12204,14 +13045,41 @@ namespace Vulkan
 
 	}
 
-	unsafe public partial struct InputAttachmentAspectReferenceKhr
+	unsafe public partial struct InputAttachmentAspectReference
 	{
 		public UInt32 Subpass;
 		public UInt32 InputAttachmentIndex;
 		public ImageAspectFlags AspectMask;
 	}
 
-	unsafe public partial class RenderPassInputAttachmentAspectCreateInfoKhr : MarshalledObject
+	unsafe public partial struct InputAttachmentAspectReferenceKhr
+	{
+		public UInt32 Subpass;
+		public UInt32 InputAttachmentIndex;
+		public ImageAspectFlags AspectMask;
+
+		public static implicit operator InputAttachmentAspectReferenceKhr (InputAttachmentAspectReference that) {
+			var ret = new InputAttachmentAspectReferenceKhr {
+				Subpass = that.Subpass,
+				InputAttachmentIndex = that.InputAttachmentIndex,
+				AspectMask = that.AspectMask,
+			};
+
+			return ret;
+		}
+
+		public static implicit operator InputAttachmentAspectReference (InputAttachmentAspectReferenceKhr that) {
+			var ret = new InputAttachmentAspectReference {
+				Subpass = that.Subpass,
+				InputAttachmentIndex = that.InputAttachmentIndex,
+				AspectMask = that.AspectMask,
+			};
+
+			return ret;
+		}
+	}
+
+	unsafe public partial class RenderPassInputAttachmentAspectCreateInfo : MarshalledObject
 	{
 		public UInt32 AspectReferenceCount {
 			get { return m->AspectReferenceCount; }
@@ -12219,14 +13087,14 @@ namespace Vulkan
 		}
 
 		NativeReference refAspectReferences;
-		public InputAttachmentAspectReferenceKhr[] AspectReferences {
+		public InputAttachmentAspectReference[] AspectReferences {
 			get {
 				if (m->AspectReferenceCount == 0)
 					return null;
-				var values = new InputAttachmentAspectReferenceKhr [m->AspectReferenceCount];
+				var values = new InputAttachmentAspectReference [m->AspectReferenceCount];
 				unsafe
 				{
-					InputAttachmentAspectReferenceKhr* ptr = (InputAttachmentAspectReferenceKhr*)m->AspectReferences;
+					InputAttachmentAspectReference* ptr = (InputAttachmentAspectReference*)m->AspectReferences;
 					for (int i = 0; i < values.Length; i++) 
 						values [i] = ptr [i];
 				}
@@ -12240,30 +13108,30 @@ namespace Vulkan
 					return;
 				}
 				m->AspectReferenceCount = (uint)value.Length;
-				refAspectReferences = new NativeReference ((int)(sizeof(InputAttachmentAspectReferenceKhr)*value.Length));
+				refAspectReferences = new NativeReference ((int)(sizeof(InputAttachmentAspectReference)*value.Length));
 				m->AspectReferences = refAspectReferences.Handle;
 				unsafe
 				{
-					InputAttachmentAspectReferenceKhr* ptr = (InputAttachmentAspectReferenceKhr*)m->AspectReferences;
+					InputAttachmentAspectReference* ptr = (InputAttachmentAspectReference*)m->AspectReferences;
 					for (int i = 0; i < value.Length; i++)
 						ptr [i] = value [i];
 				}
 			}
 		}
-		internal Interop.RenderPassInputAttachmentAspectCreateInfoKhr* m {
 
+		internal Interop.RenderPassInputAttachmentAspectCreateInfo* m {
 			get {
-				return (Interop.RenderPassInputAttachmentAspectCreateInfoKhr*)native.Handle;
+				return (Interop.RenderPassInputAttachmentAspectCreateInfo*)native.Handle;
 			}
 		}
 
-		public RenderPassInputAttachmentAspectCreateInfoKhr ()
+		public RenderPassInputAttachmentAspectCreateInfo ()
 		{
-			native = Interop.Structure.Allocate (typeof (Interop.RenderPassInputAttachmentAspectCreateInfoKhr));
+			native = Interop.Structure.Allocate (typeof (Interop.RenderPassInputAttachmentAspectCreateInfo));
 			Initialize ();
 		}
 
-		internal RenderPassInputAttachmentAspectCreateInfoKhr (NativePointer pointer)
+		internal RenderPassInputAttachmentAspectCreateInfo (NativePointer pointer)
 		{
 			native = pointer;
 			Initialize ();
@@ -12280,7 +13148,17 @@ namespace Vulkan
 
 		internal void Initialize ()
 		{
-			m->SType = StructureType.RenderPassInputAttachmentAspectCreateInfoKhr;
+			m->SType = StructureType.RenderPassInputAttachmentAspectCreateInfo;
+		}
+
+	}
+
+	unsafe public partial class RenderPassInputAttachmentAspectCreateInfoKhr : RenderPassInputAttachmentAspectCreateInfo
+	{
+		public RenderPassInputAttachmentAspectCreateInfoKhr () : base () {
+		}
+
+		internal RenderPassInputAttachmentAspectCreateInfoKhr (NativePointer pointer) : base (pointer) {
 		}
 
 	}
@@ -12292,8 +13170,8 @@ namespace Vulkan
 			get { return lSurface; }
 			set { lSurface = value; m->Surface = value != null ? (UInt64)value.m : default(UInt64); }
 		}
-		internal Interop.PhysicalDeviceSurfaceInfo2Khr* m {
 
+		internal Interop.PhysicalDeviceSurfaceInfo2Khr* m {
 			get {
 				return (Interop.PhysicalDeviceSurfaceInfo2Khr*)native.Handle;
 			}
@@ -12325,8 +13203,8 @@ namespace Vulkan
 			get { return m->SurfaceCapabilities; }
 			set { m->SurfaceCapabilities = value; }
 		}
-		internal Interop.SurfaceCapabilities2Khr* m {
 
+		internal Interop.SurfaceCapabilities2Khr* m {
 			get {
 				return (Interop.SurfaceCapabilities2Khr*)native.Handle;
 			}
@@ -12358,8 +13236,8 @@ namespace Vulkan
 			get { return m->SurfaceFormat; }
 			set { m->SurfaceFormat = value; }
 		}
-		internal Interop.SurfaceFormat2Khr* m {
 
+		internal Interop.SurfaceFormat2Khr* m {
 			get {
 				return (Interop.SurfaceFormat2Khr*)native.Handle;
 			}
@@ -12385,14 +13263,191 @@ namespace Vulkan
 
 	}
 
+	unsafe public partial class DisplayProperties2Khr : MarshalledObject
+	{
+		DisplayPropertiesKhr lDisplayProperties;
+		public DisplayPropertiesKhr DisplayProperties {
+			get { return lDisplayProperties; }
+			set { lDisplayProperties = value; m->DisplayProperties = value != null ? *value.m : default(Interop.DisplayPropertiesKhr); }
+		}
+
+		internal Interop.DisplayProperties2Khr* m {
+			get {
+				return (Interop.DisplayProperties2Khr*)native.Handle;
+			}
+		}
+
+		public DisplayProperties2Khr ()
+		{
+			native = Interop.Structure.Allocate (typeof (Interop.DisplayProperties2Khr));
+			Initialize ();
+		}
+
+		internal DisplayProperties2Khr (NativePointer pointer)
+		{
+			native = pointer;
+			Initialize ();
+		}
+
+
+		internal void Initialize ()
+		{
+			m->SType = StructureType.DisplayProperties2Khr;
+			lDisplayProperties = new DisplayPropertiesKhr (new NativePointer (native.Reference, (IntPtr)(&m->DisplayProperties)));
+		}
+
+	}
+
+	unsafe public partial class DisplayPlaneProperties2Khr : MarshalledObject
+	{
+		DisplayPlanePropertiesKhr lDisplayPlaneProperties;
+		public DisplayPlanePropertiesKhr DisplayPlaneProperties {
+			get { return lDisplayPlaneProperties; }
+			set { lDisplayPlaneProperties = value; m->DisplayPlaneProperties = value != null ? *value.m : default(Interop.DisplayPlanePropertiesKhr); }
+		}
+
+		internal Interop.DisplayPlaneProperties2Khr* m {
+			get {
+				return (Interop.DisplayPlaneProperties2Khr*)native.Handle;
+			}
+		}
+
+		public DisplayPlaneProperties2Khr ()
+		{
+			native = Interop.Structure.Allocate (typeof (Interop.DisplayPlaneProperties2Khr));
+			Initialize ();
+		}
+
+		internal DisplayPlaneProperties2Khr (NativePointer pointer)
+		{
+			native = pointer;
+			Initialize ();
+		}
+
+
+		internal void Initialize ()
+		{
+			m->SType = StructureType.DisplayPlaneProperties2Khr;
+			lDisplayPlaneProperties = new DisplayPlanePropertiesKhr (new NativePointer (native.Reference, (IntPtr)(&m->DisplayPlaneProperties)));
+		}
+
+	}
+
+	unsafe public partial class DisplayModeProperties2Khr : MarshalledObject
+	{
+		DisplayModePropertiesKhr lDisplayModeProperties;
+		public DisplayModePropertiesKhr DisplayModeProperties {
+			get { return lDisplayModeProperties; }
+			set { lDisplayModeProperties = value; m->DisplayModeProperties = value != null ? *value.m : default(Interop.DisplayModePropertiesKhr); }
+		}
+
+		internal Interop.DisplayModeProperties2Khr* m {
+			get {
+				return (Interop.DisplayModeProperties2Khr*)native.Handle;
+			}
+		}
+
+		public DisplayModeProperties2Khr ()
+		{
+			native = Interop.Structure.Allocate (typeof (Interop.DisplayModeProperties2Khr));
+			Initialize ();
+		}
+
+		internal DisplayModeProperties2Khr (NativePointer pointer)
+		{
+			native = pointer;
+			Initialize ();
+		}
+
+
+		internal void Initialize ()
+		{
+			m->SType = StructureType.DisplayModeProperties2Khr;
+			lDisplayModeProperties = new DisplayModePropertiesKhr (new NativePointer (native.Reference, (IntPtr)(&m->DisplayModeProperties)));
+		}
+
+	}
+
+	unsafe public partial class DisplayPlaneInfo2Khr : MarshalledObject
+	{
+		DisplayModeKhr lMode;
+		public DisplayModeKhr Mode {
+			get { return lMode; }
+			set { lMode = value; m->Mode = value != null ? (UInt64)value.m : default(UInt64); }
+		}
+
+		public UInt32 PlaneIndex {
+			get { return m->PlaneIndex; }
+			set { m->PlaneIndex = value; }
+		}
+
+		internal Interop.DisplayPlaneInfo2Khr* m {
+			get {
+				return (Interop.DisplayPlaneInfo2Khr*)native.Handle;
+			}
+		}
+
+		public DisplayPlaneInfo2Khr ()
+		{
+			native = Interop.Structure.Allocate (typeof (Interop.DisplayPlaneInfo2Khr));
+			Initialize ();
+		}
+
+		internal DisplayPlaneInfo2Khr (NativePointer pointer)
+		{
+			native = pointer;
+			Initialize ();
+		}
+
+
+		internal void Initialize ()
+		{
+			m->SType = StructureType.DisplayPlaneInfo2Khr;
+		}
+
+	}
+
+	unsafe public partial class DisplayPlaneCapabilities2Khr : MarshalledObject
+	{
+		public DisplayPlaneCapabilitiesKhr Capabilities {
+			get { return m->Capabilities; }
+			set { m->Capabilities = value; }
+		}
+
+		internal Interop.DisplayPlaneCapabilities2Khr* m {
+			get {
+				return (Interop.DisplayPlaneCapabilities2Khr*)native.Handle;
+			}
+		}
+
+		public DisplayPlaneCapabilities2Khr ()
+		{
+			native = Interop.Structure.Allocate (typeof (Interop.DisplayPlaneCapabilities2Khr));
+			Initialize ();
+		}
+
+		internal DisplayPlaneCapabilities2Khr (NativePointer pointer)
+		{
+			native = pointer;
+			Initialize ();
+		}
+
+
+		internal void Initialize ()
+		{
+			m->SType = StructureType.DisplayPlaneCapabilities2Khr;
+		}
+
+	}
+
 	unsafe public partial class SharedPresentSurfaceCapabilitiesKhr : MarshalledObject
 	{
 		public ImageUsageFlags SharedPresentSupportedUsageFlags {
 			get { return m->SharedPresentSupportedUsageFlags; }
 			set { m->SharedPresentSupportedUsageFlags = value; }
 		}
-		internal Interop.SharedPresentSurfaceCapabilitiesKhr* m {
 
+		internal Interop.SharedPresentSurfaceCapabilitiesKhr* m {
 			get {
 				return (Interop.SharedPresentSurfaceCapabilitiesKhr*)native.Handle;
 			}
@@ -12418,7 +13473,7 @@ namespace Vulkan
 
 	}
 
-	unsafe public partial class PhysicalDevice16BitStorageFeaturesKhr : MarshalledObject
+	unsafe public partial class PhysicalDevice16BitStorageFeatures : MarshalledObject
 	{
 		public bool StorageBuffer16BitAccess {
 			get { return m->StorageBuffer16BitAccess; }
@@ -12439,20 +13494,20 @@ namespace Vulkan
 			get { return m->StorageInputOutput16; }
 			set { m->StorageInputOutput16 = value; }
 		}
-		internal Interop.PhysicalDevice16BitStorageFeaturesKhr* m {
 
+		internal Interop.PhysicalDevice16BitStorageFeatures* m {
 			get {
-				return (Interop.PhysicalDevice16BitStorageFeaturesKhr*)native.Handle;
+				return (Interop.PhysicalDevice16BitStorageFeatures*)native.Handle;
 			}
 		}
 
-		public PhysicalDevice16BitStorageFeaturesKhr ()
+		public PhysicalDevice16BitStorageFeatures ()
 		{
-			native = Interop.Structure.Allocate (typeof (Interop.PhysicalDevice16BitStorageFeaturesKhr));
+			native = Interop.Structure.Allocate (typeof (Interop.PhysicalDevice16BitStorageFeatures));
 			Initialize ();
 		}
 
-		internal PhysicalDevice16BitStorageFeaturesKhr (NativePointer pointer)
+		internal PhysicalDevice16BitStorageFeatures (NativePointer pointer)
 		{
 			native = pointer;
 			Initialize ();
@@ -12461,32 +13516,90 @@ namespace Vulkan
 
 		internal void Initialize ()
 		{
-			m->SType = StructureType.PhysicalDevice16BitStorageFeaturesKhr;
+			m->SType = StructureType.PhysicalDevice16BitStorageFeatures;
 		}
 
 	}
 
-	unsafe public partial class BufferMemoryRequirementsInfo2Khr : MarshalledObject
+	unsafe public partial class PhysicalDevice16BitStorageFeaturesKhr : PhysicalDevice16BitStorageFeatures
+	{
+		public PhysicalDevice16BitStorageFeaturesKhr () : base () {
+		}
+
+		internal PhysicalDevice16BitStorageFeaturesKhr (NativePointer pointer) : base (pointer) {
+		}
+
+	}
+
+	unsafe public partial class PhysicalDeviceSubgroupProperties : MarshalledObject
+	{
+		public UInt32 SubgroupSize {
+			get { return m->SubgroupSize; }
+			set { m->SubgroupSize = value; }
+		}
+
+		public ShaderStageFlags SupportedStages {
+			get { return m->SupportedStages; }
+			set { m->SupportedStages = value; }
+		}
+
+		public SubgroupFeatureFlags SupportedOperations {
+			get { return m->SupportedOperations; }
+			set { m->SupportedOperations = value; }
+		}
+
+		public bool QuadOperationsInAllStages {
+			get { return m->QuadOperationsInAllStages; }
+			set { m->QuadOperationsInAllStages = value; }
+		}
+
+		internal Interop.PhysicalDeviceSubgroupProperties* m {
+			get {
+				return (Interop.PhysicalDeviceSubgroupProperties*)native.Handle;
+			}
+		}
+
+		public PhysicalDeviceSubgroupProperties ()
+		{
+			native = Interop.Structure.Allocate (typeof (Interop.PhysicalDeviceSubgroupProperties));
+			Initialize ();
+		}
+
+		internal PhysicalDeviceSubgroupProperties (NativePointer pointer)
+		{
+			native = pointer;
+			Initialize ();
+		}
+
+
+		internal void Initialize ()
+		{
+			m->SType = StructureType.PhysicalDeviceSubgroupProperties;
+		}
+
+	}
+
+	unsafe public partial class BufferMemoryRequirementsInfo2 : MarshalledObject
 	{
 		Buffer lBuffer;
 		public Buffer Buffer {
 			get { return lBuffer; }
 			set { lBuffer = value; m->Buffer = value != null ? (UInt64)value.m : default(UInt64); }
 		}
-		internal Interop.BufferMemoryRequirementsInfo2Khr* m {
 
+		internal Interop.BufferMemoryRequirementsInfo2* m {
 			get {
-				return (Interop.BufferMemoryRequirementsInfo2Khr*)native.Handle;
+				return (Interop.BufferMemoryRequirementsInfo2*)native.Handle;
 			}
 		}
 
-		public BufferMemoryRequirementsInfo2Khr ()
+		public BufferMemoryRequirementsInfo2 ()
 		{
-			native = Interop.Structure.Allocate (typeof (Interop.BufferMemoryRequirementsInfo2Khr));
+			native = Interop.Structure.Allocate (typeof (Interop.BufferMemoryRequirementsInfo2));
 			Initialize ();
 		}
 
-		internal BufferMemoryRequirementsInfo2Khr (NativePointer pointer)
+		internal BufferMemoryRequirementsInfo2 (NativePointer pointer)
 		{
 			native = pointer;
 			Initialize ();
@@ -12495,32 +13608,42 @@ namespace Vulkan
 
 		internal void Initialize ()
 		{
-			m->SType = StructureType.BufferMemoryRequirementsInfo2Khr;
+			m->SType = StructureType.BufferMemoryRequirementsInfo2;
 		}
 
 	}
 
-	unsafe public partial class ImageMemoryRequirementsInfo2Khr : MarshalledObject
+	unsafe public partial class BufferMemoryRequirementsInfo2Khr : BufferMemoryRequirementsInfo2
+	{
+		public BufferMemoryRequirementsInfo2Khr () : base () {
+		}
+
+		internal BufferMemoryRequirementsInfo2Khr (NativePointer pointer) : base (pointer) {
+		}
+
+	}
+
+	unsafe public partial class ImageMemoryRequirementsInfo2 : MarshalledObject
 	{
 		Image lImage;
 		public Image Image {
 			get { return lImage; }
 			set { lImage = value; m->Image = value != null ? (UInt64)value.m : default(UInt64); }
 		}
-		internal Interop.ImageMemoryRequirementsInfo2Khr* m {
 
+		internal Interop.ImageMemoryRequirementsInfo2* m {
 			get {
-				return (Interop.ImageMemoryRequirementsInfo2Khr*)native.Handle;
+				return (Interop.ImageMemoryRequirementsInfo2*)native.Handle;
 			}
 		}
 
-		public ImageMemoryRequirementsInfo2Khr ()
+		public ImageMemoryRequirementsInfo2 ()
 		{
-			native = Interop.Structure.Allocate (typeof (Interop.ImageMemoryRequirementsInfo2Khr));
+			native = Interop.Structure.Allocate (typeof (Interop.ImageMemoryRequirementsInfo2));
 			Initialize ();
 		}
 
-		internal ImageMemoryRequirementsInfo2Khr (NativePointer pointer)
+		internal ImageMemoryRequirementsInfo2 (NativePointer pointer)
 		{
 			native = pointer;
 			Initialize ();
@@ -12529,32 +13652,42 @@ namespace Vulkan
 
 		internal void Initialize ()
 		{
-			m->SType = StructureType.ImageMemoryRequirementsInfo2Khr;
+			m->SType = StructureType.ImageMemoryRequirementsInfo2;
 		}
 
 	}
 
-	unsafe public partial class ImageSparseMemoryRequirementsInfo2Khr : MarshalledObject
+	unsafe public partial class ImageMemoryRequirementsInfo2Khr : ImageMemoryRequirementsInfo2
+	{
+		public ImageMemoryRequirementsInfo2Khr () : base () {
+		}
+
+		internal ImageMemoryRequirementsInfo2Khr (NativePointer pointer) : base (pointer) {
+		}
+
+	}
+
+	unsafe public partial class ImageSparseMemoryRequirementsInfo2 : MarshalledObject
 	{
 		Image lImage;
 		public Image Image {
 			get { return lImage; }
 			set { lImage = value; m->Image = value != null ? (UInt64)value.m : default(UInt64); }
 		}
-		internal Interop.ImageSparseMemoryRequirementsInfo2Khr* m {
 
+		internal Interop.ImageSparseMemoryRequirementsInfo2* m {
 			get {
-				return (Interop.ImageSparseMemoryRequirementsInfo2Khr*)native.Handle;
+				return (Interop.ImageSparseMemoryRequirementsInfo2*)native.Handle;
 			}
 		}
 
-		public ImageSparseMemoryRequirementsInfo2Khr ()
+		public ImageSparseMemoryRequirementsInfo2 ()
 		{
-			native = Interop.Structure.Allocate (typeof (Interop.ImageSparseMemoryRequirementsInfo2Khr));
+			native = Interop.Structure.Allocate (typeof (Interop.ImageSparseMemoryRequirementsInfo2));
 			Initialize ();
 		}
 
-		internal ImageSparseMemoryRequirementsInfo2Khr (NativePointer pointer)
+		internal ImageSparseMemoryRequirementsInfo2 (NativePointer pointer)
 		{
 			native = pointer;
 			Initialize ();
@@ -12563,31 +13696,41 @@ namespace Vulkan
 
 		internal void Initialize ()
 		{
-			m->SType = StructureType.ImageSparseMemoryRequirementsInfo2Khr;
+			m->SType = StructureType.ImageSparseMemoryRequirementsInfo2;
 		}
 
 	}
 
-	unsafe public partial class MemoryRequirements2Khr : MarshalledObject
+	unsafe public partial class ImageSparseMemoryRequirementsInfo2Khr : ImageSparseMemoryRequirementsInfo2
+	{
+		public ImageSparseMemoryRequirementsInfo2Khr () : base () {
+		}
+
+		internal ImageSparseMemoryRequirementsInfo2Khr (NativePointer pointer) : base (pointer) {
+		}
+
+	}
+
+	unsafe public partial class MemoryRequirements2 : MarshalledObject
 	{
 		public MemoryRequirements MemoryRequirements {
 			get { return m->MemoryRequirements; }
 			set { m->MemoryRequirements = value; }
 		}
-		internal Interop.MemoryRequirements2Khr* m {
 
+		internal Interop.MemoryRequirements2* m {
 			get {
-				return (Interop.MemoryRequirements2Khr*)native.Handle;
+				return (Interop.MemoryRequirements2*)native.Handle;
 			}
 		}
 
-		public MemoryRequirements2Khr ()
+		public MemoryRequirements2 ()
 		{
-			native = Interop.Structure.Allocate (typeof (Interop.MemoryRequirements2Khr));
+			native = Interop.Structure.Allocate (typeof (Interop.MemoryRequirements2));
 			Initialize ();
 		}
 
-		internal MemoryRequirements2Khr (NativePointer pointer)
+		internal MemoryRequirements2 (NativePointer pointer)
 		{
 			native = pointer;
 			Initialize ();
@@ -12596,31 +13739,41 @@ namespace Vulkan
 
 		internal void Initialize ()
 		{
-			m->SType = StructureType.MemoryRequirements2Khr;
+			m->SType = StructureType.MemoryRequirements2;
 		}
 
 	}
 
-	unsafe public partial class SparseImageMemoryRequirements2Khr : MarshalledObject
+	unsafe public partial class MemoryRequirements2Khr : MemoryRequirements2
+	{
+		public MemoryRequirements2Khr () : base () {
+		}
+
+		internal MemoryRequirements2Khr (NativePointer pointer) : base (pointer) {
+		}
+
+	}
+
+	unsafe public partial class SparseImageMemoryRequirements2 : MarshalledObject
 	{
 		public SparseImageMemoryRequirements MemoryRequirements {
 			get { return m->MemoryRequirements; }
 			set { m->MemoryRequirements = value; }
 		}
-		internal Interop.SparseImageMemoryRequirements2Khr* m {
 
+		internal Interop.SparseImageMemoryRequirements2* m {
 			get {
-				return (Interop.SparseImageMemoryRequirements2Khr*)native.Handle;
+				return (Interop.SparseImageMemoryRequirements2*)native.Handle;
 			}
 		}
 
-		public SparseImageMemoryRequirements2Khr ()
+		public SparseImageMemoryRequirements2 ()
 		{
-			native = Interop.Structure.Allocate (typeof (Interop.SparseImageMemoryRequirements2Khr));
+			native = Interop.Structure.Allocate (typeof (Interop.SparseImageMemoryRequirements2));
 			Initialize ();
 		}
 
-		internal SparseImageMemoryRequirements2Khr (NativePointer pointer)
+		internal SparseImageMemoryRequirements2 (NativePointer pointer)
 		{
 			native = pointer;
 			Initialize ();
@@ -12629,31 +13782,41 @@ namespace Vulkan
 
 		internal void Initialize ()
 		{
-			m->SType = StructureType.SparseImageMemoryRequirements2Khr;
+			m->SType = StructureType.SparseImageMemoryRequirements2;
 		}
 
 	}
 
-	unsafe public partial class PhysicalDevicePointClippingPropertiesKhr : MarshalledObject
+	unsafe public partial class SparseImageMemoryRequirements2Khr : SparseImageMemoryRequirements2
 	{
-		public PointClippingBehaviorKhr PointClippingBehavior {
+		public SparseImageMemoryRequirements2Khr () : base () {
+		}
+
+		internal SparseImageMemoryRequirements2Khr (NativePointer pointer) : base (pointer) {
+		}
+
+	}
+
+	unsafe public partial class PhysicalDevicePointClippingProperties : MarshalledObject
+	{
+		public PointClippingBehavior PointClippingBehavior {
 			get { return m->PointClippingBehavior; }
 			set { m->PointClippingBehavior = value; }
 		}
-		internal Interop.PhysicalDevicePointClippingPropertiesKhr* m {
 
+		internal Interop.PhysicalDevicePointClippingProperties* m {
 			get {
-				return (Interop.PhysicalDevicePointClippingPropertiesKhr*)native.Handle;
+				return (Interop.PhysicalDevicePointClippingProperties*)native.Handle;
 			}
 		}
 
-		public PhysicalDevicePointClippingPropertiesKhr ()
+		public PhysicalDevicePointClippingProperties ()
 		{
-			native = Interop.Structure.Allocate (typeof (Interop.PhysicalDevicePointClippingPropertiesKhr));
+			native = Interop.Structure.Allocate (typeof (Interop.PhysicalDevicePointClippingProperties));
 			Initialize ();
 		}
 
-		internal PhysicalDevicePointClippingPropertiesKhr (NativePointer pointer)
+		internal PhysicalDevicePointClippingProperties (NativePointer pointer)
 		{
 			native = pointer;
 			Initialize ();
@@ -12662,12 +13825,22 @@ namespace Vulkan
 
 		internal void Initialize ()
 		{
-			m->SType = StructureType.PhysicalDevicePointClippingPropertiesKhr;
+			m->SType = StructureType.PhysicalDevicePointClippingProperties;
 		}
 
 	}
 
-	unsafe public partial class MemoryDedicatedRequirementsKhr : MarshalledObject
+	unsafe public partial class PhysicalDevicePointClippingPropertiesKhr : PhysicalDevicePointClippingProperties
+	{
+		public PhysicalDevicePointClippingPropertiesKhr () : base () {
+		}
+
+		internal PhysicalDevicePointClippingPropertiesKhr (NativePointer pointer) : base (pointer) {
+		}
+
+	}
+
+	unsafe public partial class MemoryDedicatedRequirements : MarshalledObject
 	{
 		public bool PrefersDedicatedAllocation {
 			get { return m->PrefersDedicatedAllocation; }
@@ -12678,20 +13851,20 @@ namespace Vulkan
 			get { return m->RequiresDedicatedAllocation; }
 			set { m->RequiresDedicatedAllocation = value; }
 		}
-		internal Interop.MemoryDedicatedRequirementsKhr* m {
 
+		internal Interop.MemoryDedicatedRequirements* m {
 			get {
-				return (Interop.MemoryDedicatedRequirementsKhr*)native.Handle;
+				return (Interop.MemoryDedicatedRequirements*)native.Handle;
 			}
 		}
 
-		public MemoryDedicatedRequirementsKhr ()
+		public MemoryDedicatedRequirements ()
 		{
-			native = Interop.Structure.Allocate (typeof (Interop.MemoryDedicatedRequirementsKhr));
+			native = Interop.Structure.Allocate (typeof (Interop.MemoryDedicatedRequirements));
 			Initialize ();
 		}
 
-		internal MemoryDedicatedRequirementsKhr (NativePointer pointer)
+		internal MemoryDedicatedRequirements (NativePointer pointer)
 		{
 			native = pointer;
 			Initialize ();
@@ -12700,12 +13873,22 @@ namespace Vulkan
 
 		internal void Initialize ()
 		{
-			m->SType = StructureType.MemoryDedicatedRequirementsKhr;
+			m->SType = StructureType.MemoryDedicatedRequirements;
 		}
 
 	}
 
-	unsafe public partial class MemoryDedicatedAllocateInfoKhr : MarshalledObject
+	unsafe public partial class MemoryDedicatedRequirementsKhr : MemoryDedicatedRequirements
+	{
+		public MemoryDedicatedRequirementsKhr () : base () {
+		}
+
+		internal MemoryDedicatedRequirementsKhr (NativePointer pointer) : base (pointer) {
+		}
+
+	}
+
+	unsafe public partial class MemoryDedicatedAllocateInfo : MarshalledObject
 	{
 		Image lImage;
 		public Image Image {
@@ -12718,20 +13901,20 @@ namespace Vulkan
 			get { return lBuffer; }
 			set { lBuffer = value; m->Buffer = value != null ? (UInt64)value.m : default(UInt64); }
 		}
-		internal Interop.MemoryDedicatedAllocateInfoKhr* m {
 
+		internal Interop.MemoryDedicatedAllocateInfo* m {
 			get {
-				return (Interop.MemoryDedicatedAllocateInfoKhr*)native.Handle;
+				return (Interop.MemoryDedicatedAllocateInfo*)native.Handle;
 			}
 		}
 
-		public MemoryDedicatedAllocateInfoKhr ()
+		public MemoryDedicatedAllocateInfo ()
 		{
-			native = Interop.Structure.Allocate (typeof (Interop.MemoryDedicatedAllocateInfoKhr));
+			native = Interop.Structure.Allocate (typeof (Interop.MemoryDedicatedAllocateInfo));
 			Initialize ();
 		}
 
-		internal MemoryDedicatedAllocateInfoKhr (NativePointer pointer)
+		internal MemoryDedicatedAllocateInfo (NativePointer pointer)
 		{
 			native = pointer;
 			Initialize ();
@@ -12740,31 +13923,41 @@ namespace Vulkan
 
 		internal void Initialize ()
 		{
-			m->SType = StructureType.MemoryDedicatedAllocateInfoKhr;
+			m->SType = StructureType.MemoryDedicatedAllocateInfo;
 		}
 
 	}
 
-	unsafe public partial class ImageViewUsageCreateInfoKhr : MarshalledObject
+	unsafe public partial class MemoryDedicatedAllocateInfoKhr : MemoryDedicatedAllocateInfo
+	{
+		public MemoryDedicatedAllocateInfoKhr () : base () {
+		}
+
+		internal MemoryDedicatedAllocateInfoKhr (NativePointer pointer) : base (pointer) {
+		}
+
+	}
+
+	unsafe public partial class ImageViewUsageCreateInfo : MarshalledObject
 	{
 		public ImageUsageFlags Usage {
 			get { return m->Usage; }
 			set { m->Usage = value; }
 		}
-		internal Interop.ImageViewUsageCreateInfoKhr* m {
 
+		internal Interop.ImageViewUsageCreateInfo* m {
 			get {
-				return (Interop.ImageViewUsageCreateInfoKhr*)native.Handle;
+				return (Interop.ImageViewUsageCreateInfo*)native.Handle;
 			}
 		}
 
-		public ImageViewUsageCreateInfoKhr ()
+		public ImageViewUsageCreateInfo ()
 		{
-			native = Interop.Structure.Allocate (typeof (Interop.ImageViewUsageCreateInfoKhr));
+			native = Interop.Structure.Allocate (typeof (Interop.ImageViewUsageCreateInfo));
 			Initialize ();
 		}
 
-		internal ImageViewUsageCreateInfoKhr (NativePointer pointer)
+		internal ImageViewUsageCreateInfo (NativePointer pointer)
 		{
 			native = pointer;
 			Initialize ();
@@ -12773,31 +13966,41 @@ namespace Vulkan
 
 		internal void Initialize ()
 		{
-			m->SType = StructureType.ImageViewUsageCreateInfoKhr;
+			m->SType = StructureType.ImageViewUsageCreateInfo;
 		}
 
 	}
 
-	unsafe public partial class PipelineTessellationDomainOriginStateCreateInfoKhr : MarshalledObject
+	unsafe public partial class ImageViewUsageCreateInfoKhr : ImageViewUsageCreateInfo
 	{
-		public TessellationDomainOriginKhr DomainOrigin {
+		public ImageViewUsageCreateInfoKhr () : base () {
+		}
+
+		internal ImageViewUsageCreateInfoKhr (NativePointer pointer) : base (pointer) {
+		}
+
+	}
+
+	unsafe public partial class PipelineTessellationDomainOriginStateCreateInfo : MarshalledObject
+	{
+		public TessellationDomainOrigin DomainOrigin {
 			get { return m->DomainOrigin; }
 			set { m->DomainOrigin = value; }
 		}
-		internal Interop.PipelineTessellationDomainOriginStateCreateInfoKhr* m {
 
+		internal Interop.PipelineTessellationDomainOriginStateCreateInfo* m {
 			get {
-				return (Interop.PipelineTessellationDomainOriginStateCreateInfoKhr*)native.Handle;
+				return (Interop.PipelineTessellationDomainOriginStateCreateInfo*)native.Handle;
 			}
 		}
 
-		public PipelineTessellationDomainOriginStateCreateInfoKhr ()
+		public PipelineTessellationDomainOriginStateCreateInfo ()
 		{
-			native = Interop.Structure.Allocate (typeof (Interop.PipelineTessellationDomainOriginStateCreateInfoKhr));
+			native = Interop.Structure.Allocate (typeof (Interop.PipelineTessellationDomainOriginStateCreateInfo));
 			Initialize ();
 		}
 
-		internal PipelineTessellationDomainOriginStateCreateInfoKhr (NativePointer pointer)
+		internal PipelineTessellationDomainOriginStateCreateInfo (NativePointer pointer)
 		{
 			native = pointer;
 			Initialize ();
@@ -12806,32 +14009,42 @@ namespace Vulkan
 
 		internal void Initialize ()
 		{
-			m->SType = StructureType.PipelineTessellationDomainOriginStateCreateInfoKhr;
+			m->SType = StructureType.PipelineTessellationDomainOriginStateCreateInfo;
 		}
 
 	}
 
-	unsafe public partial class SamplerYcbcrConversionInfoKhr : MarshalledObject
+	unsafe public partial class PipelineTessellationDomainOriginStateCreateInfoKhr : PipelineTessellationDomainOriginStateCreateInfo
 	{
-		SamplerYcbcrConversionKhr lConversion;
-		public SamplerYcbcrConversionKhr Conversion {
+		public PipelineTessellationDomainOriginStateCreateInfoKhr () : base () {
+		}
+
+		internal PipelineTessellationDomainOriginStateCreateInfoKhr (NativePointer pointer) : base (pointer) {
+		}
+
+	}
+
+	unsafe public partial class SamplerYcbcrConversionInfo : MarshalledObject
+	{
+		SamplerYcbcrConversion lConversion;
+		public SamplerYcbcrConversion Conversion {
 			get { return lConversion; }
 			set { lConversion = value; m->Conversion = value != null ? (UInt64)value.m : default(UInt64); }
 		}
-		internal Interop.SamplerYcbcrConversionInfoKhr* m {
 
+		internal Interop.SamplerYcbcrConversionInfo* m {
 			get {
-				return (Interop.SamplerYcbcrConversionInfoKhr*)native.Handle;
+				return (Interop.SamplerYcbcrConversionInfo*)native.Handle;
 			}
 		}
 
-		public SamplerYcbcrConversionInfoKhr ()
+		public SamplerYcbcrConversionInfo ()
 		{
-			native = Interop.Structure.Allocate (typeof (Interop.SamplerYcbcrConversionInfoKhr));
+			native = Interop.Structure.Allocate (typeof (Interop.SamplerYcbcrConversionInfo));
 			Initialize ();
 		}
 
-		internal SamplerYcbcrConversionInfoKhr (NativePointer pointer)
+		internal SamplerYcbcrConversionInfo (NativePointer pointer)
 		{
 			native = pointer;
 			Initialize ();
@@ -12840,24 +14053,34 @@ namespace Vulkan
 
 		internal void Initialize ()
 		{
-			m->SType = StructureType.SamplerYcbcrConversionInfoKhr;
+			m->SType = StructureType.SamplerYcbcrConversionInfo;
 		}
 
 	}
 
-	unsafe public partial class SamplerYcbcrConversionCreateInfoKhr : MarshalledObject
+	unsafe public partial class SamplerYcbcrConversionInfoKhr : SamplerYcbcrConversionInfo
+	{
+		public SamplerYcbcrConversionInfoKhr () : base () {
+		}
+
+		internal SamplerYcbcrConversionInfoKhr (NativePointer pointer) : base (pointer) {
+		}
+
+	}
+
+	unsafe public partial class SamplerYcbcrConversionCreateInfo : MarshalledObject
 	{
 		public Format Format {
 			get { return m->Format; }
 			set { m->Format = value; }
 		}
 
-		public SamplerYcbcrModelConversionKhr YcbcrModel {
+		public SamplerYcbcrModelConversion YcbcrModel {
 			get { return m->YcbcrModel; }
 			set { m->YcbcrModel = value; }
 		}
 
-		public SamplerYcbcrRangeKhr YcbcrRange {
+		public SamplerYcbcrRange YcbcrRange {
 			get { return m->YcbcrRange; }
 			set { m->YcbcrRange = value; }
 		}
@@ -12867,12 +14090,12 @@ namespace Vulkan
 			set { m->Components = value; }
 		}
 
-		public ChromaLocationKhr XChromaOffset {
+		public ChromaLocation XChromaOffset {
 			get { return m->XChromaOffset; }
 			set { m->XChromaOffset = value; }
 		}
 
-		public ChromaLocationKhr YChromaOffset {
+		public ChromaLocation YChromaOffset {
 			get { return m->YChromaOffset; }
 			set { m->YChromaOffset = value; }
 		}
@@ -12886,20 +14109,20 @@ namespace Vulkan
 			get { return m->ForceExplicitReconstruction; }
 			set { m->ForceExplicitReconstruction = value; }
 		}
-		internal Interop.SamplerYcbcrConversionCreateInfoKhr* m {
 
+		internal Interop.SamplerYcbcrConversionCreateInfo* m {
 			get {
-				return (Interop.SamplerYcbcrConversionCreateInfoKhr*)native.Handle;
+				return (Interop.SamplerYcbcrConversionCreateInfo*)native.Handle;
 			}
 		}
 
-		public SamplerYcbcrConversionCreateInfoKhr ()
+		public SamplerYcbcrConversionCreateInfo ()
 		{
-			native = Interop.Structure.Allocate (typeof (Interop.SamplerYcbcrConversionCreateInfoKhr));
+			native = Interop.Structure.Allocate (typeof (Interop.SamplerYcbcrConversionCreateInfo));
 			Initialize ();
 		}
 
-		internal SamplerYcbcrConversionCreateInfoKhr (NativePointer pointer)
+		internal SamplerYcbcrConversionCreateInfo (NativePointer pointer)
 		{
 			native = pointer;
 			Initialize ();
@@ -12908,31 +14131,41 @@ namespace Vulkan
 
 		internal void Initialize ()
 		{
-			m->SType = StructureType.SamplerYcbcrConversionCreateInfoKhr;
+			m->SType = StructureType.SamplerYcbcrConversionCreateInfo;
 		}
 
 	}
 
-	unsafe public partial class BindImagePlaneMemoryInfoKhr : MarshalledObject
+	unsafe public partial class SamplerYcbcrConversionCreateInfoKhr : SamplerYcbcrConversionCreateInfo
+	{
+		public SamplerYcbcrConversionCreateInfoKhr () : base () {
+		}
+
+		internal SamplerYcbcrConversionCreateInfoKhr (NativePointer pointer) : base (pointer) {
+		}
+
+	}
+
+	unsafe public partial class BindImagePlaneMemoryInfo : MarshalledObject
 	{
 		public ImageAspectFlags PlaneAspect {
 			get { return m->PlaneAspect; }
 			set { m->PlaneAspect = value; }
 		}
-		internal Interop.BindImagePlaneMemoryInfoKhr* m {
 
+		internal Interop.BindImagePlaneMemoryInfo* m {
 			get {
-				return (Interop.BindImagePlaneMemoryInfoKhr*)native.Handle;
+				return (Interop.BindImagePlaneMemoryInfo*)native.Handle;
 			}
 		}
 
-		public BindImagePlaneMemoryInfoKhr ()
+		public BindImagePlaneMemoryInfo ()
 		{
-			native = Interop.Structure.Allocate (typeof (Interop.BindImagePlaneMemoryInfoKhr));
+			native = Interop.Structure.Allocate (typeof (Interop.BindImagePlaneMemoryInfo));
 			Initialize ();
 		}
 
-		internal BindImagePlaneMemoryInfoKhr (NativePointer pointer)
+		internal BindImagePlaneMemoryInfo (NativePointer pointer)
 		{
 			native = pointer;
 			Initialize ();
@@ -12941,31 +14174,41 @@ namespace Vulkan
 
 		internal void Initialize ()
 		{
-			m->SType = StructureType.BindImagePlaneMemoryInfoKhr;
+			m->SType = StructureType.BindImagePlaneMemoryInfo;
 		}
 
 	}
 
-	unsafe public partial class ImagePlaneMemoryRequirementsInfoKhr : MarshalledObject
+	unsafe public partial class BindImagePlaneMemoryInfoKhr : BindImagePlaneMemoryInfo
+	{
+		public BindImagePlaneMemoryInfoKhr () : base () {
+		}
+
+		internal BindImagePlaneMemoryInfoKhr (NativePointer pointer) : base (pointer) {
+		}
+
+	}
+
+	unsafe public partial class ImagePlaneMemoryRequirementsInfo : MarshalledObject
 	{
 		public ImageAspectFlags PlaneAspect {
 			get { return m->PlaneAspect; }
 			set { m->PlaneAspect = value; }
 		}
-		internal Interop.ImagePlaneMemoryRequirementsInfoKhr* m {
 
+		internal Interop.ImagePlaneMemoryRequirementsInfo* m {
 			get {
-				return (Interop.ImagePlaneMemoryRequirementsInfoKhr*)native.Handle;
+				return (Interop.ImagePlaneMemoryRequirementsInfo*)native.Handle;
 			}
 		}
 
-		public ImagePlaneMemoryRequirementsInfoKhr ()
+		public ImagePlaneMemoryRequirementsInfo ()
 		{
-			native = Interop.Structure.Allocate (typeof (Interop.ImagePlaneMemoryRequirementsInfoKhr));
+			native = Interop.Structure.Allocate (typeof (Interop.ImagePlaneMemoryRequirementsInfo));
 			Initialize ();
 		}
 
-		internal ImagePlaneMemoryRequirementsInfoKhr (NativePointer pointer)
+		internal ImagePlaneMemoryRequirementsInfo (NativePointer pointer)
 		{
 			native = pointer;
 			Initialize ();
@@ -12974,31 +14217,41 @@ namespace Vulkan
 
 		internal void Initialize ()
 		{
-			m->SType = StructureType.ImagePlaneMemoryRequirementsInfoKhr;
+			m->SType = StructureType.ImagePlaneMemoryRequirementsInfo;
 		}
 
 	}
 
-	unsafe public partial class PhysicalDeviceSamplerYcbcrConversionFeaturesKhr : MarshalledObject
+	unsafe public partial class ImagePlaneMemoryRequirementsInfoKhr : ImagePlaneMemoryRequirementsInfo
+	{
+		public ImagePlaneMemoryRequirementsInfoKhr () : base () {
+		}
+
+		internal ImagePlaneMemoryRequirementsInfoKhr (NativePointer pointer) : base (pointer) {
+		}
+
+	}
+
+	unsafe public partial class PhysicalDeviceSamplerYcbcrConversionFeatures : MarshalledObject
 	{
 		public bool SamplerYcbcrConversion {
 			get { return m->SamplerYcbcrConversion; }
 			set { m->SamplerYcbcrConversion = value; }
 		}
-		internal Interop.PhysicalDeviceSamplerYcbcrConversionFeaturesKhr* m {
 
+		internal Interop.PhysicalDeviceSamplerYcbcrConversionFeatures* m {
 			get {
-				return (Interop.PhysicalDeviceSamplerYcbcrConversionFeaturesKhr*)native.Handle;
+				return (Interop.PhysicalDeviceSamplerYcbcrConversionFeatures*)native.Handle;
 			}
 		}
 
-		public PhysicalDeviceSamplerYcbcrConversionFeaturesKhr ()
+		public PhysicalDeviceSamplerYcbcrConversionFeatures ()
 		{
-			native = Interop.Structure.Allocate (typeof (Interop.PhysicalDeviceSamplerYcbcrConversionFeaturesKhr));
+			native = Interop.Structure.Allocate (typeof (Interop.PhysicalDeviceSamplerYcbcrConversionFeatures));
 			Initialize ();
 		}
 
-		internal PhysicalDeviceSamplerYcbcrConversionFeaturesKhr (NativePointer pointer)
+		internal PhysicalDeviceSamplerYcbcrConversionFeatures (NativePointer pointer)
 		{
 			native = pointer;
 			Initialize ();
@@ -13007,31 +14260,41 @@ namespace Vulkan
 
 		internal void Initialize ()
 		{
-			m->SType = StructureType.PhysicalDeviceSamplerYcbcrConversionFeaturesKhr;
+			m->SType = StructureType.PhysicalDeviceSamplerYcbcrConversionFeatures;
 		}
 
 	}
 
-	unsafe public partial class SamplerYcbcrConversionImageFormatPropertiesKhr : MarshalledObject
+	unsafe public partial class PhysicalDeviceSamplerYcbcrConversionFeaturesKhr : PhysicalDeviceSamplerYcbcrConversionFeatures
+	{
+		public PhysicalDeviceSamplerYcbcrConversionFeaturesKhr () : base () {
+		}
+
+		internal PhysicalDeviceSamplerYcbcrConversionFeaturesKhr (NativePointer pointer) : base (pointer) {
+		}
+
+	}
+
+	unsafe public partial class SamplerYcbcrConversionImageFormatProperties : MarshalledObject
 	{
 		public UInt32 CombinedImageSamplerDescriptorCount {
 			get { return m->CombinedImageSamplerDescriptorCount; }
 			set { m->CombinedImageSamplerDescriptorCount = value; }
 		}
-		internal Interop.SamplerYcbcrConversionImageFormatPropertiesKhr* m {
 
+		internal Interop.SamplerYcbcrConversionImageFormatProperties* m {
 			get {
-				return (Interop.SamplerYcbcrConversionImageFormatPropertiesKhr*)native.Handle;
+				return (Interop.SamplerYcbcrConversionImageFormatProperties*)native.Handle;
 			}
 		}
 
-		public SamplerYcbcrConversionImageFormatPropertiesKhr ()
+		public SamplerYcbcrConversionImageFormatProperties ()
 		{
-			native = Interop.Structure.Allocate (typeof (Interop.SamplerYcbcrConversionImageFormatPropertiesKhr));
+			native = Interop.Structure.Allocate (typeof (Interop.SamplerYcbcrConversionImageFormatProperties));
 			Initialize ();
 		}
 
-		internal SamplerYcbcrConversionImageFormatPropertiesKhr (NativePointer pointer)
+		internal SamplerYcbcrConversionImageFormatProperties (NativePointer pointer)
 		{
 			native = pointer;
 			Initialize ();
@@ -13040,7 +14303,17 @@ namespace Vulkan
 
 		internal void Initialize ()
 		{
-			m->SType = StructureType.SamplerYcbcrConversionImageFormatPropertiesKhr;
+			m->SType = StructureType.SamplerYcbcrConversionImageFormatProperties;
+		}
+
+	}
+
+	unsafe public partial class SamplerYcbcrConversionImageFormatPropertiesKhr : SamplerYcbcrConversionImageFormatProperties
+	{
+		public SamplerYcbcrConversionImageFormatPropertiesKhr () : base () {
+		}
+
+		internal SamplerYcbcrConversionImageFormatPropertiesKhr (NativePointer pointer) : base (pointer) {
 		}
 
 	}
@@ -13051,8 +14324,8 @@ namespace Vulkan
 			get { return m->SupportsTextureGatherLodbiasAmd; }
 			set { m->SupportsTextureGatherLodbiasAmd = value; }
 		}
-		internal Interop.TextureLODGatherFormatPropertiesAmd* m {
 
+		internal Interop.TextureLODGatherFormatPropertiesAmd* m {
 			get {
 				return (Interop.TextureLODGatherFormatPropertiesAmd*)native.Handle;
 			}
@@ -13078,6 +14351,192 @@ namespace Vulkan
 
 	}
 
+	unsafe public partial class ConditionalRenderingBeginInfoExt : MarshalledObject
+	{
+		Buffer lBuffer;
+		public Buffer Buffer {
+			get { return lBuffer; }
+			set { lBuffer = value; m->Buffer = value != null ? (UInt64)value.m : default(UInt64); }
+		}
+
+		public DeviceSize Offset {
+			get { return m->Offset; }
+			set { m->Offset = value; }
+		}
+
+		public ConditionalRenderingFlagsExt Flags {
+			get { return m->Flags; }
+			set { m->Flags = value; }
+		}
+
+		internal Interop.ConditionalRenderingBeginInfoExt* m {
+			get {
+				return (Interop.ConditionalRenderingBeginInfoExt*)native.Handle;
+			}
+		}
+
+		public ConditionalRenderingBeginInfoExt ()
+		{
+			native = Interop.Structure.Allocate (typeof (Interop.ConditionalRenderingBeginInfoExt));
+			Initialize ();
+		}
+
+		internal ConditionalRenderingBeginInfoExt (NativePointer pointer)
+		{
+			native = pointer;
+			Initialize ();
+		}
+
+
+		internal void Initialize ()
+		{
+			m->SType = StructureType.ConditionalRenderingBeginInfoExt;
+		}
+
+	}
+
+	unsafe public partial class ProtectedSubmitInfo : MarshalledObject
+	{
+		public bool ProtectedSubmit {
+			get { return m->ProtectedSubmit; }
+			set { m->ProtectedSubmit = value; }
+		}
+
+		internal Interop.ProtectedSubmitInfo* m {
+			get {
+				return (Interop.ProtectedSubmitInfo*)native.Handle;
+			}
+		}
+
+		public ProtectedSubmitInfo ()
+		{
+			native = Interop.Structure.Allocate (typeof (Interop.ProtectedSubmitInfo));
+			Initialize ();
+		}
+
+		internal ProtectedSubmitInfo (NativePointer pointer)
+		{
+			native = pointer;
+			Initialize ();
+		}
+
+
+		internal void Initialize ()
+		{
+			m->SType = StructureType.ProtectedSubmitInfo;
+		}
+
+	}
+
+	unsafe public partial class PhysicalDeviceProtectedMemoryFeatures : MarshalledObject
+	{
+		public bool ProtectedMemory {
+			get { return m->ProtectedMemory; }
+			set { m->ProtectedMemory = value; }
+		}
+
+		internal Interop.PhysicalDeviceProtectedMemoryFeatures* m {
+			get {
+				return (Interop.PhysicalDeviceProtectedMemoryFeatures*)native.Handle;
+			}
+		}
+
+		public PhysicalDeviceProtectedMemoryFeatures ()
+		{
+			native = Interop.Structure.Allocate (typeof (Interop.PhysicalDeviceProtectedMemoryFeatures));
+			Initialize ();
+		}
+
+		internal PhysicalDeviceProtectedMemoryFeatures (NativePointer pointer)
+		{
+			native = pointer;
+			Initialize ();
+		}
+
+
+		internal void Initialize ()
+		{
+			m->SType = StructureType.PhysicalDeviceProtectedMemoryFeatures;
+		}
+
+	}
+
+	unsafe public partial class PhysicalDeviceProtectedMemoryProperties : MarshalledObject
+	{
+		public bool ProtectedNoFault {
+			get { return m->ProtectedNoFault; }
+			set { m->ProtectedNoFault = value; }
+		}
+
+		internal Interop.PhysicalDeviceProtectedMemoryProperties* m {
+			get {
+				return (Interop.PhysicalDeviceProtectedMemoryProperties*)native.Handle;
+			}
+		}
+
+		public PhysicalDeviceProtectedMemoryProperties ()
+		{
+			native = Interop.Structure.Allocate (typeof (Interop.PhysicalDeviceProtectedMemoryProperties));
+			Initialize ();
+		}
+
+		internal PhysicalDeviceProtectedMemoryProperties (NativePointer pointer)
+		{
+			native = pointer;
+			Initialize ();
+		}
+
+
+		internal void Initialize ()
+		{
+			m->SType = StructureType.PhysicalDeviceProtectedMemoryProperties;
+		}
+
+	}
+
+	unsafe public partial class DeviceQueueInfo2 : MarshalledObject
+	{
+		public DeviceQueueCreateFlags Flags {
+			get { return m->Flags; }
+			set { m->Flags = value; }
+		}
+
+		public UInt32 QueueFamilyIndex {
+			get { return m->QueueFamilyIndex; }
+			set { m->QueueFamilyIndex = value; }
+		}
+
+		public UInt32 QueueIndex {
+			get { return m->QueueIndex; }
+			set { m->QueueIndex = value; }
+		}
+
+		internal Interop.DeviceQueueInfo2* m {
+			get {
+				return (Interop.DeviceQueueInfo2*)native.Handle;
+			}
+		}
+
+		public DeviceQueueInfo2 ()
+		{
+			native = Interop.Structure.Allocate (typeof (Interop.DeviceQueueInfo2));
+			Initialize ();
+		}
+
+		internal DeviceQueueInfo2 (NativePointer pointer)
+		{
+			native = pointer;
+			Initialize ();
+		}
+
+
+		internal void Initialize ()
+		{
+			m->SType = StructureType.DeviceQueueInfo2;
+		}
+
+	}
+
 	unsafe public partial class PipelineCoverageToColorStateCreateInfoNv : MarshalledObject
 	{
 		public UInt32 Flags {
@@ -13094,8 +14553,8 @@ namespace Vulkan
 			get { return m->CoverageToColorLocation; }
 			set { m->CoverageToColorLocation = value; }
 		}
-		internal Interop.PipelineCoverageToColorStateCreateInfoNv* m {
 
+		internal Interop.PipelineCoverageToColorStateCreateInfoNv* m {
 			get {
 				return (Interop.PipelineCoverageToColorStateCreateInfoNv*)native.Handle;
 			}
@@ -13132,8 +14591,8 @@ namespace Vulkan
 			get { return m->FilterMinmaxImageComponentMapping; }
 			set { m->FilterMinmaxImageComponentMapping = value; }
 		}
-		internal Interop.PhysicalDeviceSamplerFilterMinmaxPropertiesExt* m {
 
+		internal Interop.PhysicalDeviceSamplerFilterMinmaxPropertiesExt* m {
 			get {
 				return (Interop.PhysicalDeviceSamplerFilterMinmaxPropertiesExt*)native.Handle;
 			}
@@ -13214,8 +14673,8 @@ namespace Vulkan
 				}
 			}
 		}
-		internal Interop.SampleLocationsInfoExt* m {
 
+		internal Interop.SampleLocationsInfoExt* m {
 			get {
 				return (Interop.SampleLocationsInfoExt*)native.Handle;
 			}
@@ -13261,8 +14720,8 @@ namespace Vulkan
 			get { return lSampleLocationsInfo; }
 			set { lSampleLocationsInfo = value; m->SampleLocationsInfo = value != null ? *value.m : default(Interop.SampleLocationsInfoExt); }
 		}
-		internal Interop.AttachmentSampleLocationsExt* m {
 
+		internal Interop.AttachmentSampleLocationsExt* m {
 			get {
 				return (Interop.AttachmentSampleLocationsExt*)native.Handle;
 			}
@@ -13300,8 +14759,8 @@ namespace Vulkan
 			get { return lSampleLocationsInfo; }
 			set { lSampleLocationsInfo = value; m->SampleLocationsInfo = value != null ? *value.m : default(Interop.SampleLocationsInfoExt); }
 		}
-		internal Interop.SubpassSampleLocationsExt* m {
 
+		internal Interop.SubpassSampleLocationsExt* m {
 			get {
 				return (Interop.SubpassSampleLocationsExt*)native.Handle;
 			}
@@ -13408,8 +14867,8 @@ namespace Vulkan
 				}
 			}
 		}
-		internal Interop.RenderPassSampleLocationsBeginInfoExt* m {
 
+		internal Interop.RenderPassSampleLocationsBeginInfoExt* m {
 			get {
 				return (Interop.RenderPassSampleLocationsBeginInfoExt*)native.Handle;
 			}
@@ -13457,8 +14916,8 @@ namespace Vulkan
 			get { return lSampleLocationsInfo; }
 			set { lSampleLocationsInfo = value; m->SampleLocationsInfo = value != null ? *value.m : default(Interop.SampleLocationsInfoExt); }
 		}
-		internal Interop.PipelineSampleLocationsStateCreateInfoExt* m {
 
+		internal Interop.PipelineSampleLocationsStateCreateInfoExt* m {
 			get {
 				return (Interop.PipelineSampleLocationsStateCreateInfoExt*)native.Handle;
 			}
@@ -13524,8 +14983,8 @@ namespace Vulkan
 			get { return m->VariableSampleLocations; }
 			set { m->VariableSampleLocations = value; }
 		}
-		internal Interop.PhysicalDeviceSampleLocationsPropertiesExt* m {
 
+		internal Interop.PhysicalDeviceSampleLocationsPropertiesExt* m {
 			get {
 				return (Interop.PhysicalDeviceSampleLocationsPropertiesExt*)native.Handle;
 			}
@@ -13557,8 +15016,8 @@ namespace Vulkan
 			get { return m->MaxSampleLocationGridSize; }
 			set { m->MaxSampleLocationGridSize = value; }
 		}
-		internal Interop.MultisamplePropertiesExt* m {
 
+		internal Interop.MultisamplePropertiesExt* m {
 			get {
 				return (Interop.MultisamplePropertiesExt*)native.Handle;
 			}
@@ -13590,8 +15049,8 @@ namespace Vulkan
 			get { return m->ReductionMode; }
 			set { m->ReductionMode = value; }
 		}
-		internal Interop.SamplerReductionModeCreateInfoExt* m {
 
+		internal Interop.SamplerReductionModeCreateInfoExt* m {
 			get {
 				return (Interop.SamplerReductionModeCreateInfoExt*)native.Handle;
 			}
@@ -13623,8 +15082,8 @@ namespace Vulkan
 			get { return m->AdvancedBlendCoherentOperations; }
 			set { m->AdvancedBlendCoherentOperations = value; }
 		}
-		internal Interop.PhysicalDeviceBlendOperationAdvancedFeaturesExt* m {
 
+		internal Interop.PhysicalDeviceBlendOperationAdvancedFeaturesExt* m {
 			get {
 				return (Interop.PhysicalDeviceBlendOperationAdvancedFeaturesExt*)native.Handle;
 			}
@@ -13681,8 +15140,8 @@ namespace Vulkan
 			get { return m->AdvancedBlendAllOperations; }
 			set { m->AdvancedBlendAllOperations = value; }
 		}
-		internal Interop.PhysicalDeviceBlendOperationAdvancedPropertiesExt* m {
 
+		internal Interop.PhysicalDeviceBlendOperationAdvancedPropertiesExt* m {
 			get {
 				return (Interop.PhysicalDeviceBlendOperationAdvancedPropertiesExt*)native.Handle;
 			}
@@ -13724,8 +15183,8 @@ namespace Vulkan
 			get { return m->BlendOverlap; }
 			set { m->BlendOverlap = value; }
 		}
-		internal Interop.PipelineColorBlendAdvancedStateCreateInfoExt* m {
 
+		internal Interop.PipelineColorBlendAdvancedStateCreateInfoExt* m {
 			get {
 				return (Interop.PipelineColorBlendAdvancedStateCreateInfoExt*)native.Handle;
 			}
@@ -13747,6 +15206,168 @@ namespace Vulkan
 		internal void Initialize ()
 		{
 			m->SType = StructureType.PipelineColorBlendAdvancedStateCreateInfoExt;
+		}
+
+	}
+
+	unsafe public partial class PhysicalDeviceInlineUniformBlockFeaturesExt : MarshalledObject
+	{
+		public bool InlineUniformBlock {
+			get { return m->InlineUniformBlock; }
+			set { m->InlineUniformBlock = value; }
+		}
+
+		public bool DescriptorBindingInlineUniformBlockUpdateAfterBind {
+			get { return m->DescriptorBindingInlineUniformBlockUpdateAfterBind; }
+			set { m->DescriptorBindingInlineUniformBlockUpdateAfterBind = value; }
+		}
+
+		internal Interop.PhysicalDeviceInlineUniformBlockFeaturesExt* m {
+			get {
+				return (Interop.PhysicalDeviceInlineUniformBlockFeaturesExt*)native.Handle;
+			}
+		}
+
+		public PhysicalDeviceInlineUniformBlockFeaturesExt ()
+		{
+			native = Interop.Structure.Allocate (typeof (Interop.PhysicalDeviceInlineUniformBlockFeaturesExt));
+			Initialize ();
+		}
+
+		internal PhysicalDeviceInlineUniformBlockFeaturesExt (NativePointer pointer)
+		{
+			native = pointer;
+			Initialize ();
+		}
+
+
+		internal void Initialize ()
+		{
+			m->SType = StructureType.PhysicalDeviceInlineUniformBlockFeaturesExt;
+		}
+
+	}
+
+	unsafe public partial class PhysicalDeviceInlineUniformBlockPropertiesExt : MarshalledObject
+	{
+		public UInt32 MaxInlineUniformBlockSize {
+			get { return m->MaxInlineUniformBlockSize; }
+			set { m->MaxInlineUniformBlockSize = value; }
+		}
+
+		public UInt32 MaxPerStageDescriptorInlineUniformBlocks {
+			get { return m->MaxPerStageDescriptorInlineUniformBlocks; }
+			set { m->MaxPerStageDescriptorInlineUniformBlocks = value; }
+		}
+
+		public UInt32 MaxPerStageDescriptorUpdateAfterBindInlineUniformBlocks {
+			get { return m->MaxPerStageDescriptorUpdateAfterBindInlineUniformBlocks; }
+			set { m->MaxPerStageDescriptorUpdateAfterBindInlineUniformBlocks = value; }
+		}
+
+		public UInt32 MaxDescriptorSetInlineUniformBlocks {
+			get { return m->MaxDescriptorSetInlineUniformBlocks; }
+			set { m->MaxDescriptorSetInlineUniformBlocks = value; }
+		}
+
+		public UInt32 MaxDescriptorSetUpdateAfterBindInlineUniformBlocks {
+			get { return m->MaxDescriptorSetUpdateAfterBindInlineUniformBlocks; }
+			set { m->MaxDescriptorSetUpdateAfterBindInlineUniformBlocks = value; }
+		}
+
+		internal Interop.PhysicalDeviceInlineUniformBlockPropertiesExt* m {
+			get {
+				return (Interop.PhysicalDeviceInlineUniformBlockPropertiesExt*)native.Handle;
+			}
+		}
+
+		public PhysicalDeviceInlineUniformBlockPropertiesExt ()
+		{
+			native = Interop.Structure.Allocate (typeof (Interop.PhysicalDeviceInlineUniformBlockPropertiesExt));
+			Initialize ();
+		}
+
+		internal PhysicalDeviceInlineUniformBlockPropertiesExt (NativePointer pointer)
+		{
+			native = pointer;
+			Initialize ();
+		}
+
+
+		internal void Initialize ()
+		{
+			m->SType = StructureType.PhysicalDeviceInlineUniformBlockPropertiesExt;
+		}
+
+	}
+
+	unsafe public partial class WriteDescriptorSetInlineUniformBlockExt : MarshalledObject
+	{
+		public UInt32 DataSize {
+			get { return m->DataSize; }
+			set { m->DataSize = value; }
+		}
+
+		public IntPtr Data {
+			get { return m->Data; }
+			set { m->Data = value; }
+		}
+
+		internal Interop.WriteDescriptorSetInlineUniformBlockExt* m {
+			get {
+				return (Interop.WriteDescriptorSetInlineUniformBlockExt*)native.Handle;
+			}
+		}
+
+		public WriteDescriptorSetInlineUniformBlockExt ()
+		{
+			native = Interop.Structure.Allocate (typeof (Interop.WriteDescriptorSetInlineUniformBlockExt));
+			Initialize ();
+		}
+
+		internal WriteDescriptorSetInlineUniformBlockExt (NativePointer pointer)
+		{
+			native = pointer;
+			Initialize ();
+		}
+
+
+		internal void Initialize ()
+		{
+			m->SType = StructureType.WriteDescriptorSetInlineUniformBlockExt;
+		}
+
+	}
+
+	unsafe public partial class DescriptorPoolInlineUniformBlockCreateInfoExt : MarshalledObject
+	{
+		public UInt32 MaxInlineUniformBlockBindings {
+			get { return m->MaxInlineUniformBlockBindings; }
+			set { m->MaxInlineUniformBlockBindings = value; }
+		}
+
+		internal Interop.DescriptorPoolInlineUniformBlockCreateInfoExt* m {
+			get {
+				return (Interop.DescriptorPoolInlineUniformBlockCreateInfoExt*)native.Handle;
+			}
+		}
+
+		public DescriptorPoolInlineUniformBlockCreateInfoExt ()
+		{
+			native = Interop.Structure.Allocate (typeof (Interop.DescriptorPoolInlineUniformBlockCreateInfoExt));
+			Initialize ();
+		}
+
+		internal DescriptorPoolInlineUniformBlockCreateInfoExt (NativePointer pointer)
+		{
+			native = pointer;
+			Initialize ();
+		}
+
+
+		internal void Initialize ()
+		{
+			m->SType = StructureType.DescriptorPoolInlineUniformBlockCreateInfoExt;
 		}
 
 	}
@@ -13805,8 +15426,8 @@ namespace Vulkan
 				}
 			}
 		}
-		internal Interop.PipelineCoverageModulationStateCreateInfoNv* m {
 
+		internal Interop.PipelineCoverageModulationStateCreateInfoNv* m {
 			get {
 				return (Interop.PipelineCoverageModulationStateCreateInfoNv*)native.Handle;
 			}
@@ -13879,8 +15500,8 @@ namespace Vulkan
 				}
 			}
 		}
-		internal Interop.ImageFormatListCreateInfoKhr* m {
 
+		internal Interop.ImageFormatListCreateInfoKhr* m {
 			get {
 				return (Interop.ImageFormatListCreateInfoKhr*)native.Handle;
 			}
@@ -13930,8 +15551,8 @@ namespace Vulkan
 			get { return m->InitialData; }
 			set { m->InitialData = value; }
 		}
-		internal Interop.ValidationCacheCreateInfoExt* m {
 
+		internal Interop.ValidationCacheCreateInfoExt* m {
 			get {
 				return (Interop.ValidationCacheCreateInfoExt*)native.Handle;
 			}
@@ -13964,8 +15585,8 @@ namespace Vulkan
 			get { return lValidationCache; }
 			set { lValidationCache = value; m->ValidationCache = value != null ? (UInt64)value.m : default(UInt64); }
 		}
-		internal Interop.ShaderModuleValidationCacheCreateInfoExt* m {
 
+		internal Interop.ShaderModuleValidationCacheCreateInfoExt* m {
 			get {
 				return (Interop.ShaderModuleValidationCacheCreateInfoExt*)native.Handle;
 			}
@@ -13987,6 +15608,324 @@ namespace Vulkan
 		internal void Initialize ()
 		{
 			m->SType = StructureType.ShaderModuleValidationCacheCreateInfoExt;
+		}
+
+	}
+
+	unsafe public partial class PhysicalDeviceMaintenance3Properties : MarshalledObject
+	{
+		public UInt32 MaxPerSetDescriptors {
+			get { return m->MaxPerSetDescriptors; }
+			set { m->MaxPerSetDescriptors = value; }
+		}
+
+		public DeviceSize MaxMemoryAllocationSize {
+			get { return m->MaxMemoryAllocationSize; }
+			set { m->MaxMemoryAllocationSize = value; }
+		}
+
+		internal Interop.PhysicalDeviceMaintenance3Properties* m {
+			get {
+				return (Interop.PhysicalDeviceMaintenance3Properties*)native.Handle;
+			}
+		}
+
+		public PhysicalDeviceMaintenance3Properties ()
+		{
+			native = Interop.Structure.Allocate (typeof (Interop.PhysicalDeviceMaintenance3Properties));
+			Initialize ();
+		}
+
+		internal PhysicalDeviceMaintenance3Properties (NativePointer pointer)
+		{
+			native = pointer;
+			Initialize ();
+		}
+
+
+		internal void Initialize ()
+		{
+			m->SType = StructureType.PhysicalDeviceMaintenance3Properties;
+		}
+
+	}
+
+	unsafe public partial class PhysicalDeviceMaintenance3PropertiesKhr : PhysicalDeviceMaintenance3Properties
+	{
+		public PhysicalDeviceMaintenance3PropertiesKhr () : base () {
+		}
+
+		internal PhysicalDeviceMaintenance3PropertiesKhr (NativePointer pointer) : base (pointer) {
+		}
+
+	}
+
+	unsafe public partial class DescriptorSetLayoutSupport : MarshalledObject
+	{
+		public bool Supported {
+			get { return m->Supported; }
+			set { m->Supported = value; }
+		}
+
+		internal Interop.DescriptorSetLayoutSupport* m {
+			get {
+				return (Interop.DescriptorSetLayoutSupport*)native.Handle;
+			}
+		}
+
+		public DescriptorSetLayoutSupport ()
+		{
+			native = Interop.Structure.Allocate (typeof (Interop.DescriptorSetLayoutSupport));
+			Initialize ();
+		}
+
+		internal DescriptorSetLayoutSupport (NativePointer pointer)
+		{
+			native = pointer;
+			Initialize ();
+		}
+
+
+		internal void Initialize ()
+		{
+			m->SType = StructureType.DescriptorSetLayoutSupport;
+		}
+
+	}
+
+	unsafe public partial class DescriptorSetLayoutSupportKhr : DescriptorSetLayoutSupport
+	{
+		public DescriptorSetLayoutSupportKhr () : base () {
+		}
+
+		internal DescriptorSetLayoutSupportKhr (NativePointer pointer) : base (pointer) {
+		}
+
+	}
+
+	unsafe public partial class PhysicalDeviceShaderDrawParametersFeatures : MarshalledObject
+	{
+		public bool ShaderDrawParameters {
+			get { return m->ShaderDrawParameters; }
+			set { m->ShaderDrawParameters = value; }
+		}
+
+		internal Interop.PhysicalDeviceShaderDrawParametersFeatures* m {
+			get {
+				return (Interop.PhysicalDeviceShaderDrawParametersFeatures*)native.Handle;
+			}
+		}
+
+		public PhysicalDeviceShaderDrawParametersFeatures ()
+		{
+			native = Interop.Structure.Allocate (typeof (Interop.PhysicalDeviceShaderDrawParametersFeatures));
+			Initialize ();
+		}
+
+		internal PhysicalDeviceShaderDrawParametersFeatures (NativePointer pointer)
+		{
+			native = pointer;
+			Initialize ();
+		}
+
+
+		internal void Initialize ()
+		{
+			m->SType = StructureType.PhysicalDeviceShaderDrawParametersFeatures;
+		}
+
+	}
+
+	unsafe public partial class PhysicalDeviceShaderDrawParameterFeatures : PhysicalDeviceShaderDrawParametersFeatures
+	{
+		public PhysicalDeviceShaderDrawParameterFeatures () : base () {
+		}
+
+		internal PhysicalDeviceShaderDrawParameterFeatures (NativePointer pointer) : base (pointer) {
+		}
+
+	}
+
+	unsafe public partial class PhysicalDeviceFloat16Int8FeaturesKhr : MarshalledObject
+	{
+		public bool ShaderFloat16 {
+			get { return m->ShaderFloat16; }
+			set { m->ShaderFloat16 = value; }
+		}
+
+		public bool ShaderInt8 {
+			get { return m->ShaderInt8; }
+			set { m->ShaderInt8 = value; }
+		}
+
+		internal Interop.PhysicalDeviceFloat16Int8FeaturesKhr* m {
+			get {
+				return (Interop.PhysicalDeviceFloat16Int8FeaturesKhr*)native.Handle;
+			}
+		}
+
+		public PhysicalDeviceFloat16Int8FeaturesKhr ()
+		{
+			native = Interop.Structure.Allocate (typeof (Interop.PhysicalDeviceFloat16Int8FeaturesKhr));
+			Initialize ();
+		}
+
+		internal PhysicalDeviceFloat16Int8FeaturesKhr (NativePointer pointer)
+		{
+			native = pointer;
+			Initialize ();
+		}
+
+
+		internal void Initialize ()
+		{
+			m->SType = StructureType.PhysicalDeviceFloat16Int8FeaturesKhr;
+		}
+
+	}
+
+	unsafe public partial class PhysicalDeviceFloatControlsPropertiesKhr : MarshalledObject
+	{
+		public bool SeparateDenormSettings {
+			get { return m->SeparateDenormSettings; }
+			set { m->SeparateDenormSettings = value; }
+		}
+
+		public bool SeparateRoundingModeSettings {
+			get { return m->SeparateRoundingModeSettings; }
+			set { m->SeparateRoundingModeSettings = value; }
+		}
+
+		public bool ShaderSignedZeroInfNanPreserveFloat16 {
+			get { return m->ShaderSignedZeroInfNanPreserveFloat16; }
+			set { m->ShaderSignedZeroInfNanPreserveFloat16 = value; }
+		}
+
+		public bool ShaderSignedZeroInfNanPreserveFloat32 {
+			get { return m->ShaderSignedZeroInfNanPreserveFloat32; }
+			set { m->ShaderSignedZeroInfNanPreserveFloat32 = value; }
+		}
+
+		public bool ShaderSignedZeroInfNanPreserveFloat64 {
+			get { return m->ShaderSignedZeroInfNanPreserveFloat64; }
+			set { m->ShaderSignedZeroInfNanPreserveFloat64 = value; }
+		}
+
+		public bool ShaderDenormPreserveFloat16 {
+			get { return m->ShaderDenormPreserveFloat16; }
+			set { m->ShaderDenormPreserveFloat16 = value; }
+		}
+
+		public bool ShaderDenormPreserveFloat32 {
+			get { return m->ShaderDenormPreserveFloat32; }
+			set { m->ShaderDenormPreserveFloat32 = value; }
+		}
+
+		public bool ShaderDenormPreserveFloat64 {
+			get { return m->ShaderDenormPreserveFloat64; }
+			set { m->ShaderDenormPreserveFloat64 = value; }
+		}
+
+		public bool ShaderDenormFlushToZeroFloat16 {
+			get { return m->ShaderDenormFlushToZeroFloat16; }
+			set { m->ShaderDenormFlushToZeroFloat16 = value; }
+		}
+
+		public bool ShaderDenormFlushToZeroFloat32 {
+			get { return m->ShaderDenormFlushToZeroFloat32; }
+			set { m->ShaderDenormFlushToZeroFloat32 = value; }
+		}
+
+		public bool ShaderDenormFlushToZeroFloat64 {
+			get { return m->ShaderDenormFlushToZeroFloat64; }
+			set { m->ShaderDenormFlushToZeroFloat64 = value; }
+		}
+
+		public bool ShaderRoundingModeRtefloat16 {
+			get { return m->ShaderRoundingModeRtefloat16; }
+			set { m->ShaderRoundingModeRtefloat16 = value; }
+		}
+
+		public bool ShaderRoundingModeRtefloat32 {
+			get { return m->ShaderRoundingModeRtefloat32; }
+			set { m->ShaderRoundingModeRtefloat32 = value; }
+		}
+
+		public bool ShaderRoundingModeRtefloat64 {
+			get { return m->ShaderRoundingModeRtefloat64; }
+			set { m->ShaderRoundingModeRtefloat64 = value; }
+		}
+
+		public bool ShaderRoundingModeRtzfloat16 {
+			get { return m->ShaderRoundingModeRtzfloat16; }
+			set { m->ShaderRoundingModeRtzfloat16 = value; }
+		}
+
+		public bool ShaderRoundingModeRtzfloat32 {
+			get { return m->ShaderRoundingModeRtzfloat32; }
+			set { m->ShaderRoundingModeRtzfloat32 = value; }
+		}
+
+		public bool ShaderRoundingModeRtzfloat64 {
+			get { return m->ShaderRoundingModeRtzfloat64; }
+			set { m->ShaderRoundingModeRtzfloat64 = value; }
+		}
+
+		internal Interop.PhysicalDeviceFloatControlsPropertiesKhr* m {
+			get {
+				return (Interop.PhysicalDeviceFloatControlsPropertiesKhr*)native.Handle;
+			}
+		}
+
+		public PhysicalDeviceFloatControlsPropertiesKhr ()
+		{
+			native = Interop.Structure.Allocate (typeof (Interop.PhysicalDeviceFloatControlsPropertiesKhr));
+			Initialize ();
+		}
+
+		internal PhysicalDeviceFloatControlsPropertiesKhr (NativePointer pointer)
+		{
+			native = pointer;
+			Initialize ();
+		}
+
+
+		internal void Initialize ()
+		{
+			m->SType = StructureType.PhysicalDeviceFloatControlsPropertiesKhr;
+		}
+
+	}
+
+	unsafe public partial class PhysicalDeviceHostQueryResetFeaturesExt : MarshalledObject
+	{
+		public bool HostQueryReset {
+			get { return m->HostQueryReset; }
+			set { m->HostQueryReset = value; }
+		}
+
+		internal Interop.PhysicalDeviceHostQueryResetFeaturesExt* m {
+			get {
+				return (Interop.PhysicalDeviceHostQueryResetFeaturesExt*)native.Handle;
+			}
+		}
+
+		public PhysicalDeviceHostQueryResetFeaturesExt ()
+		{
+			native = Interop.Structure.Allocate (typeof (Interop.PhysicalDeviceHostQueryResetFeaturesExt));
+			Initialize ();
+		}
+
+		internal PhysicalDeviceHostQueryResetFeaturesExt (NativePointer pointer)
+		{
+			native = pointer;
+			Initialize ();
+		}
+
+
+		internal void Initialize ()
+		{
+			m->SType = StructureType.PhysicalDeviceHostQueryResetFeaturesExt;
 		}
 
 	}
@@ -14049,8 +15988,8 @@ namespace Vulkan
 					m->ComputeWorkGroupSize [i] = 0;
 			}
 		}
-		internal Interop.ShaderStatisticsInfoAmd* m {
 
+		internal Interop.ShaderStatisticsInfoAmd* m {
 			get {
 				return (Interop.ShaderStatisticsInfoAmd*)native.Handle;
 			}
@@ -14074,8 +16013,8 @@ namespace Vulkan
 			get { return m->GlobalPriority; }
 			set { m->GlobalPriority = value; }
 		}
-		internal Interop.DeviceQueueGlobalPriorityCreateInfoExt* m {
 
+		internal Interop.DeviceQueueGlobalPriorityCreateInfoExt* m {
 			get {
 				return (Interop.DeviceQueueGlobalPriorityCreateInfoExt*)native.Handle;
 			}
@@ -14101,9 +16040,389 @@ namespace Vulkan
 
 	}
 
+	unsafe public partial class DebugUtilsObjectNameInfoExt : MarshalledObject
+	{
+		public ObjectType ObjectType {
+			get { return m->ObjectType; }
+			set { m->ObjectType = value; }
+		}
+
+		public UInt64 ObjectHandle {
+			get { return m->ObjectHandle; }
+			set { m->ObjectHandle = value; }
+		}
+
+		public string ObjectName {
+			get { return Marshal.PtrToStringAnsi (m->ObjectName); }
+			set { m->ObjectName = Marshal.StringToHGlobalAnsi (value); }
+		}
+
+		internal Interop.DebugUtilsObjectNameInfoExt* m {
+			get {
+				return (Interop.DebugUtilsObjectNameInfoExt*)native.Handle;
+			}
+		}
+
+		public DebugUtilsObjectNameInfoExt ()
+		{
+			native = Interop.Structure.Allocate (typeof (Interop.DebugUtilsObjectNameInfoExt));
+			Initialize ();
+		}
+
+		internal DebugUtilsObjectNameInfoExt (NativePointer pointer)
+		{
+			native = pointer;
+			Initialize ();
+		}
+
+
+		internal void Initialize ()
+		{
+			m->SType = StructureType.DebugUtilsObjectNameInfoExt;
+		}
+
+	}
+
+	unsafe public partial class DebugUtilsObjectTagInfoExt : MarshalledObject
+	{
+		public ObjectType ObjectType {
+			get { return m->ObjectType; }
+			set { m->ObjectType = value; }
+		}
+
+		public UInt64 ObjectHandle {
+			get { return m->ObjectHandle; }
+			set { m->ObjectHandle = value; }
+		}
+
+		public UInt64 TagName {
+			get { return m->TagName; }
+			set { m->TagName = value; }
+		}
+
+		public UIntPtr TagSize {
+			get { return m->TagSize; }
+			set { m->TagSize = value; }
+		}
+
+		public IntPtr Tag {
+			get { return m->Tag; }
+			set { m->Tag = value; }
+		}
+
+		internal Interop.DebugUtilsObjectTagInfoExt* m {
+			get {
+				return (Interop.DebugUtilsObjectTagInfoExt*)native.Handle;
+			}
+		}
+
+		public DebugUtilsObjectTagInfoExt ()
+		{
+			native = Interop.Structure.Allocate (typeof (Interop.DebugUtilsObjectTagInfoExt));
+			Initialize ();
+		}
+
+		internal DebugUtilsObjectTagInfoExt (NativePointer pointer)
+		{
+			native = pointer;
+			Initialize ();
+		}
+
+
+		internal void Initialize ()
+		{
+			m->SType = StructureType.DebugUtilsObjectTagInfoExt;
+		}
+
+	}
+
+	unsafe public partial class DebugUtilsLabelExt : MarshalledObject
+	{
+		public string LabelName {
+			get { return Marshal.PtrToStringAnsi (m->LabelName); }
+			set { m->LabelName = Marshal.StringToHGlobalAnsi (value); }
+		}
+
+		public float[] Color {
+			get {
+				var arr = new float [4];
+				for (int i = 0; i < 4; i++)
+					arr [i] = m->Color [i];
+				return arr;
+			}
+
+			set {
+				if (value.Length > 4)
+					throw new Exception ("array too long");
+				for (int i = 0; i < value.Length; i++)
+					m->Color [i] = value [i];
+				for (int i = value.Length; i < 4; i++)
+					m->Color [i] = 0;
+			}
+		}
+
+		internal Interop.DebugUtilsLabelExt* m {
+			get {
+				return (Interop.DebugUtilsLabelExt*)native.Handle;
+			}
+		}
+
+		public DebugUtilsLabelExt ()
+		{
+			native = Interop.Structure.Allocate (typeof (Interop.DebugUtilsLabelExt));
+			Initialize ();
+		}
+
+		internal DebugUtilsLabelExt (NativePointer pointer)
+		{
+			native = pointer;
+			Initialize ();
+		}
+
+
+		internal void Initialize ()
+		{
+			m->SType = StructureType.DebugUtilsLabelExt;
+		}
+
+	}
+
+	unsafe public partial class DebugUtilsMessengerCreateInfoExt : MarshalledObject
+	{
+		public UInt32 Flags {
+			get { return m->Flags; }
+			set { m->Flags = value; }
+		}
+
+		public DebugUtilsMessageSeverityFlagsExt MessageSeverity {
+			get { return m->MessageSeverity; }
+			set { m->MessageSeverity = value; }
+		}
+
+		public DebugUtilsMessageTypeFlagsExt MessageType {
+			get { return m->MessageType; }
+			set { m->MessageType = value; }
+		}
+
+		public IntPtr PfnUserCallback {
+			get { return m->PfnUserCallback; }
+			set { m->PfnUserCallback = value; }
+		}
+
+		public IntPtr UserData {
+			get { return m->UserData; }
+			set { m->UserData = value; }
+		}
+
+		internal Interop.DebugUtilsMessengerCreateInfoExt* m {
+			get {
+				return (Interop.DebugUtilsMessengerCreateInfoExt*)native.Handle;
+			}
+		}
+
+		public DebugUtilsMessengerCreateInfoExt ()
+		{
+			native = Interop.Structure.Allocate (typeof (Interop.DebugUtilsMessengerCreateInfoExt));
+			Initialize ();
+		}
+
+		internal DebugUtilsMessengerCreateInfoExt (NativePointer pointer)
+		{
+			native = pointer;
+			Initialize ();
+		}
+
+
+		internal void Initialize ()
+		{
+			m->SType = StructureType.DebugUtilsMessengerCreateInfoExt;
+		}
+
+	}
+
+	unsafe public partial class DebugUtilsMessengerCallbackDataExt : MarshalledObject
+	{
+		public UInt32 Flags {
+			get { return m->Flags; }
+			set { m->Flags = value; }
+		}
+
+		public string MessageIdName {
+			get { return Marshal.PtrToStringAnsi (m->MessageIdName); }
+			set { m->MessageIdName = Marshal.StringToHGlobalAnsi (value); }
+		}
+
+		public Int32 MessageIdNumber {
+			get { return m->MessageIdNumber; }
+			set { m->MessageIdNumber = value; }
+		}
+
+		public string Message {
+			get { return Marshal.PtrToStringAnsi (m->Message); }
+			set { m->Message = Marshal.StringToHGlobalAnsi (value); }
+		}
+
+		public UInt32 QueueLabelCount {
+			get { return m->QueueLabelCount; }
+			set { m->QueueLabelCount = value; }
+		}
+
+		NativeReference refQueueLabels;
+		public DebugUtilsLabelExt[] QueueLabels {
+			get {
+				if (m->QueueLabelCount == 0)
+					return null;
+				var values = new DebugUtilsLabelExt [m->QueueLabelCount];
+				unsafe
+				{
+					Interop.DebugUtilsLabelExt* ptr = (Interop.DebugUtilsLabelExt*)m->QueueLabels;
+					for (int i = 0; i < values.Length; i++) {
+						values [i] = new DebugUtilsLabelExt ();
+						*values [i].m = ptr [i];
+					}
+				}
+				return values;
+			}
+
+			set {
+				if (value == null) {
+					m->QueueLabelCount = 0;
+					m->QueueLabels = IntPtr.Zero;
+					return;
+				}
+				m->QueueLabelCount = (uint)value.Length;
+				refQueueLabels = new NativeReference ((int)(sizeof(Interop.DebugUtilsLabelExt)*value.Length));
+				m->QueueLabels = refQueueLabels.Handle;
+				unsafe
+				{
+					Interop.DebugUtilsLabelExt* ptr = (Interop.DebugUtilsLabelExt*)m->QueueLabels;
+					for (int i = 0; i < value.Length; i++)
+						ptr [i] = *value [i].m;
+				}
+			}
+		}
+
+		public UInt32 CmdBufLabelCount {
+			get { return m->CmdBufLabelCount; }
+			set { m->CmdBufLabelCount = value; }
+		}
+
+		NativeReference refCmdBufLabels;
+		public DebugUtilsLabelExt[] CmdBufLabels {
+			get {
+				if (m->CmdBufLabelCount == 0)
+					return null;
+				var values = new DebugUtilsLabelExt [m->CmdBufLabelCount];
+				unsafe
+				{
+					Interop.DebugUtilsLabelExt* ptr = (Interop.DebugUtilsLabelExt*)m->CmdBufLabels;
+					for (int i = 0; i < values.Length; i++) {
+						values [i] = new DebugUtilsLabelExt ();
+						*values [i].m = ptr [i];
+					}
+				}
+				return values;
+			}
+
+			set {
+				if (value == null) {
+					m->CmdBufLabelCount = 0;
+					m->CmdBufLabels = IntPtr.Zero;
+					return;
+				}
+				m->CmdBufLabelCount = (uint)value.Length;
+				refCmdBufLabels = new NativeReference ((int)(sizeof(Interop.DebugUtilsLabelExt)*value.Length));
+				m->CmdBufLabels = refCmdBufLabels.Handle;
+				unsafe
+				{
+					Interop.DebugUtilsLabelExt* ptr = (Interop.DebugUtilsLabelExt*)m->CmdBufLabels;
+					for (int i = 0; i < value.Length; i++)
+						ptr [i] = *value [i].m;
+				}
+			}
+		}
+
+		public UInt32 ObjectCount {
+			get { return m->ObjectCount; }
+			set { m->ObjectCount = value; }
+		}
+
+		NativeReference refObjects;
+		public DebugUtilsObjectNameInfoExt[] Objects {
+			get {
+				if (m->ObjectCount == 0)
+					return null;
+				var values = new DebugUtilsObjectNameInfoExt [m->ObjectCount];
+				unsafe
+				{
+					Interop.DebugUtilsObjectNameInfoExt* ptr = (Interop.DebugUtilsObjectNameInfoExt*)m->Objects;
+					for (int i = 0; i < values.Length; i++) {
+						values [i] = new DebugUtilsObjectNameInfoExt ();
+						*values [i].m = ptr [i];
+					}
+				}
+				return values;
+			}
+
+			set {
+				if (value == null) {
+					m->ObjectCount = 0;
+					m->Objects = IntPtr.Zero;
+					return;
+				}
+				m->ObjectCount = (uint)value.Length;
+				refObjects = new NativeReference ((int)(sizeof(Interop.DebugUtilsObjectNameInfoExt)*value.Length));
+				m->Objects = refObjects.Handle;
+				unsafe
+				{
+					Interop.DebugUtilsObjectNameInfoExt* ptr = (Interop.DebugUtilsObjectNameInfoExt*)m->Objects;
+					for (int i = 0; i < value.Length; i++)
+						ptr [i] = *value [i].m;
+				}
+			}
+		}
+
+		internal Interop.DebugUtilsMessengerCallbackDataExt* m {
+			get {
+				return (Interop.DebugUtilsMessengerCallbackDataExt*)native.Handle;
+			}
+		}
+
+		public DebugUtilsMessengerCallbackDataExt ()
+		{
+			native = Interop.Structure.Allocate (typeof (Interop.DebugUtilsMessengerCallbackDataExt));
+			Initialize ();
+		}
+
+		internal DebugUtilsMessengerCallbackDataExt (NativePointer pointer)
+		{
+			native = pointer;
+			Initialize ();
+		}
+
+		override public void Dispose (bool disposing)
+		{
+			base.Dispose (disposing);
+			if (!disposing)
+				return;
+			refQueueLabels.Dispose ();
+			refQueueLabels = null;
+			refCmdBufLabels.Dispose ();
+			refCmdBufLabels = null;
+			refObjects.Dispose ();
+			refObjects = null;
+		}
+
+		internal void Initialize ()
+		{
+			m->SType = StructureType.DebugUtilsMessengerCallbackDataExt;
+		}
+
+	}
+
 	unsafe public partial class ImportMemoryHostPointerInfoExt : MarshalledObject
 	{
-		public ExternalMemoryHandleTypeFlagsKhr HandleType {
+		public ExternalMemoryHandleTypeFlags HandleType {
 			get { return m->HandleType; }
 			set { m->HandleType = value; }
 		}
@@ -14112,8 +16431,8 @@ namespace Vulkan
 			get { return m->HostPointer; }
 			set { m->HostPointer = value; }
 		}
-		internal Interop.ImportMemoryHostPointerInfoExt* m {
 
+		internal Interop.ImportMemoryHostPointerInfoExt* m {
 			get {
 				return (Interop.ImportMemoryHostPointerInfoExt*)native.Handle;
 			}
@@ -14145,8 +16464,8 @@ namespace Vulkan
 			get { return m->MemoryTypeBits; }
 			set { m->MemoryTypeBits = value; }
 		}
-		internal Interop.MemoryHostPointerPropertiesExt* m {
 
+		internal Interop.MemoryHostPointerPropertiesExt* m {
 			get {
 				return (Interop.MemoryHostPointerPropertiesExt*)native.Handle;
 			}
@@ -14178,8 +16497,8 @@ namespace Vulkan
 			get { return m->MinImportedHostPointerAlignment; }
 			set { m->MinImportedHostPointerAlignment = value; }
 		}
-		internal Interop.PhysicalDeviceExternalMemoryHostPropertiesExt* m {
 
+		internal Interop.PhysicalDeviceExternalMemoryHostPropertiesExt* m {
 			get {
 				return (Interop.PhysicalDeviceExternalMemoryHostPropertiesExt*)native.Handle;
 			}
@@ -14251,8 +16570,8 @@ namespace Vulkan
 			get { return m->ConservativeRasterizationPostDepthCoverage; }
 			set { m->ConservativeRasterizationPostDepthCoverage = value; }
 		}
-		internal Interop.PhysicalDeviceConservativeRasterizationPropertiesExt* m {
 
+		internal Interop.PhysicalDeviceConservativeRasterizationPropertiesExt* m {
 			get {
 				return (Interop.PhysicalDeviceConservativeRasterizationPropertiesExt*)native.Handle;
 			}
@@ -14278,6 +16597,137 @@ namespace Vulkan
 
 	}
 
+	unsafe public partial class CalibratedTimestampInfoExt : MarshalledObject
+	{
+		public TimeDomainExt TimeDomain {
+			get { return m->TimeDomain; }
+			set { m->TimeDomain = value; }
+		}
+
+		internal Interop.CalibratedTimestampInfoExt* m {
+			get {
+				return (Interop.CalibratedTimestampInfoExt*)native.Handle;
+			}
+		}
+
+		public CalibratedTimestampInfoExt ()
+		{
+			native = Interop.Structure.Allocate (typeof (Interop.CalibratedTimestampInfoExt));
+			Initialize ();
+		}
+
+		internal CalibratedTimestampInfoExt (NativePointer pointer)
+		{
+			native = pointer;
+			Initialize ();
+		}
+
+
+		internal void Initialize ()
+		{
+			m->SType = StructureType.CalibratedTimestampInfoExt;
+		}
+
+	}
+
+	unsafe public partial class PhysicalDeviceShaderCorePropertiesAmd : MarshalledObject
+	{
+		public UInt32 ShaderEngineCount {
+			get { return m->ShaderEngineCount; }
+			set { m->ShaderEngineCount = value; }
+		}
+
+		public UInt32 ShaderArraysPerEngineCount {
+			get { return m->ShaderArraysPerEngineCount; }
+			set { m->ShaderArraysPerEngineCount = value; }
+		}
+
+		public UInt32 ComputeUnitsPerShaderArray {
+			get { return m->ComputeUnitsPerShaderArray; }
+			set { m->ComputeUnitsPerShaderArray = value; }
+		}
+
+		public UInt32 SimdPerComputeUnit {
+			get { return m->SimdPerComputeUnit; }
+			set { m->SimdPerComputeUnit = value; }
+		}
+
+		public UInt32 WavefrontsPerSimd {
+			get { return m->WavefrontsPerSimd; }
+			set { m->WavefrontsPerSimd = value; }
+		}
+
+		public UInt32 WavefrontSize {
+			get { return m->WavefrontSize; }
+			set { m->WavefrontSize = value; }
+		}
+
+		public UInt32 SgprsPerSimd {
+			get { return m->SgprsPerSimd; }
+			set { m->SgprsPerSimd = value; }
+		}
+
+		public UInt32 MinSgprAllocation {
+			get { return m->MinSgprAllocation; }
+			set { m->MinSgprAllocation = value; }
+		}
+
+		public UInt32 MaxSgprAllocation {
+			get { return m->MaxSgprAllocation; }
+			set { m->MaxSgprAllocation = value; }
+		}
+
+		public UInt32 SgprAllocationGranularity {
+			get { return m->SgprAllocationGranularity; }
+			set { m->SgprAllocationGranularity = value; }
+		}
+
+		public UInt32 VgprsPerSimd {
+			get { return m->VgprsPerSimd; }
+			set { m->VgprsPerSimd = value; }
+		}
+
+		public UInt32 MinVgprAllocation {
+			get { return m->MinVgprAllocation; }
+			set { m->MinVgprAllocation = value; }
+		}
+
+		public UInt32 MaxVgprAllocation {
+			get { return m->MaxVgprAllocation; }
+			set { m->MaxVgprAllocation = value; }
+		}
+
+		public UInt32 VgprAllocationGranularity {
+			get { return m->VgprAllocationGranularity; }
+			set { m->VgprAllocationGranularity = value; }
+		}
+
+		internal Interop.PhysicalDeviceShaderCorePropertiesAmd* m {
+			get {
+				return (Interop.PhysicalDeviceShaderCorePropertiesAmd*)native.Handle;
+			}
+		}
+
+		public PhysicalDeviceShaderCorePropertiesAmd ()
+		{
+			native = Interop.Structure.Allocate (typeof (Interop.PhysicalDeviceShaderCorePropertiesAmd));
+			Initialize ();
+		}
+
+		internal PhysicalDeviceShaderCorePropertiesAmd (NativePointer pointer)
+		{
+			native = pointer;
+			Initialize ();
+		}
+
+
+		internal void Initialize ()
+		{
+			m->SType = StructureType.PhysicalDeviceShaderCorePropertiesAmd;
+		}
+
+	}
+
 	unsafe public partial class PipelineRasterizationConservativeStateCreateInfoExt : MarshalledObject
 	{
 		public UInt32 Flags {
@@ -14294,8 +16744,8 @@ namespace Vulkan
 			get { return m->ExtraPrimitiveOverestimationSize; }
 			set { m->ExtraPrimitiveOverestimationSize = value; }
 		}
-		internal Interop.PipelineRasterizationConservativeStateCreateInfoExt* m {
 
+		internal Interop.PipelineRasterizationConservativeStateCreateInfoExt* m {
 			get {
 				return (Interop.PipelineRasterizationConservativeStateCreateInfoExt*)native.Handle;
 			}
@@ -14317,6 +16767,5773 @@ namespace Vulkan
 		internal void Initialize ()
 		{
 			m->SType = StructureType.PipelineRasterizationConservativeStateCreateInfoExt;
+		}
+
+	}
+
+	unsafe public partial class PhysicalDeviceDescriptorIndexingFeaturesExt : MarshalledObject
+	{
+		public bool ShaderInputAttachmentArrayDynamicIndexing {
+			get { return m->ShaderInputAttachmentArrayDynamicIndexing; }
+			set { m->ShaderInputAttachmentArrayDynamicIndexing = value; }
+		}
+
+		public bool ShaderUniformTexelBufferArrayDynamicIndexing {
+			get { return m->ShaderUniformTexelBufferArrayDynamicIndexing; }
+			set { m->ShaderUniformTexelBufferArrayDynamicIndexing = value; }
+		}
+
+		public bool ShaderStorageTexelBufferArrayDynamicIndexing {
+			get { return m->ShaderStorageTexelBufferArrayDynamicIndexing; }
+			set { m->ShaderStorageTexelBufferArrayDynamicIndexing = value; }
+		}
+
+		public bool ShaderUniformBufferArrayNonUniformIndexing {
+			get { return m->ShaderUniformBufferArrayNonUniformIndexing; }
+			set { m->ShaderUniformBufferArrayNonUniformIndexing = value; }
+		}
+
+		public bool ShaderSampledImageArrayNonUniformIndexing {
+			get { return m->ShaderSampledImageArrayNonUniformIndexing; }
+			set { m->ShaderSampledImageArrayNonUniformIndexing = value; }
+		}
+
+		public bool ShaderStorageBufferArrayNonUniformIndexing {
+			get { return m->ShaderStorageBufferArrayNonUniformIndexing; }
+			set { m->ShaderStorageBufferArrayNonUniformIndexing = value; }
+		}
+
+		public bool ShaderStorageImageArrayNonUniformIndexing {
+			get { return m->ShaderStorageImageArrayNonUniformIndexing; }
+			set { m->ShaderStorageImageArrayNonUniformIndexing = value; }
+		}
+
+		public bool ShaderInputAttachmentArrayNonUniformIndexing {
+			get { return m->ShaderInputAttachmentArrayNonUniformIndexing; }
+			set { m->ShaderInputAttachmentArrayNonUniformIndexing = value; }
+		}
+
+		public bool ShaderUniformTexelBufferArrayNonUniformIndexing {
+			get { return m->ShaderUniformTexelBufferArrayNonUniformIndexing; }
+			set { m->ShaderUniformTexelBufferArrayNonUniformIndexing = value; }
+		}
+
+		public bool ShaderStorageTexelBufferArrayNonUniformIndexing {
+			get { return m->ShaderStorageTexelBufferArrayNonUniformIndexing; }
+			set { m->ShaderStorageTexelBufferArrayNonUniformIndexing = value; }
+		}
+
+		public bool DescriptorBindingUniformBufferUpdateAfterBind {
+			get { return m->DescriptorBindingUniformBufferUpdateAfterBind; }
+			set { m->DescriptorBindingUniformBufferUpdateAfterBind = value; }
+		}
+
+		public bool DescriptorBindingSampledImageUpdateAfterBind {
+			get { return m->DescriptorBindingSampledImageUpdateAfterBind; }
+			set { m->DescriptorBindingSampledImageUpdateAfterBind = value; }
+		}
+
+		public bool DescriptorBindingStorageImageUpdateAfterBind {
+			get { return m->DescriptorBindingStorageImageUpdateAfterBind; }
+			set { m->DescriptorBindingStorageImageUpdateAfterBind = value; }
+		}
+
+		public bool DescriptorBindingStorageBufferUpdateAfterBind {
+			get { return m->DescriptorBindingStorageBufferUpdateAfterBind; }
+			set { m->DescriptorBindingStorageBufferUpdateAfterBind = value; }
+		}
+
+		public bool DescriptorBindingUniformTexelBufferUpdateAfterBind {
+			get { return m->DescriptorBindingUniformTexelBufferUpdateAfterBind; }
+			set { m->DescriptorBindingUniformTexelBufferUpdateAfterBind = value; }
+		}
+
+		public bool DescriptorBindingStorageTexelBufferUpdateAfterBind {
+			get { return m->DescriptorBindingStorageTexelBufferUpdateAfterBind; }
+			set { m->DescriptorBindingStorageTexelBufferUpdateAfterBind = value; }
+		}
+
+		public bool DescriptorBindingUpdateUnusedWhilePending {
+			get { return m->DescriptorBindingUpdateUnusedWhilePending; }
+			set { m->DescriptorBindingUpdateUnusedWhilePending = value; }
+		}
+
+		public bool DescriptorBindingPartiallyBound {
+			get { return m->DescriptorBindingPartiallyBound; }
+			set { m->DescriptorBindingPartiallyBound = value; }
+		}
+
+		public bool DescriptorBindingVariableDescriptorCount {
+			get { return m->DescriptorBindingVariableDescriptorCount; }
+			set { m->DescriptorBindingVariableDescriptorCount = value; }
+		}
+
+		public bool RuntimeDescriptorArray {
+			get { return m->RuntimeDescriptorArray; }
+			set { m->RuntimeDescriptorArray = value; }
+		}
+
+		internal Interop.PhysicalDeviceDescriptorIndexingFeaturesExt* m {
+			get {
+				return (Interop.PhysicalDeviceDescriptorIndexingFeaturesExt*)native.Handle;
+			}
+		}
+
+		public PhysicalDeviceDescriptorIndexingFeaturesExt ()
+		{
+			native = Interop.Structure.Allocate (typeof (Interop.PhysicalDeviceDescriptorIndexingFeaturesExt));
+			Initialize ();
+		}
+
+		internal PhysicalDeviceDescriptorIndexingFeaturesExt (NativePointer pointer)
+		{
+			native = pointer;
+			Initialize ();
+		}
+
+
+		internal void Initialize ()
+		{
+			m->SType = StructureType.PhysicalDeviceDescriptorIndexingFeaturesExt;
+		}
+
+	}
+
+	unsafe public partial class PhysicalDeviceDescriptorIndexingPropertiesExt : MarshalledObject
+	{
+		public UInt32 MaxUpdateAfterBindDescriptorsInAllPools {
+			get { return m->MaxUpdateAfterBindDescriptorsInAllPools; }
+			set { m->MaxUpdateAfterBindDescriptorsInAllPools = value; }
+		}
+
+		public bool ShaderUniformBufferArrayNonUniformIndexingNative {
+			get { return m->ShaderUniformBufferArrayNonUniformIndexingNative; }
+			set { m->ShaderUniformBufferArrayNonUniformIndexingNative = value; }
+		}
+
+		public bool ShaderSampledImageArrayNonUniformIndexingNative {
+			get { return m->ShaderSampledImageArrayNonUniformIndexingNative; }
+			set { m->ShaderSampledImageArrayNonUniformIndexingNative = value; }
+		}
+
+		public bool ShaderStorageBufferArrayNonUniformIndexingNative {
+			get { return m->ShaderStorageBufferArrayNonUniformIndexingNative; }
+			set { m->ShaderStorageBufferArrayNonUniformIndexingNative = value; }
+		}
+
+		public bool ShaderStorageImageArrayNonUniformIndexingNative {
+			get { return m->ShaderStorageImageArrayNonUniformIndexingNative; }
+			set { m->ShaderStorageImageArrayNonUniformIndexingNative = value; }
+		}
+
+		public bool ShaderInputAttachmentArrayNonUniformIndexingNative {
+			get { return m->ShaderInputAttachmentArrayNonUniformIndexingNative; }
+			set { m->ShaderInputAttachmentArrayNonUniformIndexingNative = value; }
+		}
+
+		public bool RobustBufferAccessUpdateAfterBind {
+			get { return m->RobustBufferAccessUpdateAfterBind; }
+			set { m->RobustBufferAccessUpdateAfterBind = value; }
+		}
+
+		public bool QuadDivergentImplicitLod {
+			get { return m->QuadDivergentImplicitLod; }
+			set { m->QuadDivergentImplicitLod = value; }
+		}
+
+		public UInt32 MaxPerStageDescriptorUpdateAfterBindSamplers {
+			get { return m->MaxPerStageDescriptorUpdateAfterBindSamplers; }
+			set { m->MaxPerStageDescriptorUpdateAfterBindSamplers = value; }
+		}
+
+		public UInt32 MaxPerStageDescriptorUpdateAfterBindUniformBuffers {
+			get { return m->MaxPerStageDescriptorUpdateAfterBindUniformBuffers; }
+			set { m->MaxPerStageDescriptorUpdateAfterBindUniformBuffers = value; }
+		}
+
+		public UInt32 MaxPerStageDescriptorUpdateAfterBindStorageBuffers {
+			get { return m->MaxPerStageDescriptorUpdateAfterBindStorageBuffers; }
+			set { m->MaxPerStageDescriptorUpdateAfterBindStorageBuffers = value; }
+		}
+
+		public UInt32 MaxPerStageDescriptorUpdateAfterBindSampledImages {
+			get { return m->MaxPerStageDescriptorUpdateAfterBindSampledImages; }
+			set { m->MaxPerStageDescriptorUpdateAfterBindSampledImages = value; }
+		}
+
+		public UInt32 MaxPerStageDescriptorUpdateAfterBindStorageImages {
+			get { return m->MaxPerStageDescriptorUpdateAfterBindStorageImages; }
+			set { m->MaxPerStageDescriptorUpdateAfterBindStorageImages = value; }
+		}
+
+		public UInt32 MaxPerStageDescriptorUpdateAfterBindInputAttachments {
+			get { return m->MaxPerStageDescriptorUpdateAfterBindInputAttachments; }
+			set { m->MaxPerStageDescriptorUpdateAfterBindInputAttachments = value; }
+		}
+
+		public UInt32 MaxPerStageUpdateAfterBindResources {
+			get { return m->MaxPerStageUpdateAfterBindResources; }
+			set { m->MaxPerStageUpdateAfterBindResources = value; }
+		}
+
+		public UInt32 MaxDescriptorSetUpdateAfterBindSamplers {
+			get { return m->MaxDescriptorSetUpdateAfterBindSamplers; }
+			set { m->MaxDescriptorSetUpdateAfterBindSamplers = value; }
+		}
+
+		public UInt32 MaxDescriptorSetUpdateAfterBindUniformBuffers {
+			get { return m->MaxDescriptorSetUpdateAfterBindUniformBuffers; }
+			set { m->MaxDescriptorSetUpdateAfterBindUniformBuffers = value; }
+		}
+
+		public UInt32 MaxDescriptorSetUpdateAfterBindUniformBuffersDynamic {
+			get { return m->MaxDescriptorSetUpdateAfterBindUniformBuffersDynamic; }
+			set { m->MaxDescriptorSetUpdateAfterBindUniformBuffersDynamic = value; }
+		}
+
+		public UInt32 MaxDescriptorSetUpdateAfterBindStorageBuffers {
+			get { return m->MaxDescriptorSetUpdateAfterBindStorageBuffers; }
+			set { m->MaxDescriptorSetUpdateAfterBindStorageBuffers = value; }
+		}
+
+		public UInt32 MaxDescriptorSetUpdateAfterBindStorageBuffersDynamic {
+			get { return m->MaxDescriptorSetUpdateAfterBindStorageBuffersDynamic; }
+			set { m->MaxDescriptorSetUpdateAfterBindStorageBuffersDynamic = value; }
+		}
+
+		public UInt32 MaxDescriptorSetUpdateAfterBindSampledImages {
+			get { return m->MaxDescriptorSetUpdateAfterBindSampledImages; }
+			set { m->MaxDescriptorSetUpdateAfterBindSampledImages = value; }
+		}
+
+		public UInt32 MaxDescriptorSetUpdateAfterBindStorageImages {
+			get { return m->MaxDescriptorSetUpdateAfterBindStorageImages; }
+			set { m->MaxDescriptorSetUpdateAfterBindStorageImages = value; }
+		}
+
+		public UInt32 MaxDescriptorSetUpdateAfterBindInputAttachments {
+			get { return m->MaxDescriptorSetUpdateAfterBindInputAttachments; }
+			set { m->MaxDescriptorSetUpdateAfterBindInputAttachments = value; }
+		}
+
+		internal Interop.PhysicalDeviceDescriptorIndexingPropertiesExt* m {
+			get {
+				return (Interop.PhysicalDeviceDescriptorIndexingPropertiesExt*)native.Handle;
+			}
+		}
+
+		public PhysicalDeviceDescriptorIndexingPropertiesExt ()
+		{
+			native = Interop.Structure.Allocate (typeof (Interop.PhysicalDeviceDescriptorIndexingPropertiesExt));
+			Initialize ();
+		}
+
+		internal PhysicalDeviceDescriptorIndexingPropertiesExt (NativePointer pointer)
+		{
+			native = pointer;
+			Initialize ();
+		}
+
+
+		internal void Initialize ()
+		{
+			m->SType = StructureType.PhysicalDeviceDescriptorIndexingPropertiesExt;
+		}
+
+	}
+
+	unsafe public partial class DescriptorSetLayoutBindingFlagsCreateInfoExt : MarshalledObject
+	{
+		public UInt32 BindingCount {
+			get { return m->BindingCount; }
+			set { m->BindingCount = value; }
+		}
+
+		NativeReference refBindingFlags;
+		public DescriptorBindingFlagsExt[] BindingFlags {
+			get {
+				if (m->BindingCount == 0)
+					return null;
+				var values = new DescriptorBindingFlagsExt [m->BindingCount];
+				unsafe
+				{
+					DescriptorBindingFlagsExt* ptr = (DescriptorBindingFlagsExt*)m->BindingFlags;
+					for (int i = 0; i < values.Length; i++) 
+						values [i] = ptr [i];
+				}
+				return values;
+			}
+
+			set {
+				if (value == null) {
+					m->BindingCount = 0;
+					m->BindingFlags = IntPtr.Zero;
+					return;
+				}
+				m->BindingCount = (uint)value.Length;
+				refBindingFlags = new NativeReference ((int)(sizeof(DescriptorBindingFlagsExt)*value.Length));
+				m->BindingFlags = refBindingFlags.Handle;
+				unsafe
+				{
+					DescriptorBindingFlagsExt* ptr = (DescriptorBindingFlagsExt*)m->BindingFlags;
+					for (int i = 0; i < value.Length; i++)
+						ptr [i] = value [i];
+				}
+			}
+		}
+
+		internal Interop.DescriptorSetLayoutBindingFlagsCreateInfoExt* m {
+			get {
+				return (Interop.DescriptorSetLayoutBindingFlagsCreateInfoExt*)native.Handle;
+			}
+		}
+
+		public DescriptorSetLayoutBindingFlagsCreateInfoExt ()
+		{
+			native = Interop.Structure.Allocate (typeof (Interop.DescriptorSetLayoutBindingFlagsCreateInfoExt));
+			Initialize ();
+		}
+
+		internal DescriptorSetLayoutBindingFlagsCreateInfoExt (NativePointer pointer)
+		{
+			native = pointer;
+			Initialize ();
+		}
+
+		override public void Dispose (bool disposing)
+		{
+			base.Dispose (disposing);
+			if (!disposing)
+				return;
+			refBindingFlags.Dispose ();
+			refBindingFlags = null;
+		}
+
+		internal void Initialize ()
+		{
+			m->SType = StructureType.DescriptorSetLayoutBindingFlagsCreateInfoExt;
+		}
+
+	}
+
+	unsafe public partial class DescriptorSetVariableDescriptorCountAllocateInfoExt : MarshalledObject
+	{
+		public UInt32 DescriptorSetCount {
+			get { return m->DescriptorSetCount; }
+			set { m->DescriptorSetCount = value; }
+		}
+
+		NativeReference refDescriptorCounts;
+		public UInt32[] DescriptorCounts {
+			get {
+				if (m->DescriptorSetCount == 0)
+					return null;
+				var values = new UInt32 [m->DescriptorSetCount];
+				unsafe
+				{
+					UInt32* ptr = (UInt32*)m->DescriptorCounts;
+					for (int i = 0; i < values.Length; i++) 
+						values [i] = ptr [i];
+				}
+				return values;
+			}
+
+			set {
+				if (value == null) {
+					m->DescriptorSetCount = 0;
+					m->DescriptorCounts = IntPtr.Zero;
+					return;
+				}
+				m->DescriptorSetCount = (uint)value.Length;
+				refDescriptorCounts = new NativeReference ((int)(sizeof(UInt32)*value.Length));
+				m->DescriptorCounts = refDescriptorCounts.Handle;
+				unsafe
+				{
+					UInt32* ptr = (UInt32*)m->DescriptorCounts;
+					for (int i = 0; i < value.Length; i++)
+						ptr [i] = value [i];
+				}
+			}
+		}
+
+		internal Interop.DescriptorSetVariableDescriptorCountAllocateInfoExt* m {
+			get {
+				return (Interop.DescriptorSetVariableDescriptorCountAllocateInfoExt*)native.Handle;
+			}
+		}
+
+		public DescriptorSetVariableDescriptorCountAllocateInfoExt ()
+		{
+			native = Interop.Structure.Allocate (typeof (Interop.DescriptorSetVariableDescriptorCountAllocateInfoExt));
+			Initialize ();
+		}
+
+		internal DescriptorSetVariableDescriptorCountAllocateInfoExt (NativePointer pointer)
+		{
+			native = pointer;
+			Initialize ();
+		}
+
+		override public void Dispose (bool disposing)
+		{
+			base.Dispose (disposing);
+			if (!disposing)
+				return;
+			refDescriptorCounts.Dispose ();
+			refDescriptorCounts = null;
+		}
+
+		internal void Initialize ()
+		{
+			m->SType = StructureType.DescriptorSetVariableDescriptorCountAllocateInfoExt;
+		}
+
+	}
+
+	unsafe public partial class DescriptorSetVariableDescriptorCountLayoutSupportExt : MarshalledObject
+	{
+		public UInt32 MaxVariableDescriptorCount {
+			get { return m->MaxVariableDescriptorCount; }
+			set { m->MaxVariableDescriptorCount = value; }
+		}
+
+		internal Interop.DescriptorSetVariableDescriptorCountLayoutSupportExt* m {
+			get {
+				return (Interop.DescriptorSetVariableDescriptorCountLayoutSupportExt*)native.Handle;
+			}
+		}
+
+		public DescriptorSetVariableDescriptorCountLayoutSupportExt ()
+		{
+			native = Interop.Structure.Allocate (typeof (Interop.DescriptorSetVariableDescriptorCountLayoutSupportExt));
+			Initialize ();
+		}
+
+		internal DescriptorSetVariableDescriptorCountLayoutSupportExt (NativePointer pointer)
+		{
+			native = pointer;
+			Initialize ();
+		}
+
+
+		internal void Initialize ()
+		{
+			m->SType = StructureType.DescriptorSetVariableDescriptorCountLayoutSupportExt;
+		}
+
+	}
+
+	unsafe public partial class AttachmentDescription2Khr : MarshalledObject
+	{
+		public AttachmentDescriptionFlags Flags {
+			get { return m->Flags; }
+			set { m->Flags = value; }
+		}
+
+		public Format Format {
+			get { return m->Format; }
+			set { m->Format = value; }
+		}
+
+		public SampleCountFlags Samples {
+			get { return m->Samples; }
+			set { m->Samples = value; }
+		}
+
+		public AttachmentLoadOp LoadOp {
+			get { return m->LoadOp; }
+			set { m->LoadOp = value; }
+		}
+
+		public AttachmentStoreOp StoreOp {
+			get { return m->StoreOp; }
+			set { m->StoreOp = value; }
+		}
+
+		public AttachmentLoadOp StencilLoadOp {
+			get { return m->StencilLoadOp; }
+			set { m->StencilLoadOp = value; }
+		}
+
+		public AttachmentStoreOp StencilStoreOp {
+			get { return m->StencilStoreOp; }
+			set { m->StencilStoreOp = value; }
+		}
+
+		public ImageLayout InitialLayout {
+			get { return m->InitialLayout; }
+			set { m->InitialLayout = value; }
+		}
+
+		public ImageLayout FinalLayout {
+			get { return m->FinalLayout; }
+			set { m->FinalLayout = value; }
+		}
+
+		internal Interop.AttachmentDescription2Khr* m {
+			get {
+				return (Interop.AttachmentDescription2Khr*)native.Handle;
+			}
+		}
+
+		public AttachmentDescription2Khr ()
+		{
+			native = Interop.Structure.Allocate (typeof (Interop.AttachmentDescription2Khr));
+			Initialize ();
+		}
+
+		internal AttachmentDescription2Khr (NativePointer pointer)
+		{
+			native = pointer;
+			Initialize ();
+		}
+
+
+		internal void Initialize ()
+		{
+			m->SType = StructureType.AttachmentDescription2Khr;
+		}
+
+	}
+
+	unsafe public partial class AttachmentReference2Khr : MarshalledObject
+	{
+		public UInt32 Attachment {
+			get { return m->Attachment; }
+			set { m->Attachment = value; }
+		}
+
+		public ImageLayout Layout {
+			get { return m->Layout; }
+			set { m->Layout = value; }
+		}
+
+		public ImageAspectFlags AspectMask {
+			get { return m->AspectMask; }
+			set { m->AspectMask = value; }
+		}
+
+		internal Interop.AttachmentReference2Khr* m {
+			get {
+				return (Interop.AttachmentReference2Khr*)native.Handle;
+			}
+		}
+
+		public AttachmentReference2Khr ()
+		{
+			native = Interop.Structure.Allocate (typeof (Interop.AttachmentReference2Khr));
+			Initialize ();
+		}
+
+		internal AttachmentReference2Khr (NativePointer pointer)
+		{
+			native = pointer;
+			Initialize ();
+		}
+
+
+		internal void Initialize ()
+		{
+			m->SType = StructureType.AttachmentReference2Khr;
+		}
+
+	}
+
+	unsafe public partial class SubpassDescription2Khr : MarshalledObject
+	{
+		public SubpassDescriptionFlags Flags {
+			get { return m->Flags; }
+			set { m->Flags = value; }
+		}
+
+		public PipelineBindPoint PipelineBindPoint {
+			get { return m->PipelineBindPoint; }
+			set { m->PipelineBindPoint = value; }
+		}
+
+		public UInt32 ViewMask {
+			get { return m->ViewMask; }
+			set { m->ViewMask = value; }
+		}
+
+		public UInt32 InputAttachmentCount {
+			get { return m->InputAttachmentCount; }
+			set { m->InputAttachmentCount = value; }
+		}
+
+		NativeReference refInputAttachments;
+		public AttachmentReference2Khr[] InputAttachments {
+			get {
+				if (m->InputAttachmentCount == 0)
+					return null;
+				var values = new AttachmentReference2Khr [m->InputAttachmentCount];
+				unsafe
+				{
+					Interop.AttachmentReference2Khr* ptr = (Interop.AttachmentReference2Khr*)m->InputAttachments;
+					for (int i = 0; i < values.Length; i++) {
+						values [i] = new AttachmentReference2Khr ();
+						*values [i].m = ptr [i];
+					}
+				}
+				return values;
+			}
+
+			set {
+				if (value == null) {
+					m->InputAttachmentCount = 0;
+					m->InputAttachments = IntPtr.Zero;
+					return;
+				}
+				m->InputAttachmentCount = (uint)value.Length;
+				refInputAttachments = new NativeReference ((int)(sizeof(Interop.AttachmentReference2Khr)*value.Length));
+				m->InputAttachments = refInputAttachments.Handle;
+				unsafe
+				{
+					Interop.AttachmentReference2Khr* ptr = (Interop.AttachmentReference2Khr*)m->InputAttachments;
+					for (int i = 0; i < value.Length; i++)
+						ptr [i] = *value [i].m;
+				}
+			}
+		}
+
+		public UInt32 ColorAttachmentCount {
+			get { return m->ColorAttachmentCount; }
+			set { m->ColorAttachmentCount = value; }
+		}
+
+		NativeReference refColorAttachments;
+		public AttachmentReference2Khr[] ColorAttachments {
+			get {
+				if (m->ColorAttachmentCount == 0)
+					return null;
+				var values = new AttachmentReference2Khr [m->ColorAttachmentCount];
+				unsafe
+				{
+					Interop.AttachmentReference2Khr* ptr = (Interop.AttachmentReference2Khr*)m->ColorAttachments;
+					for (int i = 0; i < values.Length; i++) {
+						values [i] = new AttachmentReference2Khr ();
+						*values [i].m = ptr [i];
+					}
+				}
+				return values;
+			}
+
+			set {
+				if (value == null) {
+					m->ColorAttachmentCount = 0;
+					m->ColorAttachments = IntPtr.Zero;
+					return;
+				}
+				m->ColorAttachmentCount = (uint)value.Length;
+				refColorAttachments = new NativeReference ((int)(sizeof(Interop.AttachmentReference2Khr)*value.Length));
+				m->ColorAttachments = refColorAttachments.Handle;
+				unsafe
+				{
+					Interop.AttachmentReference2Khr* ptr = (Interop.AttachmentReference2Khr*)m->ColorAttachments;
+					for (int i = 0; i < value.Length; i++)
+						ptr [i] = *value [i].m;
+				}
+			}
+		}
+
+		NativeReference refResolveAttachments;
+		public AttachmentReference2Khr[] ResolveAttachments {
+			get {
+				if (m->ColorAttachmentCount == 0)
+					return null;
+				var values = new AttachmentReference2Khr [m->ColorAttachmentCount];
+				unsafe
+				{
+					Interop.AttachmentReference2Khr* ptr = (Interop.AttachmentReference2Khr*)m->ResolveAttachments;
+					for (int i = 0; i < values.Length; i++) {
+						values [i] = new AttachmentReference2Khr ();
+						*values [i].m = ptr [i];
+					}
+				}
+				return values;
+			}
+
+			set {
+				if (value == null) {
+					m->ColorAttachmentCount = 0;
+					m->ResolveAttachments = IntPtr.Zero;
+					return;
+				}
+				m->ColorAttachmentCount = (uint)value.Length;
+				refResolveAttachments = new NativeReference ((int)(sizeof(Interop.AttachmentReference2Khr)*value.Length));
+				m->ResolveAttachments = refResolveAttachments.Handle;
+				unsafe
+				{
+					Interop.AttachmentReference2Khr* ptr = (Interop.AttachmentReference2Khr*)m->ResolveAttachments;
+					for (int i = 0; i < value.Length; i++)
+						ptr [i] = *value [i].m;
+				}
+			}
+		}
+
+		AttachmentReference2Khr lDepthStencilAttachment;
+		public AttachmentReference2Khr DepthStencilAttachment {
+			get { return lDepthStencilAttachment; }
+			set { lDepthStencilAttachment = value; m->DepthStencilAttachment = value != null ? (IntPtr)value.m : default(IntPtr); }
+		}
+
+		public UInt32 PreserveAttachmentCount {
+			get { return m->PreserveAttachmentCount; }
+			set { m->PreserveAttachmentCount = value; }
+		}
+
+		NativeReference refPreserveAttachments;
+		public UInt32[] PreserveAttachments {
+			get {
+				if (m->PreserveAttachmentCount == 0)
+					return null;
+				var values = new UInt32 [m->PreserveAttachmentCount];
+				unsafe
+				{
+					UInt32* ptr = (UInt32*)m->PreserveAttachments;
+					for (int i = 0; i < values.Length; i++) 
+						values [i] = ptr [i];
+				}
+				return values;
+			}
+
+			set {
+				if (value == null) {
+					m->PreserveAttachmentCount = 0;
+					m->PreserveAttachments = IntPtr.Zero;
+					return;
+				}
+				m->PreserveAttachmentCount = (uint)value.Length;
+				refPreserveAttachments = new NativeReference ((int)(sizeof(UInt32)*value.Length));
+				m->PreserveAttachments = refPreserveAttachments.Handle;
+				unsafe
+				{
+					UInt32* ptr = (UInt32*)m->PreserveAttachments;
+					for (int i = 0; i < value.Length; i++)
+						ptr [i] = value [i];
+				}
+			}
+		}
+
+		internal Interop.SubpassDescription2Khr* m {
+			get {
+				return (Interop.SubpassDescription2Khr*)native.Handle;
+			}
+		}
+
+		public SubpassDescription2Khr ()
+		{
+			native = Interop.Structure.Allocate (typeof (Interop.SubpassDescription2Khr));
+			Initialize ();
+		}
+
+		internal SubpassDescription2Khr (NativePointer pointer)
+		{
+			native = pointer;
+			Initialize ();
+		}
+
+		override public void Dispose (bool disposing)
+		{
+			base.Dispose (disposing);
+			if (!disposing)
+				return;
+			refInputAttachments.Dispose ();
+			refInputAttachments = null;
+			refColorAttachments.Dispose ();
+			refColorAttachments = null;
+			refResolveAttachments.Dispose ();
+			refResolveAttachments = null;
+			refPreserveAttachments.Dispose ();
+			refPreserveAttachments = null;
+		}
+
+		internal void Initialize ()
+		{
+			m->SType = StructureType.SubpassDescription2Khr;
+		}
+
+	}
+
+	unsafe public partial class SubpassDependency2Khr : MarshalledObject
+	{
+		public UInt32 SrcSubpass {
+			get { return m->SrcSubpass; }
+			set { m->SrcSubpass = value; }
+		}
+
+		public UInt32 DstSubpass {
+			get { return m->DstSubpass; }
+			set { m->DstSubpass = value; }
+		}
+
+		public PipelineStageFlags SrcStageMask {
+			get { return m->SrcStageMask; }
+			set { m->SrcStageMask = value; }
+		}
+
+		public PipelineStageFlags DstStageMask {
+			get { return m->DstStageMask; }
+			set { m->DstStageMask = value; }
+		}
+
+		public AccessFlags SrcAccessMask {
+			get { return m->SrcAccessMask; }
+			set { m->SrcAccessMask = value; }
+		}
+
+		public AccessFlags DstAccessMask {
+			get { return m->DstAccessMask; }
+			set { m->DstAccessMask = value; }
+		}
+
+		public DependencyFlags DependencyFlags {
+			get { return m->DependencyFlags; }
+			set { m->DependencyFlags = value; }
+		}
+
+		public Int32 ViewOffset {
+			get { return m->ViewOffset; }
+			set { m->ViewOffset = value; }
+		}
+
+		internal Interop.SubpassDependency2Khr* m {
+			get {
+				return (Interop.SubpassDependency2Khr*)native.Handle;
+			}
+		}
+
+		public SubpassDependency2Khr ()
+		{
+			native = Interop.Structure.Allocate (typeof (Interop.SubpassDependency2Khr));
+			Initialize ();
+		}
+
+		internal SubpassDependency2Khr (NativePointer pointer)
+		{
+			native = pointer;
+			Initialize ();
+		}
+
+
+		internal void Initialize ()
+		{
+			m->SType = StructureType.SubpassDependency2Khr;
+		}
+
+	}
+
+	unsafe public partial class RenderPassCreateInfo2Khr : MarshalledObject
+	{
+		public UInt32 Flags {
+			get { return m->Flags; }
+			set { m->Flags = value; }
+		}
+
+		public UInt32 AttachmentCount {
+			get { return m->AttachmentCount; }
+			set { m->AttachmentCount = value; }
+		}
+
+		NativeReference refAttachments;
+		public AttachmentDescription2Khr[] Attachments {
+			get {
+				if (m->AttachmentCount == 0)
+					return null;
+				var values = new AttachmentDescription2Khr [m->AttachmentCount];
+				unsafe
+				{
+					Interop.AttachmentDescription2Khr* ptr = (Interop.AttachmentDescription2Khr*)m->Attachments;
+					for (int i = 0; i < values.Length; i++) {
+						values [i] = new AttachmentDescription2Khr ();
+						*values [i].m = ptr [i];
+					}
+				}
+				return values;
+			}
+
+			set {
+				if (value == null) {
+					m->AttachmentCount = 0;
+					m->Attachments = IntPtr.Zero;
+					return;
+				}
+				m->AttachmentCount = (uint)value.Length;
+				refAttachments = new NativeReference ((int)(sizeof(Interop.AttachmentDescription2Khr)*value.Length));
+				m->Attachments = refAttachments.Handle;
+				unsafe
+				{
+					Interop.AttachmentDescription2Khr* ptr = (Interop.AttachmentDescription2Khr*)m->Attachments;
+					for (int i = 0; i < value.Length; i++)
+						ptr [i] = *value [i].m;
+				}
+			}
+		}
+
+		public UInt32 SubpassCount {
+			get { return m->SubpassCount; }
+			set { m->SubpassCount = value; }
+		}
+
+		NativeReference refSubpasses;
+		public SubpassDescription2Khr[] Subpasses {
+			get {
+				if (m->SubpassCount == 0)
+					return null;
+				var values = new SubpassDescription2Khr [m->SubpassCount];
+				unsafe
+				{
+					Interop.SubpassDescription2Khr* ptr = (Interop.SubpassDescription2Khr*)m->Subpasses;
+					for (int i = 0; i < values.Length; i++) {
+						values [i] = new SubpassDescription2Khr ();
+						*values [i].m = ptr [i];
+					}
+				}
+				return values;
+			}
+
+			set {
+				if (value == null) {
+					m->SubpassCount = 0;
+					m->Subpasses = IntPtr.Zero;
+					return;
+				}
+				m->SubpassCount = (uint)value.Length;
+				refSubpasses = new NativeReference ((int)(sizeof(Interop.SubpassDescription2Khr)*value.Length));
+				m->Subpasses = refSubpasses.Handle;
+				unsafe
+				{
+					Interop.SubpassDescription2Khr* ptr = (Interop.SubpassDescription2Khr*)m->Subpasses;
+					for (int i = 0; i < value.Length; i++)
+						ptr [i] = *value [i].m;
+				}
+			}
+		}
+
+		public UInt32 DependencyCount {
+			get { return m->DependencyCount; }
+			set { m->DependencyCount = value; }
+		}
+
+		NativeReference refDependencies;
+		public SubpassDependency2Khr[] Dependencies {
+			get {
+				if (m->DependencyCount == 0)
+					return null;
+				var values = new SubpassDependency2Khr [m->DependencyCount];
+				unsafe
+				{
+					Interop.SubpassDependency2Khr* ptr = (Interop.SubpassDependency2Khr*)m->Dependencies;
+					for (int i = 0; i < values.Length; i++) {
+						values [i] = new SubpassDependency2Khr ();
+						*values [i].m = ptr [i];
+					}
+				}
+				return values;
+			}
+
+			set {
+				if (value == null) {
+					m->DependencyCount = 0;
+					m->Dependencies = IntPtr.Zero;
+					return;
+				}
+				m->DependencyCount = (uint)value.Length;
+				refDependencies = new NativeReference ((int)(sizeof(Interop.SubpassDependency2Khr)*value.Length));
+				m->Dependencies = refDependencies.Handle;
+				unsafe
+				{
+					Interop.SubpassDependency2Khr* ptr = (Interop.SubpassDependency2Khr*)m->Dependencies;
+					for (int i = 0; i < value.Length; i++)
+						ptr [i] = *value [i].m;
+				}
+			}
+		}
+
+		public UInt32 CorrelatedViewMaskCount {
+			get { return m->CorrelatedViewMaskCount; }
+			set { m->CorrelatedViewMaskCount = value; }
+		}
+
+		NativeReference refCorrelatedViewMasks;
+		public UInt32[] CorrelatedViewMasks {
+			get {
+				if (m->CorrelatedViewMaskCount == 0)
+					return null;
+				var values = new UInt32 [m->CorrelatedViewMaskCount];
+				unsafe
+				{
+					UInt32* ptr = (UInt32*)m->CorrelatedViewMasks;
+					for (int i = 0; i < values.Length; i++) 
+						values [i] = ptr [i];
+				}
+				return values;
+			}
+
+			set {
+				if (value == null) {
+					m->CorrelatedViewMaskCount = 0;
+					m->CorrelatedViewMasks = IntPtr.Zero;
+					return;
+				}
+				m->CorrelatedViewMaskCount = (uint)value.Length;
+				refCorrelatedViewMasks = new NativeReference ((int)(sizeof(UInt32)*value.Length));
+				m->CorrelatedViewMasks = refCorrelatedViewMasks.Handle;
+				unsafe
+				{
+					UInt32* ptr = (UInt32*)m->CorrelatedViewMasks;
+					for (int i = 0; i < value.Length; i++)
+						ptr [i] = value [i];
+				}
+			}
+		}
+
+		internal Interop.RenderPassCreateInfo2Khr* m {
+			get {
+				return (Interop.RenderPassCreateInfo2Khr*)native.Handle;
+			}
+		}
+
+		public RenderPassCreateInfo2Khr ()
+		{
+			native = Interop.Structure.Allocate (typeof (Interop.RenderPassCreateInfo2Khr));
+			Initialize ();
+		}
+
+		internal RenderPassCreateInfo2Khr (NativePointer pointer)
+		{
+			native = pointer;
+			Initialize ();
+		}
+
+		override public void Dispose (bool disposing)
+		{
+			base.Dispose (disposing);
+			if (!disposing)
+				return;
+			refAttachments.Dispose ();
+			refAttachments = null;
+			refSubpasses.Dispose ();
+			refSubpasses = null;
+			refDependencies.Dispose ();
+			refDependencies = null;
+			refCorrelatedViewMasks.Dispose ();
+			refCorrelatedViewMasks = null;
+		}
+
+		internal void Initialize ()
+		{
+			m->SType = StructureType.RenderPassCreateInfo2Khr;
+		}
+
+	}
+
+	unsafe public partial class SubpassBeginInfoKhr : MarshalledObject
+	{
+		public SubpassContents Contents {
+			get { return m->Contents; }
+			set { m->Contents = value; }
+		}
+
+		internal Interop.SubpassBeginInfoKhr* m {
+			get {
+				return (Interop.SubpassBeginInfoKhr*)native.Handle;
+			}
+		}
+
+		public SubpassBeginInfoKhr ()
+		{
+			native = Interop.Structure.Allocate (typeof (Interop.SubpassBeginInfoKhr));
+			Initialize ();
+		}
+
+		internal SubpassBeginInfoKhr (NativePointer pointer)
+		{
+			native = pointer;
+			Initialize ();
+		}
+
+
+		internal void Initialize ()
+		{
+			m->SType = StructureType.SubpassBeginInfoKhr;
+		}
+
+	}
+
+	unsafe public partial class SubpassEndInfoKhr : MarshalledObject
+	{
+
+		internal Interop.SubpassEndInfoKhr* m {
+			get {
+				return (Interop.SubpassEndInfoKhr*)native.Handle;
+			}
+		}
+
+		public SubpassEndInfoKhr ()
+		{
+			native = Interop.Structure.Allocate (typeof (Interop.SubpassEndInfoKhr));
+			Initialize ();
+		}
+
+		internal SubpassEndInfoKhr (NativePointer pointer)
+		{
+			native = pointer;
+			Initialize ();
+		}
+
+
+		internal void Initialize ()
+		{
+			m->SType = StructureType.SubpassEndInfoKhr;
+		}
+
+	}
+
+	unsafe public partial struct VertexInputBindingDivisorDescriptionExt
+	{
+		public UInt32 Binding;
+		public UInt32 Divisor;
+	}
+
+	unsafe public partial class PipelineVertexInputDivisorStateCreateInfoExt : MarshalledObject
+	{
+		public UInt32 VertexBindingDivisorCount {
+			get { return m->VertexBindingDivisorCount; }
+			set { m->VertexBindingDivisorCount = value; }
+		}
+
+		NativeReference refVertexBindingDivisors;
+		public VertexInputBindingDivisorDescriptionExt[] VertexBindingDivisors {
+			get {
+				if (m->VertexBindingDivisorCount == 0)
+					return null;
+				var values = new VertexInputBindingDivisorDescriptionExt [m->VertexBindingDivisorCount];
+				unsafe
+				{
+					VertexInputBindingDivisorDescriptionExt* ptr = (VertexInputBindingDivisorDescriptionExt*)m->VertexBindingDivisors;
+					for (int i = 0; i < values.Length; i++) 
+						values [i] = ptr [i];
+				}
+				return values;
+			}
+
+			set {
+				if (value == null) {
+					m->VertexBindingDivisorCount = 0;
+					m->VertexBindingDivisors = IntPtr.Zero;
+					return;
+				}
+				m->VertexBindingDivisorCount = (uint)value.Length;
+				refVertexBindingDivisors = new NativeReference ((int)(sizeof(VertexInputBindingDivisorDescriptionExt)*value.Length));
+				m->VertexBindingDivisors = refVertexBindingDivisors.Handle;
+				unsafe
+				{
+					VertexInputBindingDivisorDescriptionExt* ptr = (VertexInputBindingDivisorDescriptionExt*)m->VertexBindingDivisors;
+					for (int i = 0; i < value.Length; i++)
+						ptr [i] = value [i];
+				}
+			}
+		}
+
+		internal Interop.PipelineVertexInputDivisorStateCreateInfoExt* m {
+			get {
+				return (Interop.PipelineVertexInputDivisorStateCreateInfoExt*)native.Handle;
+			}
+		}
+
+		public PipelineVertexInputDivisorStateCreateInfoExt ()
+		{
+			native = Interop.Structure.Allocate (typeof (Interop.PipelineVertexInputDivisorStateCreateInfoExt));
+			Initialize ();
+		}
+
+		internal PipelineVertexInputDivisorStateCreateInfoExt (NativePointer pointer)
+		{
+			native = pointer;
+			Initialize ();
+		}
+
+		override public void Dispose (bool disposing)
+		{
+			base.Dispose (disposing);
+			if (!disposing)
+				return;
+			refVertexBindingDivisors.Dispose ();
+			refVertexBindingDivisors = null;
+		}
+
+		internal void Initialize ()
+		{
+			m->SType = StructureType.PipelineVertexInputDivisorStateCreateInfoExt;
+		}
+
+	}
+
+	unsafe public partial class PhysicalDeviceVertexAttributeDivisorPropertiesExt : MarshalledObject
+	{
+		public UInt32 MaxVertexAttribDivisor {
+			get { return m->MaxVertexAttribDivisor; }
+			set { m->MaxVertexAttribDivisor = value; }
+		}
+
+		internal Interop.PhysicalDeviceVertexAttributeDivisorPropertiesExt* m {
+			get {
+				return (Interop.PhysicalDeviceVertexAttributeDivisorPropertiesExt*)native.Handle;
+			}
+		}
+
+		public PhysicalDeviceVertexAttributeDivisorPropertiesExt ()
+		{
+			native = Interop.Structure.Allocate (typeof (Interop.PhysicalDeviceVertexAttributeDivisorPropertiesExt));
+			Initialize ();
+		}
+
+		internal PhysicalDeviceVertexAttributeDivisorPropertiesExt (NativePointer pointer)
+		{
+			native = pointer;
+			Initialize ();
+		}
+
+
+		internal void Initialize ()
+		{
+			m->SType = StructureType.PhysicalDeviceVertexAttributeDivisorPropertiesExt;
+		}
+
+	}
+
+	unsafe public partial class PhysicalDevicePCIBusInfoPropertiesExt : MarshalledObject
+	{
+		public UInt32 PciDomain {
+			get { return m->PciDomain; }
+			set { m->PciDomain = value; }
+		}
+
+		public UInt32 PciBus {
+			get { return m->PciBus; }
+			set { m->PciBus = value; }
+		}
+
+		public UInt32 PciDevice {
+			get { return m->PciDevice; }
+			set { m->PciDevice = value; }
+		}
+
+		public UInt32 PciFunction {
+			get { return m->PciFunction; }
+			set { m->PciFunction = value; }
+		}
+
+		internal Interop.PhysicalDevicePCIBusInfoPropertiesExt* m {
+			get {
+				return (Interop.PhysicalDevicePCIBusInfoPropertiesExt*)native.Handle;
+			}
+		}
+
+		public PhysicalDevicePCIBusInfoPropertiesExt ()
+		{
+			native = Interop.Structure.Allocate (typeof (Interop.PhysicalDevicePCIBusInfoPropertiesExt));
+			Initialize ();
+		}
+
+		internal PhysicalDevicePCIBusInfoPropertiesExt (NativePointer pointer)
+		{
+			native = pointer;
+			Initialize ();
+		}
+
+
+		internal void Initialize ()
+		{
+			m->SType = StructureType.PhysicalDevicePCIBusInfoPropertiesExt;
+		}
+
+	}
+
+	unsafe public partial class AndroidHardwareBufferUsageAndroid : MarshalledObject
+	{
+		public UInt64 AndroidHardwareBufferUsage {
+			get { return m->AndroidHardwareBufferUsage; }
+			set { m->AndroidHardwareBufferUsage = value; }
+		}
+
+		internal Interop.AndroidHardwareBufferUsageAndroid* m {
+			get {
+				return (Interop.AndroidHardwareBufferUsageAndroid*)native.Handle;
+			}
+		}
+
+		public AndroidHardwareBufferUsageAndroid ()
+		{
+			native = Interop.Structure.Allocate (typeof (Interop.AndroidHardwareBufferUsageAndroid));
+			Initialize ();
+		}
+
+		internal AndroidHardwareBufferUsageAndroid (NativePointer pointer)
+		{
+			native = pointer;
+			Initialize ();
+		}
+
+
+		internal void Initialize ()
+		{
+			m->SType = StructureType.AndroidHardwareBufferUsageAndroid;
+		}
+
+	}
+
+	unsafe public partial class AndroidHardwareBufferPropertiesAndroid : MarshalledObject
+	{
+		public DeviceSize AllocationSize {
+			get { return m->AllocationSize; }
+			set { m->AllocationSize = value; }
+		}
+
+		public UInt32 MemoryTypeBits {
+			get { return m->MemoryTypeBits; }
+			set { m->MemoryTypeBits = value; }
+		}
+
+		internal Interop.AndroidHardwareBufferPropertiesAndroid* m {
+			get {
+				return (Interop.AndroidHardwareBufferPropertiesAndroid*)native.Handle;
+			}
+		}
+
+		public AndroidHardwareBufferPropertiesAndroid ()
+		{
+			native = Interop.Structure.Allocate (typeof (Interop.AndroidHardwareBufferPropertiesAndroid));
+			Initialize ();
+		}
+
+		internal AndroidHardwareBufferPropertiesAndroid (NativePointer pointer)
+		{
+			native = pointer;
+			Initialize ();
+		}
+
+
+		internal void Initialize ()
+		{
+			m->SType = StructureType.AndroidHardwareBufferPropertiesAndroid;
+		}
+
+	}
+
+	unsafe public partial class MemoryGetAndroidHardwareBufferInfoAndroid : MarshalledObject
+	{
+		DeviceMemory lMemory;
+		public DeviceMemory Memory {
+			get { return lMemory; }
+			set { lMemory = value; m->Memory = value != null ? (UInt64)value.m : default(UInt64); }
+		}
+
+		internal Interop.MemoryGetAndroidHardwareBufferInfoAndroid* m {
+			get {
+				return (Interop.MemoryGetAndroidHardwareBufferInfoAndroid*)native.Handle;
+			}
+		}
+
+		public MemoryGetAndroidHardwareBufferInfoAndroid ()
+		{
+			native = Interop.Structure.Allocate (typeof (Interop.MemoryGetAndroidHardwareBufferInfoAndroid));
+			Initialize ();
+		}
+
+		internal MemoryGetAndroidHardwareBufferInfoAndroid (NativePointer pointer)
+		{
+			native = pointer;
+			Initialize ();
+		}
+
+
+		internal void Initialize ()
+		{
+			m->SType = StructureType.MemoryGetAndroidHardwareBufferInfoAndroid;
+		}
+
+	}
+
+	unsafe public partial class AndroidHardwareBufferFormatPropertiesAndroid : MarshalledObject
+	{
+		public Format Format {
+			get { return m->Format; }
+			set { m->Format = value; }
+		}
+
+		public UInt64 ExternalFormat {
+			get { return m->ExternalFormat; }
+			set { m->ExternalFormat = value; }
+		}
+
+		public FormatFeatureFlags FormatFeatures {
+			get { return m->FormatFeatures; }
+			set { m->FormatFeatures = value; }
+		}
+
+		public ComponentMapping SamplerYcbcrConversionComponents {
+			get { return m->SamplerYcbcrConversionComponents; }
+			set { m->SamplerYcbcrConversionComponents = value; }
+		}
+
+		public SamplerYcbcrModelConversion SuggestedYcbcrModel {
+			get { return m->SuggestedYcbcrModel; }
+			set { m->SuggestedYcbcrModel = value; }
+		}
+
+		public SamplerYcbcrRange SuggestedYcbcrRange {
+			get { return m->SuggestedYcbcrRange; }
+			set { m->SuggestedYcbcrRange = value; }
+		}
+
+		public ChromaLocation SuggestedXchromaOffset {
+			get { return m->SuggestedXchromaOffset; }
+			set { m->SuggestedXchromaOffset = value; }
+		}
+
+		public ChromaLocation SuggestedYchromaOffset {
+			get { return m->SuggestedYchromaOffset; }
+			set { m->SuggestedYchromaOffset = value; }
+		}
+
+		internal Interop.AndroidHardwareBufferFormatPropertiesAndroid* m {
+			get {
+				return (Interop.AndroidHardwareBufferFormatPropertiesAndroid*)native.Handle;
+			}
+		}
+
+		public AndroidHardwareBufferFormatPropertiesAndroid ()
+		{
+			native = Interop.Structure.Allocate (typeof (Interop.AndroidHardwareBufferFormatPropertiesAndroid));
+			Initialize ();
+		}
+
+		internal AndroidHardwareBufferFormatPropertiesAndroid (NativePointer pointer)
+		{
+			native = pointer;
+			Initialize ();
+		}
+
+
+		internal void Initialize ()
+		{
+			m->SType = StructureType.AndroidHardwareBufferFormatPropertiesAndroid;
+		}
+
+	}
+
+	unsafe public partial class CommandBufferInheritanceConditionalRenderingInfoExt : MarshalledObject
+	{
+		public bool ConditionalRenderingEnable {
+			get { return m->ConditionalRenderingEnable; }
+			set { m->ConditionalRenderingEnable = value; }
+		}
+
+		internal Interop.CommandBufferInheritanceConditionalRenderingInfoExt* m {
+			get {
+				return (Interop.CommandBufferInheritanceConditionalRenderingInfoExt*)native.Handle;
+			}
+		}
+
+		public CommandBufferInheritanceConditionalRenderingInfoExt ()
+		{
+			native = Interop.Structure.Allocate (typeof (Interop.CommandBufferInheritanceConditionalRenderingInfoExt));
+			Initialize ();
+		}
+
+		internal CommandBufferInheritanceConditionalRenderingInfoExt (NativePointer pointer)
+		{
+			native = pointer;
+			Initialize ();
+		}
+
+
+		internal void Initialize ()
+		{
+			m->SType = StructureType.CommandBufferInheritanceConditionalRenderingInfoExt;
+		}
+
+	}
+
+	unsafe public partial class ExternalFormatAndroid : MarshalledObject
+	{
+		public UInt64 ExternalFormat {
+			get { return m->ExternalFormat; }
+			set { m->ExternalFormat = value; }
+		}
+
+		internal Interop.ExternalFormatAndroid* m {
+			get {
+				return (Interop.ExternalFormatAndroid*)native.Handle;
+			}
+		}
+
+		public ExternalFormatAndroid ()
+		{
+			native = Interop.Structure.Allocate (typeof (Interop.ExternalFormatAndroid));
+			Initialize ();
+		}
+
+		internal ExternalFormatAndroid (NativePointer pointer)
+		{
+			native = pointer;
+			Initialize ();
+		}
+
+
+		internal void Initialize ()
+		{
+			m->SType = StructureType.ExternalFormatAndroid;
+		}
+
+	}
+
+	unsafe public partial class PhysicalDevice8BitStorageFeaturesKhr : MarshalledObject
+	{
+		public bool StorageBuffer8BitAccess {
+			get { return m->StorageBuffer8BitAccess; }
+			set { m->StorageBuffer8BitAccess = value; }
+		}
+
+		public bool UniformAndStorageBuffer8BitAccess {
+			get { return m->UniformAndStorageBuffer8BitAccess; }
+			set { m->UniformAndStorageBuffer8BitAccess = value; }
+		}
+
+		public bool StoragePushConstant8 {
+			get { return m->StoragePushConstant8; }
+			set { m->StoragePushConstant8 = value; }
+		}
+
+		internal Interop.PhysicalDevice8BitStorageFeaturesKhr* m {
+			get {
+				return (Interop.PhysicalDevice8BitStorageFeaturesKhr*)native.Handle;
+			}
+		}
+
+		public PhysicalDevice8BitStorageFeaturesKhr ()
+		{
+			native = Interop.Structure.Allocate (typeof (Interop.PhysicalDevice8BitStorageFeaturesKhr));
+			Initialize ();
+		}
+
+		internal PhysicalDevice8BitStorageFeaturesKhr (NativePointer pointer)
+		{
+			native = pointer;
+			Initialize ();
+		}
+
+
+		internal void Initialize ()
+		{
+			m->SType = StructureType.PhysicalDevice8BitStorageFeaturesKhr;
+		}
+
+	}
+
+	unsafe public partial class PhysicalDeviceConditionalRenderingFeaturesExt : MarshalledObject
+	{
+		public bool ConditionalRendering {
+			get { return m->ConditionalRendering; }
+			set { m->ConditionalRendering = value; }
+		}
+
+		public bool InheritedConditionalRendering {
+			get { return m->InheritedConditionalRendering; }
+			set { m->InheritedConditionalRendering = value; }
+		}
+
+		internal Interop.PhysicalDeviceConditionalRenderingFeaturesExt* m {
+			get {
+				return (Interop.PhysicalDeviceConditionalRenderingFeaturesExt*)native.Handle;
+			}
+		}
+
+		public PhysicalDeviceConditionalRenderingFeaturesExt ()
+		{
+			native = Interop.Structure.Allocate (typeof (Interop.PhysicalDeviceConditionalRenderingFeaturesExt));
+			Initialize ();
+		}
+
+		internal PhysicalDeviceConditionalRenderingFeaturesExt (NativePointer pointer)
+		{
+			native = pointer;
+			Initialize ();
+		}
+
+
+		internal void Initialize ()
+		{
+			m->SType = StructureType.PhysicalDeviceConditionalRenderingFeaturesExt;
+		}
+
+	}
+
+	unsafe public partial class PhysicalDeviceVulkanMemoryModelFeaturesKhr : MarshalledObject
+	{
+		public bool VulkanMemoryModel {
+			get { return m->VulkanMemoryModel; }
+			set { m->VulkanMemoryModel = value; }
+		}
+
+		public bool VulkanMemoryModelDeviceScope {
+			get { return m->VulkanMemoryModelDeviceScope; }
+			set { m->VulkanMemoryModelDeviceScope = value; }
+		}
+
+		public bool VulkanMemoryModelAvailabilityVisibilityChains {
+			get { return m->VulkanMemoryModelAvailabilityVisibilityChains; }
+			set { m->VulkanMemoryModelAvailabilityVisibilityChains = value; }
+		}
+
+		internal Interop.PhysicalDeviceVulkanMemoryModelFeaturesKhr* m {
+			get {
+				return (Interop.PhysicalDeviceVulkanMemoryModelFeaturesKhr*)native.Handle;
+			}
+		}
+
+		public PhysicalDeviceVulkanMemoryModelFeaturesKhr ()
+		{
+			native = Interop.Structure.Allocate (typeof (Interop.PhysicalDeviceVulkanMemoryModelFeaturesKhr));
+			Initialize ();
+		}
+
+		internal PhysicalDeviceVulkanMemoryModelFeaturesKhr (NativePointer pointer)
+		{
+			native = pointer;
+			Initialize ();
+		}
+
+
+		internal void Initialize ()
+		{
+			m->SType = StructureType.PhysicalDeviceVulkanMemoryModelFeaturesKhr;
+		}
+
+	}
+
+	unsafe public partial class PhysicalDeviceShaderAtomicInt64FeaturesKhr : MarshalledObject
+	{
+		public bool ShaderBufferInt64Atomics {
+			get { return m->ShaderBufferInt64Atomics; }
+			set { m->ShaderBufferInt64Atomics = value; }
+		}
+
+		public bool ShaderSharedInt64Atomics {
+			get { return m->ShaderSharedInt64Atomics; }
+			set { m->ShaderSharedInt64Atomics = value; }
+		}
+
+		internal Interop.PhysicalDeviceShaderAtomicInt64FeaturesKhr* m {
+			get {
+				return (Interop.PhysicalDeviceShaderAtomicInt64FeaturesKhr*)native.Handle;
+			}
+		}
+
+		public PhysicalDeviceShaderAtomicInt64FeaturesKhr ()
+		{
+			native = Interop.Structure.Allocate (typeof (Interop.PhysicalDeviceShaderAtomicInt64FeaturesKhr));
+			Initialize ();
+		}
+
+		internal PhysicalDeviceShaderAtomicInt64FeaturesKhr (NativePointer pointer)
+		{
+			native = pointer;
+			Initialize ();
+		}
+
+
+		internal void Initialize ()
+		{
+			m->SType = StructureType.PhysicalDeviceShaderAtomicInt64FeaturesKhr;
+		}
+
+	}
+
+	unsafe public partial class PhysicalDeviceVertexAttributeDivisorFeaturesExt : MarshalledObject
+	{
+		public bool VertexAttributeInstanceRateDivisor {
+			get { return m->VertexAttributeInstanceRateDivisor; }
+			set { m->VertexAttributeInstanceRateDivisor = value; }
+		}
+
+		public bool VertexAttributeInstanceRateZeroDivisor {
+			get { return m->VertexAttributeInstanceRateZeroDivisor; }
+			set { m->VertexAttributeInstanceRateZeroDivisor = value; }
+		}
+
+		internal Interop.PhysicalDeviceVertexAttributeDivisorFeaturesExt* m {
+			get {
+				return (Interop.PhysicalDeviceVertexAttributeDivisorFeaturesExt*)native.Handle;
+			}
+		}
+
+		public PhysicalDeviceVertexAttributeDivisorFeaturesExt ()
+		{
+			native = Interop.Structure.Allocate (typeof (Interop.PhysicalDeviceVertexAttributeDivisorFeaturesExt));
+			Initialize ();
+		}
+
+		internal PhysicalDeviceVertexAttributeDivisorFeaturesExt (NativePointer pointer)
+		{
+			native = pointer;
+			Initialize ();
+		}
+
+
+		internal void Initialize ()
+		{
+			m->SType = StructureType.PhysicalDeviceVertexAttributeDivisorFeaturesExt;
+		}
+
+	}
+
+	unsafe public partial class QueueFamilyCheckpointPropertiesNv : MarshalledObject
+	{
+		public PipelineStageFlags CheckpointExecutionStageMask {
+			get { return m->CheckpointExecutionStageMask; }
+			set { m->CheckpointExecutionStageMask = value; }
+		}
+
+		internal Interop.QueueFamilyCheckpointPropertiesNv* m {
+			get {
+				return (Interop.QueueFamilyCheckpointPropertiesNv*)native.Handle;
+			}
+		}
+
+		public QueueFamilyCheckpointPropertiesNv ()
+		{
+			native = Interop.Structure.Allocate (typeof (Interop.QueueFamilyCheckpointPropertiesNv));
+			Initialize ();
+		}
+
+		internal QueueFamilyCheckpointPropertiesNv (NativePointer pointer)
+		{
+			native = pointer;
+			Initialize ();
+		}
+
+
+		internal void Initialize ()
+		{
+			m->SType = StructureType.QueueFamilyCheckpointPropertiesNv;
+		}
+
+	}
+
+	unsafe public partial class CheckpointDataNv : MarshalledObject
+	{
+		public PipelineStageFlags Stage {
+			get { return m->Stage; }
+			set { m->Stage = value; }
+		}
+
+		public IntPtr CheckpointMarker {
+			get { return m->CheckpointMarker; }
+			set { m->CheckpointMarker = value; }
+		}
+
+		internal Interop.CheckpointDataNv* m {
+			get {
+				return (Interop.CheckpointDataNv*)native.Handle;
+			}
+		}
+
+		public CheckpointDataNv ()
+		{
+			native = Interop.Structure.Allocate (typeof (Interop.CheckpointDataNv));
+			Initialize ();
+		}
+
+		internal CheckpointDataNv (NativePointer pointer)
+		{
+			native = pointer;
+			Initialize ();
+		}
+
+
+		internal void Initialize ()
+		{
+			m->SType = StructureType.CheckpointDataNv;
+		}
+
+	}
+
+	unsafe public partial class PhysicalDeviceDepthStencilResolvePropertiesKhr : MarshalledObject
+	{
+		public ResolveModeFlagsKhr SupportedDepthResolveModes {
+			get { return m->SupportedDepthResolveModes; }
+			set { m->SupportedDepthResolveModes = value; }
+		}
+
+		public ResolveModeFlagsKhr SupportedStencilResolveModes {
+			get { return m->SupportedStencilResolveModes; }
+			set { m->SupportedStencilResolveModes = value; }
+		}
+
+		public bool IndependentResolveNone {
+			get { return m->IndependentResolveNone; }
+			set { m->IndependentResolveNone = value; }
+		}
+
+		public bool IndependentResolve {
+			get { return m->IndependentResolve; }
+			set { m->IndependentResolve = value; }
+		}
+
+		internal Interop.PhysicalDeviceDepthStencilResolvePropertiesKhr* m {
+			get {
+				return (Interop.PhysicalDeviceDepthStencilResolvePropertiesKhr*)native.Handle;
+			}
+		}
+
+		public PhysicalDeviceDepthStencilResolvePropertiesKhr ()
+		{
+			native = Interop.Structure.Allocate (typeof (Interop.PhysicalDeviceDepthStencilResolvePropertiesKhr));
+			Initialize ();
+		}
+
+		internal PhysicalDeviceDepthStencilResolvePropertiesKhr (NativePointer pointer)
+		{
+			native = pointer;
+			Initialize ();
+		}
+
+
+		internal void Initialize ()
+		{
+			m->SType = StructureType.PhysicalDeviceDepthStencilResolvePropertiesKhr;
+		}
+
+	}
+
+	unsafe public partial class SubpassDescriptionDepthStencilResolveKhr : MarshalledObject
+	{
+		public ResolveModeFlagsKhr DepthResolveMode {
+			get { return m->DepthResolveMode; }
+			set { m->DepthResolveMode = value; }
+		}
+
+		public ResolveModeFlagsKhr StencilResolveMode {
+			get { return m->StencilResolveMode; }
+			set { m->StencilResolveMode = value; }
+		}
+
+		AttachmentReference2Khr lDepthStencilResolveAttachment;
+		public AttachmentReference2Khr DepthStencilResolveAttachment {
+			get { return lDepthStencilResolveAttachment; }
+			set { lDepthStencilResolveAttachment = value; m->DepthStencilResolveAttachment = value != null ? (IntPtr)value.m : default(IntPtr); }
+		}
+
+		internal Interop.SubpassDescriptionDepthStencilResolveKhr* m {
+			get {
+				return (Interop.SubpassDescriptionDepthStencilResolveKhr*)native.Handle;
+			}
+		}
+
+		public SubpassDescriptionDepthStencilResolveKhr ()
+		{
+			native = Interop.Structure.Allocate (typeof (Interop.SubpassDescriptionDepthStencilResolveKhr));
+			Initialize ();
+		}
+
+		internal SubpassDescriptionDepthStencilResolveKhr (NativePointer pointer)
+		{
+			native = pointer;
+			Initialize ();
+		}
+
+
+		internal void Initialize ()
+		{
+			m->SType = StructureType.SubpassDescriptionDepthStencilResolveKhr;
+		}
+
+	}
+
+	unsafe public partial class ImageViewASTCDecodeModeExt : MarshalledObject
+	{
+		public Format DecodeMode {
+			get { return m->DecodeMode; }
+			set { m->DecodeMode = value; }
+		}
+
+		internal Interop.ImageViewASTCDecodeModeExt* m {
+			get {
+				return (Interop.ImageViewASTCDecodeModeExt*)native.Handle;
+			}
+		}
+
+		public ImageViewASTCDecodeModeExt ()
+		{
+			native = Interop.Structure.Allocate (typeof (Interop.ImageViewASTCDecodeModeExt));
+			Initialize ();
+		}
+
+		internal ImageViewASTCDecodeModeExt (NativePointer pointer)
+		{
+			native = pointer;
+			Initialize ();
+		}
+
+
+		internal void Initialize ()
+		{
+			m->SType = StructureType.ImageViewASTCDecodeModeExt;
+		}
+
+	}
+
+	unsafe public partial class PhysicalDeviceASTCDecodeFeaturesExt : MarshalledObject
+	{
+		public bool DecodeModeSharedExponent {
+			get { return m->DecodeModeSharedExponent; }
+			set { m->DecodeModeSharedExponent = value; }
+		}
+
+		internal Interop.PhysicalDeviceASTCDecodeFeaturesExt* m {
+			get {
+				return (Interop.PhysicalDeviceASTCDecodeFeaturesExt*)native.Handle;
+			}
+		}
+
+		public PhysicalDeviceASTCDecodeFeaturesExt ()
+		{
+			native = Interop.Structure.Allocate (typeof (Interop.PhysicalDeviceASTCDecodeFeaturesExt));
+			Initialize ();
+		}
+
+		internal PhysicalDeviceASTCDecodeFeaturesExt (NativePointer pointer)
+		{
+			native = pointer;
+			Initialize ();
+		}
+
+
+		internal void Initialize ()
+		{
+			m->SType = StructureType.PhysicalDeviceASTCDecodeFeaturesExt;
+		}
+
+	}
+
+	unsafe public partial class PhysicalDeviceTransformFeedbackFeaturesExt : MarshalledObject
+	{
+		public bool TransformFeedback {
+			get { return m->TransformFeedback; }
+			set { m->TransformFeedback = value; }
+		}
+
+		public bool GeometryStreams {
+			get { return m->GeometryStreams; }
+			set { m->GeometryStreams = value; }
+		}
+
+		internal Interop.PhysicalDeviceTransformFeedbackFeaturesExt* m {
+			get {
+				return (Interop.PhysicalDeviceTransformFeedbackFeaturesExt*)native.Handle;
+			}
+		}
+
+		public PhysicalDeviceTransformFeedbackFeaturesExt ()
+		{
+			native = Interop.Structure.Allocate (typeof (Interop.PhysicalDeviceTransformFeedbackFeaturesExt));
+			Initialize ();
+		}
+
+		internal PhysicalDeviceTransformFeedbackFeaturesExt (NativePointer pointer)
+		{
+			native = pointer;
+			Initialize ();
+		}
+
+
+		internal void Initialize ()
+		{
+			m->SType = StructureType.PhysicalDeviceTransformFeedbackFeaturesExt;
+		}
+
+	}
+
+	unsafe public partial class PhysicalDeviceTransformFeedbackPropertiesExt : MarshalledObject
+	{
+		public UInt32 MaxTransformFeedbackStreams {
+			get { return m->MaxTransformFeedbackStreams; }
+			set { m->MaxTransformFeedbackStreams = value; }
+		}
+
+		public UInt32 MaxTransformFeedbackBuffers {
+			get { return m->MaxTransformFeedbackBuffers; }
+			set { m->MaxTransformFeedbackBuffers = value; }
+		}
+
+		public DeviceSize MaxTransformFeedbackBufferSize {
+			get { return m->MaxTransformFeedbackBufferSize; }
+			set { m->MaxTransformFeedbackBufferSize = value; }
+		}
+
+		public UInt32 MaxTransformFeedbackStreamDataSize {
+			get { return m->MaxTransformFeedbackStreamDataSize; }
+			set { m->MaxTransformFeedbackStreamDataSize = value; }
+		}
+
+		public UInt32 MaxTransformFeedbackBufferDataSize {
+			get { return m->MaxTransformFeedbackBufferDataSize; }
+			set { m->MaxTransformFeedbackBufferDataSize = value; }
+		}
+
+		public UInt32 MaxTransformFeedbackBufferDataStride {
+			get { return m->MaxTransformFeedbackBufferDataStride; }
+			set { m->MaxTransformFeedbackBufferDataStride = value; }
+		}
+
+		public bool TransformFeedbackQueries {
+			get { return m->TransformFeedbackQueries; }
+			set { m->TransformFeedbackQueries = value; }
+		}
+
+		public bool TransformFeedbackStreamsLinesTriangles {
+			get { return m->TransformFeedbackStreamsLinesTriangles; }
+			set { m->TransformFeedbackStreamsLinesTriangles = value; }
+		}
+
+		public bool TransformFeedbackRasterizationStreamSelect {
+			get { return m->TransformFeedbackRasterizationStreamSelect; }
+			set { m->TransformFeedbackRasterizationStreamSelect = value; }
+		}
+
+		public bool TransformFeedbackDraw {
+			get { return m->TransformFeedbackDraw; }
+			set { m->TransformFeedbackDraw = value; }
+		}
+
+		internal Interop.PhysicalDeviceTransformFeedbackPropertiesExt* m {
+			get {
+				return (Interop.PhysicalDeviceTransformFeedbackPropertiesExt*)native.Handle;
+			}
+		}
+
+		public PhysicalDeviceTransformFeedbackPropertiesExt ()
+		{
+			native = Interop.Structure.Allocate (typeof (Interop.PhysicalDeviceTransformFeedbackPropertiesExt));
+			Initialize ();
+		}
+
+		internal PhysicalDeviceTransformFeedbackPropertiesExt (NativePointer pointer)
+		{
+			native = pointer;
+			Initialize ();
+		}
+
+
+		internal void Initialize ()
+		{
+			m->SType = StructureType.PhysicalDeviceTransformFeedbackPropertiesExt;
+		}
+
+	}
+
+	unsafe public partial class PipelineRasterizationStateStreamCreateInfoExt : MarshalledObject
+	{
+		public UInt32 Flags {
+			get { return m->Flags; }
+			set { m->Flags = value; }
+		}
+
+		public UInt32 RasterizationStream {
+			get { return m->RasterizationStream; }
+			set { m->RasterizationStream = value; }
+		}
+
+		internal Interop.PipelineRasterizationStateStreamCreateInfoExt* m {
+			get {
+				return (Interop.PipelineRasterizationStateStreamCreateInfoExt*)native.Handle;
+			}
+		}
+
+		public PipelineRasterizationStateStreamCreateInfoExt ()
+		{
+			native = Interop.Structure.Allocate (typeof (Interop.PipelineRasterizationStateStreamCreateInfoExt));
+			Initialize ();
+		}
+
+		internal PipelineRasterizationStateStreamCreateInfoExt (NativePointer pointer)
+		{
+			native = pointer;
+			Initialize ();
+		}
+
+
+		internal void Initialize ()
+		{
+			m->SType = StructureType.PipelineRasterizationStateStreamCreateInfoExt;
+		}
+
+	}
+
+	unsafe public partial class PhysicalDeviceRepresentativeFragmentTestFeaturesNv : MarshalledObject
+	{
+		public bool RepresentativeFragmentTest {
+			get { return m->RepresentativeFragmentTest; }
+			set { m->RepresentativeFragmentTest = value; }
+		}
+
+		internal Interop.PhysicalDeviceRepresentativeFragmentTestFeaturesNv* m {
+			get {
+				return (Interop.PhysicalDeviceRepresentativeFragmentTestFeaturesNv*)native.Handle;
+			}
+		}
+
+		public PhysicalDeviceRepresentativeFragmentTestFeaturesNv ()
+		{
+			native = Interop.Structure.Allocate (typeof (Interop.PhysicalDeviceRepresentativeFragmentTestFeaturesNv));
+			Initialize ();
+		}
+
+		internal PhysicalDeviceRepresentativeFragmentTestFeaturesNv (NativePointer pointer)
+		{
+			native = pointer;
+			Initialize ();
+		}
+
+
+		internal void Initialize ()
+		{
+			m->SType = StructureType.PhysicalDeviceRepresentativeFragmentTestFeaturesNv;
+		}
+
+	}
+
+	unsafe public partial class PipelineRepresentativeFragmentTestStateCreateInfoNv : MarshalledObject
+	{
+		public bool RepresentativeFragmentTestEnable {
+			get { return m->RepresentativeFragmentTestEnable; }
+			set { m->RepresentativeFragmentTestEnable = value; }
+		}
+
+		internal Interop.PipelineRepresentativeFragmentTestStateCreateInfoNv* m {
+			get {
+				return (Interop.PipelineRepresentativeFragmentTestStateCreateInfoNv*)native.Handle;
+			}
+		}
+
+		public PipelineRepresentativeFragmentTestStateCreateInfoNv ()
+		{
+			native = Interop.Structure.Allocate (typeof (Interop.PipelineRepresentativeFragmentTestStateCreateInfoNv));
+			Initialize ();
+		}
+
+		internal PipelineRepresentativeFragmentTestStateCreateInfoNv (NativePointer pointer)
+		{
+			native = pointer;
+			Initialize ();
+		}
+
+
+		internal void Initialize ()
+		{
+			m->SType = StructureType.PipelineRepresentativeFragmentTestStateCreateInfoNv;
+		}
+
+	}
+
+	unsafe public partial class PhysicalDeviceExclusiveScissorFeaturesNv : MarshalledObject
+	{
+		public bool ExclusiveScissor {
+			get { return m->ExclusiveScissor; }
+			set { m->ExclusiveScissor = value; }
+		}
+
+		internal Interop.PhysicalDeviceExclusiveScissorFeaturesNv* m {
+			get {
+				return (Interop.PhysicalDeviceExclusiveScissorFeaturesNv*)native.Handle;
+			}
+		}
+
+		public PhysicalDeviceExclusiveScissorFeaturesNv ()
+		{
+			native = Interop.Structure.Allocate (typeof (Interop.PhysicalDeviceExclusiveScissorFeaturesNv));
+			Initialize ();
+		}
+
+		internal PhysicalDeviceExclusiveScissorFeaturesNv (NativePointer pointer)
+		{
+			native = pointer;
+			Initialize ();
+		}
+
+
+		internal void Initialize ()
+		{
+			m->SType = StructureType.PhysicalDeviceExclusiveScissorFeaturesNv;
+		}
+
+	}
+
+	unsafe public partial class PipelineViewportExclusiveScissorStateCreateInfoNv : MarshalledObject
+	{
+		public UInt32 ExclusiveScissorCount {
+			get { return m->ExclusiveScissorCount; }
+			set { m->ExclusiveScissorCount = value; }
+		}
+
+		NativeReference refExclusiveScissors;
+		public Rect2D[] ExclusiveScissors {
+			get {
+				if (m->ExclusiveScissorCount == 0)
+					return null;
+				var values = new Rect2D [m->ExclusiveScissorCount];
+				unsafe
+				{
+					Rect2D* ptr = (Rect2D*)m->ExclusiveScissors;
+					for (int i = 0; i < values.Length; i++) 
+						values [i] = ptr [i];
+				}
+				return values;
+			}
+
+			set {
+				if (value == null) {
+					m->ExclusiveScissorCount = 0;
+					m->ExclusiveScissors = IntPtr.Zero;
+					return;
+				}
+				m->ExclusiveScissorCount = (uint)value.Length;
+				refExclusiveScissors = new NativeReference ((int)(sizeof(Rect2D)*value.Length));
+				m->ExclusiveScissors = refExclusiveScissors.Handle;
+				unsafe
+				{
+					Rect2D* ptr = (Rect2D*)m->ExclusiveScissors;
+					for (int i = 0; i < value.Length; i++)
+						ptr [i] = value [i];
+				}
+			}
+		}
+
+		internal Interop.PipelineViewportExclusiveScissorStateCreateInfoNv* m {
+			get {
+				return (Interop.PipelineViewportExclusiveScissorStateCreateInfoNv*)native.Handle;
+			}
+		}
+
+		public PipelineViewportExclusiveScissorStateCreateInfoNv ()
+		{
+			native = Interop.Structure.Allocate (typeof (Interop.PipelineViewportExclusiveScissorStateCreateInfoNv));
+			Initialize ();
+		}
+
+		internal PipelineViewportExclusiveScissorStateCreateInfoNv (NativePointer pointer)
+		{
+			native = pointer;
+			Initialize ();
+		}
+
+		override public void Dispose (bool disposing)
+		{
+			base.Dispose (disposing);
+			if (!disposing)
+				return;
+			refExclusiveScissors.Dispose ();
+			refExclusiveScissors = null;
+		}
+
+		internal void Initialize ()
+		{
+			m->SType = StructureType.PipelineViewportExclusiveScissorStateCreateInfoNv;
+		}
+
+	}
+
+	unsafe public partial class PhysicalDeviceCornerSampledImageFeaturesNv : MarshalledObject
+	{
+		public bool CornerSampledImage {
+			get { return m->CornerSampledImage; }
+			set { m->CornerSampledImage = value; }
+		}
+
+		internal Interop.PhysicalDeviceCornerSampledImageFeaturesNv* m {
+			get {
+				return (Interop.PhysicalDeviceCornerSampledImageFeaturesNv*)native.Handle;
+			}
+		}
+
+		public PhysicalDeviceCornerSampledImageFeaturesNv ()
+		{
+			native = Interop.Structure.Allocate (typeof (Interop.PhysicalDeviceCornerSampledImageFeaturesNv));
+			Initialize ();
+		}
+
+		internal PhysicalDeviceCornerSampledImageFeaturesNv (NativePointer pointer)
+		{
+			native = pointer;
+			Initialize ();
+		}
+
+
+		internal void Initialize ()
+		{
+			m->SType = StructureType.PhysicalDeviceCornerSampledImageFeaturesNv;
+		}
+
+	}
+
+	unsafe public partial class PhysicalDeviceComputeShaderDerivativesFeaturesNv : MarshalledObject
+	{
+		public bool ComputeDerivativeGroupQuads {
+			get { return m->ComputeDerivativeGroupQuads; }
+			set { m->ComputeDerivativeGroupQuads = value; }
+		}
+
+		public bool ComputeDerivativeGroupLinear {
+			get { return m->ComputeDerivativeGroupLinear; }
+			set { m->ComputeDerivativeGroupLinear = value; }
+		}
+
+		internal Interop.PhysicalDeviceComputeShaderDerivativesFeaturesNv* m {
+			get {
+				return (Interop.PhysicalDeviceComputeShaderDerivativesFeaturesNv*)native.Handle;
+			}
+		}
+
+		public PhysicalDeviceComputeShaderDerivativesFeaturesNv ()
+		{
+			native = Interop.Structure.Allocate (typeof (Interop.PhysicalDeviceComputeShaderDerivativesFeaturesNv));
+			Initialize ();
+		}
+
+		internal PhysicalDeviceComputeShaderDerivativesFeaturesNv (NativePointer pointer)
+		{
+			native = pointer;
+			Initialize ();
+		}
+
+
+		internal void Initialize ()
+		{
+			m->SType = StructureType.PhysicalDeviceComputeShaderDerivativesFeaturesNv;
+		}
+
+	}
+
+	unsafe public partial class PhysicalDeviceFragmentShaderBarycentricFeaturesNv : MarshalledObject
+	{
+		public bool FragmentShaderBarycentric {
+			get { return m->FragmentShaderBarycentric; }
+			set { m->FragmentShaderBarycentric = value; }
+		}
+
+		internal Interop.PhysicalDeviceFragmentShaderBarycentricFeaturesNv* m {
+			get {
+				return (Interop.PhysicalDeviceFragmentShaderBarycentricFeaturesNv*)native.Handle;
+			}
+		}
+
+		public PhysicalDeviceFragmentShaderBarycentricFeaturesNv ()
+		{
+			native = Interop.Structure.Allocate (typeof (Interop.PhysicalDeviceFragmentShaderBarycentricFeaturesNv));
+			Initialize ();
+		}
+
+		internal PhysicalDeviceFragmentShaderBarycentricFeaturesNv (NativePointer pointer)
+		{
+			native = pointer;
+			Initialize ();
+		}
+
+
+		internal void Initialize ()
+		{
+			m->SType = StructureType.PhysicalDeviceFragmentShaderBarycentricFeaturesNv;
+		}
+
+	}
+
+	unsafe public partial class PhysicalDeviceShaderImageFootprintFeaturesNv : MarshalledObject
+	{
+		public bool ImageFootprint {
+			get { return m->ImageFootprint; }
+			set { m->ImageFootprint = value; }
+		}
+
+		internal Interop.PhysicalDeviceShaderImageFootprintFeaturesNv* m {
+			get {
+				return (Interop.PhysicalDeviceShaderImageFootprintFeaturesNv*)native.Handle;
+			}
+		}
+
+		public PhysicalDeviceShaderImageFootprintFeaturesNv ()
+		{
+			native = Interop.Structure.Allocate (typeof (Interop.PhysicalDeviceShaderImageFootprintFeaturesNv));
+			Initialize ();
+		}
+
+		internal PhysicalDeviceShaderImageFootprintFeaturesNv (NativePointer pointer)
+		{
+			native = pointer;
+			Initialize ();
+		}
+
+
+		internal void Initialize ()
+		{
+			m->SType = StructureType.PhysicalDeviceShaderImageFootprintFeaturesNv;
+		}
+
+	}
+
+	unsafe public partial class PhysicalDeviceDedicatedAllocationImageAliasingFeaturesNv : MarshalledObject
+	{
+		public bool DedicatedAllocationImageAliasing {
+			get { return m->DedicatedAllocationImageAliasing; }
+			set { m->DedicatedAllocationImageAliasing = value; }
+		}
+
+		internal Interop.PhysicalDeviceDedicatedAllocationImageAliasingFeaturesNv* m {
+			get {
+				return (Interop.PhysicalDeviceDedicatedAllocationImageAliasingFeaturesNv*)native.Handle;
+			}
+		}
+
+		public PhysicalDeviceDedicatedAllocationImageAliasingFeaturesNv ()
+		{
+			native = Interop.Structure.Allocate (typeof (Interop.PhysicalDeviceDedicatedAllocationImageAliasingFeaturesNv));
+			Initialize ();
+		}
+
+		internal PhysicalDeviceDedicatedAllocationImageAliasingFeaturesNv (NativePointer pointer)
+		{
+			native = pointer;
+			Initialize ();
+		}
+
+
+		internal void Initialize ()
+		{
+			m->SType = StructureType.PhysicalDeviceDedicatedAllocationImageAliasingFeaturesNv;
+		}
+
+	}
+
+	unsafe public partial class ShadingRatePaletteNv : MarshalledObject
+	{
+		public UInt32 ShadingRatePaletteEntryCount {
+			get { return m->ShadingRatePaletteEntryCount; }
+			set { m->ShadingRatePaletteEntryCount = value; }
+		}
+
+		NativeReference refShadingRatePaletteEntries;
+		public ShadingRatePaletteEntryNv[] ShadingRatePaletteEntries {
+			get {
+				if (m->ShadingRatePaletteEntryCount == 0)
+					return null;
+				var values = new ShadingRatePaletteEntryNv [m->ShadingRatePaletteEntryCount];
+				unsafe
+				{
+					ShadingRatePaletteEntryNv* ptr = (ShadingRatePaletteEntryNv*)m->ShadingRatePaletteEntries;
+					for (int i = 0; i < values.Length; i++) 
+						values [i] = ptr [i];
+				}
+				return values;
+			}
+
+			set {
+				if (value == null) {
+					m->ShadingRatePaletteEntryCount = 0;
+					m->ShadingRatePaletteEntries = IntPtr.Zero;
+					return;
+				}
+				m->ShadingRatePaletteEntryCount = (uint)value.Length;
+				refShadingRatePaletteEntries = new NativeReference ((int)(sizeof(ShadingRatePaletteEntryNv)*value.Length));
+				m->ShadingRatePaletteEntries = refShadingRatePaletteEntries.Handle;
+				unsafe
+				{
+					ShadingRatePaletteEntryNv* ptr = (ShadingRatePaletteEntryNv*)m->ShadingRatePaletteEntries;
+					for (int i = 0; i < value.Length; i++)
+						ptr [i] = value [i];
+				}
+			}
+		}
+
+		internal Interop.ShadingRatePaletteNv* m {
+			get {
+				return (Interop.ShadingRatePaletteNv*)native.Handle;
+			}
+		}
+
+		public ShadingRatePaletteNv ()
+		{
+			native = Interop.Structure.Allocate (typeof (Interop.ShadingRatePaletteNv));
+		}
+
+		internal ShadingRatePaletteNv (NativePointer pointer)
+		{
+			native = pointer;
+		}
+
+		override public void Dispose (bool disposing)
+		{
+			base.Dispose (disposing);
+			if (!disposing)
+				return;
+			refShadingRatePaletteEntries.Dispose ();
+			refShadingRatePaletteEntries = null;
+		}
+	}
+
+	unsafe public partial class PipelineViewportShadingRateImageStateCreateInfoNv : MarshalledObject
+	{
+		public bool ShadingRateImageEnable {
+			get { return m->ShadingRateImageEnable; }
+			set { m->ShadingRateImageEnable = value; }
+		}
+
+		public UInt32 ViewportCount {
+			get { return m->ViewportCount; }
+			set { m->ViewportCount = value; }
+		}
+
+		NativeReference refShadingRatePalettes;
+		public ShadingRatePaletteNv[] ShadingRatePalettes {
+			get {
+				if (m->ViewportCount == 0)
+					return null;
+				var values = new ShadingRatePaletteNv [m->ViewportCount];
+				unsafe
+				{
+					Interop.ShadingRatePaletteNv* ptr = (Interop.ShadingRatePaletteNv*)m->ShadingRatePalettes;
+					for (int i = 0; i < values.Length; i++) {
+						values [i] = new ShadingRatePaletteNv ();
+						*values [i].m = ptr [i];
+					}
+				}
+				return values;
+			}
+
+			set {
+				if (value == null) {
+					m->ViewportCount = 0;
+					m->ShadingRatePalettes = IntPtr.Zero;
+					return;
+				}
+				m->ViewportCount = (uint)value.Length;
+				refShadingRatePalettes = new NativeReference ((int)(sizeof(Interop.ShadingRatePaletteNv)*value.Length));
+				m->ShadingRatePalettes = refShadingRatePalettes.Handle;
+				unsafe
+				{
+					Interop.ShadingRatePaletteNv* ptr = (Interop.ShadingRatePaletteNv*)m->ShadingRatePalettes;
+					for (int i = 0; i < value.Length; i++)
+						ptr [i] = *value [i].m;
+				}
+			}
+		}
+
+		internal Interop.PipelineViewportShadingRateImageStateCreateInfoNv* m {
+			get {
+				return (Interop.PipelineViewportShadingRateImageStateCreateInfoNv*)native.Handle;
+			}
+		}
+
+		public PipelineViewportShadingRateImageStateCreateInfoNv ()
+		{
+			native = Interop.Structure.Allocate (typeof (Interop.PipelineViewportShadingRateImageStateCreateInfoNv));
+			Initialize ();
+		}
+
+		internal PipelineViewportShadingRateImageStateCreateInfoNv (NativePointer pointer)
+		{
+			native = pointer;
+			Initialize ();
+		}
+
+		override public void Dispose (bool disposing)
+		{
+			base.Dispose (disposing);
+			if (!disposing)
+				return;
+			refShadingRatePalettes.Dispose ();
+			refShadingRatePalettes = null;
+		}
+
+		internal void Initialize ()
+		{
+			m->SType = StructureType.PipelineViewportShadingRateImageStateCreateInfoNv;
+		}
+
+	}
+
+	unsafe public partial class PhysicalDeviceShadingRateImageFeaturesNv : MarshalledObject
+	{
+		public bool ShadingRateImage {
+			get { return m->ShadingRateImage; }
+			set { m->ShadingRateImage = value; }
+		}
+
+		public bool ShadingRateCoarseSampleOrder {
+			get { return m->ShadingRateCoarseSampleOrder; }
+			set { m->ShadingRateCoarseSampleOrder = value; }
+		}
+
+		internal Interop.PhysicalDeviceShadingRateImageFeaturesNv* m {
+			get {
+				return (Interop.PhysicalDeviceShadingRateImageFeaturesNv*)native.Handle;
+			}
+		}
+
+		public PhysicalDeviceShadingRateImageFeaturesNv ()
+		{
+			native = Interop.Structure.Allocate (typeof (Interop.PhysicalDeviceShadingRateImageFeaturesNv));
+			Initialize ();
+		}
+
+		internal PhysicalDeviceShadingRateImageFeaturesNv (NativePointer pointer)
+		{
+			native = pointer;
+			Initialize ();
+		}
+
+
+		internal void Initialize ()
+		{
+			m->SType = StructureType.PhysicalDeviceShadingRateImageFeaturesNv;
+		}
+
+	}
+
+	unsafe public partial class PhysicalDeviceShadingRateImagePropertiesNv : MarshalledObject
+	{
+		public Extent2D ShadingRateTexelSize {
+			get { return m->ShadingRateTexelSize; }
+			set { m->ShadingRateTexelSize = value; }
+		}
+
+		public UInt32 ShadingRatePaletteSize {
+			get { return m->ShadingRatePaletteSize; }
+			set { m->ShadingRatePaletteSize = value; }
+		}
+
+		public UInt32 ShadingRateMaxCoarseSamples {
+			get { return m->ShadingRateMaxCoarseSamples; }
+			set { m->ShadingRateMaxCoarseSamples = value; }
+		}
+
+		internal Interop.PhysicalDeviceShadingRateImagePropertiesNv* m {
+			get {
+				return (Interop.PhysicalDeviceShadingRateImagePropertiesNv*)native.Handle;
+			}
+		}
+
+		public PhysicalDeviceShadingRateImagePropertiesNv ()
+		{
+			native = Interop.Structure.Allocate (typeof (Interop.PhysicalDeviceShadingRateImagePropertiesNv));
+			Initialize ();
+		}
+
+		internal PhysicalDeviceShadingRateImagePropertiesNv (NativePointer pointer)
+		{
+			native = pointer;
+			Initialize ();
+		}
+
+
+		internal void Initialize ()
+		{
+			m->SType = StructureType.PhysicalDeviceShadingRateImagePropertiesNv;
+		}
+
+	}
+
+	unsafe public partial struct CoarseSampleLocationNv
+	{
+		public UInt32 PixelX;
+		public UInt32 PixelY;
+		public UInt32 Sample;
+	}
+
+	unsafe public partial class CoarseSampleOrderCustomNv : MarshalledObject
+	{
+		public ShadingRatePaletteEntryNv ShadingRate {
+			get { return m->ShadingRate; }
+			set { m->ShadingRate = value; }
+		}
+
+		public UInt32 SampleCount {
+			get { return m->SampleCount; }
+			set { m->SampleCount = value; }
+		}
+
+		public UInt32 SampleLocationCount {
+			get { return m->SampleLocationCount; }
+			set { m->SampleLocationCount = value; }
+		}
+
+		NativeReference refSampleLocations;
+		public CoarseSampleLocationNv[] SampleLocations {
+			get {
+				if (m->SampleLocationCount == 0)
+					return null;
+				var values = new CoarseSampleLocationNv [m->SampleLocationCount];
+				unsafe
+				{
+					CoarseSampleLocationNv* ptr = (CoarseSampleLocationNv*)m->SampleLocations;
+					for (int i = 0; i < values.Length; i++) 
+						values [i] = ptr [i];
+				}
+				return values;
+			}
+
+			set {
+				if (value == null) {
+					m->SampleLocationCount = 0;
+					m->SampleLocations = IntPtr.Zero;
+					return;
+				}
+				m->SampleLocationCount = (uint)value.Length;
+				refSampleLocations = new NativeReference ((int)(sizeof(CoarseSampleLocationNv)*value.Length));
+				m->SampleLocations = refSampleLocations.Handle;
+				unsafe
+				{
+					CoarseSampleLocationNv* ptr = (CoarseSampleLocationNv*)m->SampleLocations;
+					for (int i = 0; i < value.Length; i++)
+						ptr [i] = value [i];
+				}
+			}
+		}
+
+		internal Interop.CoarseSampleOrderCustomNv* m {
+			get {
+				return (Interop.CoarseSampleOrderCustomNv*)native.Handle;
+			}
+		}
+
+		public CoarseSampleOrderCustomNv ()
+		{
+			native = Interop.Structure.Allocate (typeof (Interop.CoarseSampleOrderCustomNv));
+		}
+
+		internal CoarseSampleOrderCustomNv (NativePointer pointer)
+		{
+			native = pointer;
+		}
+
+		override public void Dispose (bool disposing)
+		{
+			base.Dispose (disposing);
+			if (!disposing)
+				return;
+			refSampleLocations.Dispose ();
+			refSampleLocations = null;
+		}
+	}
+
+	unsafe public partial class PipelineViewportCoarseSampleOrderStateCreateInfoNv : MarshalledObject
+	{
+		public CoarseSampleOrderTypeNv SampleOrderType {
+			get { return m->SampleOrderType; }
+			set { m->SampleOrderType = value; }
+		}
+
+		public UInt32 CustomSampleOrderCount {
+			get { return m->CustomSampleOrderCount; }
+			set { m->CustomSampleOrderCount = value; }
+		}
+
+		NativeReference refCustomSampleOrders;
+		public CoarseSampleOrderCustomNv[] CustomSampleOrders {
+			get {
+				if (m->CustomSampleOrderCount == 0)
+					return null;
+				var values = new CoarseSampleOrderCustomNv [m->CustomSampleOrderCount];
+				unsafe
+				{
+					Interop.CoarseSampleOrderCustomNv* ptr = (Interop.CoarseSampleOrderCustomNv*)m->CustomSampleOrders;
+					for (int i = 0; i < values.Length; i++) {
+						values [i] = new CoarseSampleOrderCustomNv ();
+						*values [i].m = ptr [i];
+					}
+				}
+				return values;
+			}
+
+			set {
+				if (value == null) {
+					m->CustomSampleOrderCount = 0;
+					m->CustomSampleOrders = IntPtr.Zero;
+					return;
+				}
+				m->CustomSampleOrderCount = (uint)value.Length;
+				refCustomSampleOrders = new NativeReference ((int)(sizeof(Interop.CoarseSampleOrderCustomNv)*value.Length));
+				m->CustomSampleOrders = refCustomSampleOrders.Handle;
+				unsafe
+				{
+					Interop.CoarseSampleOrderCustomNv* ptr = (Interop.CoarseSampleOrderCustomNv*)m->CustomSampleOrders;
+					for (int i = 0; i < value.Length; i++)
+						ptr [i] = *value [i].m;
+				}
+			}
+		}
+
+		internal Interop.PipelineViewportCoarseSampleOrderStateCreateInfoNv* m {
+			get {
+				return (Interop.PipelineViewportCoarseSampleOrderStateCreateInfoNv*)native.Handle;
+			}
+		}
+
+		public PipelineViewportCoarseSampleOrderStateCreateInfoNv ()
+		{
+			native = Interop.Structure.Allocate (typeof (Interop.PipelineViewportCoarseSampleOrderStateCreateInfoNv));
+			Initialize ();
+		}
+
+		internal PipelineViewportCoarseSampleOrderStateCreateInfoNv (NativePointer pointer)
+		{
+			native = pointer;
+			Initialize ();
+		}
+
+		override public void Dispose (bool disposing)
+		{
+			base.Dispose (disposing);
+			if (!disposing)
+				return;
+			refCustomSampleOrders.Dispose ();
+			refCustomSampleOrders = null;
+		}
+
+		internal void Initialize ()
+		{
+			m->SType = StructureType.PipelineViewportCoarseSampleOrderStateCreateInfoNv;
+		}
+
+	}
+
+	unsafe public partial class PhysicalDeviceMeshShaderFeaturesNv : MarshalledObject
+	{
+		public bool TaskShader {
+			get { return m->TaskShader; }
+			set { m->TaskShader = value; }
+		}
+
+		public bool MeshShader {
+			get { return m->MeshShader; }
+			set { m->MeshShader = value; }
+		}
+
+		internal Interop.PhysicalDeviceMeshShaderFeaturesNv* m {
+			get {
+				return (Interop.PhysicalDeviceMeshShaderFeaturesNv*)native.Handle;
+			}
+		}
+
+		public PhysicalDeviceMeshShaderFeaturesNv ()
+		{
+			native = Interop.Structure.Allocate (typeof (Interop.PhysicalDeviceMeshShaderFeaturesNv));
+			Initialize ();
+		}
+
+		internal PhysicalDeviceMeshShaderFeaturesNv (NativePointer pointer)
+		{
+			native = pointer;
+			Initialize ();
+		}
+
+
+		internal void Initialize ()
+		{
+			m->SType = StructureType.PhysicalDeviceMeshShaderFeaturesNv;
+		}
+
+	}
+
+	unsafe public partial class PhysicalDeviceMeshShaderPropertiesNv : MarshalledObject
+	{
+		public UInt32 MaxDrawMeshTasksCount {
+			get { return m->MaxDrawMeshTasksCount; }
+			set { m->MaxDrawMeshTasksCount = value; }
+		}
+
+		public UInt32 MaxTaskWorkGroupInvocations {
+			get { return m->MaxTaskWorkGroupInvocations; }
+			set { m->MaxTaskWorkGroupInvocations = value; }
+		}
+
+		public UInt32[] MaxTaskWorkGroupSize {
+			get {
+				var arr = new UInt32 [3];
+				for (int i = 0; i < 3; i++)
+					arr [i] = m->MaxTaskWorkGroupSize [i];
+				return arr;
+			}
+
+			set {
+				if (value.Length > 3)
+					throw new Exception ("array too long");
+				for (int i = 0; i < value.Length; i++)
+					m->MaxTaskWorkGroupSize [i] = value [i];
+				for (int i = value.Length; i < 3; i++)
+					m->MaxTaskWorkGroupSize [i] = 0;
+			}
+		}
+
+		public UInt32 MaxTaskTotalMemorySize {
+			get { return m->MaxTaskTotalMemorySize; }
+			set { m->MaxTaskTotalMemorySize = value; }
+		}
+
+		public UInt32 MaxTaskOutputCount {
+			get { return m->MaxTaskOutputCount; }
+			set { m->MaxTaskOutputCount = value; }
+		}
+
+		public UInt32 MaxMeshWorkGroupInvocations {
+			get { return m->MaxMeshWorkGroupInvocations; }
+			set { m->MaxMeshWorkGroupInvocations = value; }
+		}
+
+		public UInt32[] MaxMeshWorkGroupSize {
+			get {
+				var arr = new UInt32 [3];
+				for (int i = 0; i < 3; i++)
+					arr [i] = m->MaxMeshWorkGroupSize [i];
+				return arr;
+			}
+
+			set {
+				if (value.Length > 3)
+					throw new Exception ("array too long");
+				for (int i = 0; i < value.Length; i++)
+					m->MaxMeshWorkGroupSize [i] = value [i];
+				for (int i = value.Length; i < 3; i++)
+					m->MaxMeshWorkGroupSize [i] = 0;
+			}
+		}
+
+		public UInt32 MaxMeshTotalMemorySize {
+			get { return m->MaxMeshTotalMemorySize; }
+			set { m->MaxMeshTotalMemorySize = value; }
+		}
+
+		public UInt32 MaxMeshOutputVertices {
+			get { return m->MaxMeshOutputVertices; }
+			set { m->MaxMeshOutputVertices = value; }
+		}
+
+		public UInt32 MaxMeshOutputPrimitives {
+			get { return m->MaxMeshOutputPrimitives; }
+			set { m->MaxMeshOutputPrimitives = value; }
+		}
+
+		public UInt32 MaxMeshMultiviewViewCount {
+			get { return m->MaxMeshMultiviewViewCount; }
+			set { m->MaxMeshMultiviewViewCount = value; }
+		}
+
+		public UInt32 MeshOutputPerVertexGranularity {
+			get { return m->MeshOutputPerVertexGranularity; }
+			set { m->MeshOutputPerVertexGranularity = value; }
+		}
+
+		public UInt32 MeshOutputPerPrimitiveGranularity {
+			get { return m->MeshOutputPerPrimitiveGranularity; }
+			set { m->MeshOutputPerPrimitiveGranularity = value; }
+		}
+
+		internal Interop.PhysicalDeviceMeshShaderPropertiesNv* m {
+			get {
+				return (Interop.PhysicalDeviceMeshShaderPropertiesNv*)native.Handle;
+			}
+		}
+
+		public PhysicalDeviceMeshShaderPropertiesNv ()
+		{
+			native = Interop.Structure.Allocate (typeof (Interop.PhysicalDeviceMeshShaderPropertiesNv));
+			Initialize ();
+		}
+
+		internal PhysicalDeviceMeshShaderPropertiesNv (NativePointer pointer)
+		{
+			native = pointer;
+			Initialize ();
+		}
+
+
+		internal void Initialize ()
+		{
+			m->SType = StructureType.PhysicalDeviceMeshShaderPropertiesNv;
+		}
+
+	}
+
+	unsafe public partial struct DrawMeshTasksIndirectCommandNv
+	{
+		public UInt32 TaskCount;
+		public UInt32 FirstTask;
+	}
+
+	unsafe public partial class RayTracingShaderGroupCreateInfoNv : MarshalledObject
+	{
+		public RayTracingShaderGroupTypeNv Type {
+			get { return m->Type; }
+			set { m->Type = value; }
+		}
+
+		public UInt32 GeneralShader {
+			get { return m->GeneralShader; }
+			set { m->GeneralShader = value; }
+		}
+
+		public UInt32 ClosestHitShader {
+			get { return m->ClosestHitShader; }
+			set { m->ClosestHitShader = value; }
+		}
+
+		public UInt32 AnyHitShader {
+			get { return m->AnyHitShader; }
+			set { m->AnyHitShader = value; }
+		}
+
+		public UInt32 IntersectionShader {
+			get { return m->IntersectionShader; }
+			set { m->IntersectionShader = value; }
+		}
+
+		internal Interop.RayTracingShaderGroupCreateInfoNv* m {
+			get {
+				return (Interop.RayTracingShaderGroupCreateInfoNv*)native.Handle;
+			}
+		}
+
+		public RayTracingShaderGroupCreateInfoNv ()
+		{
+			native = Interop.Structure.Allocate (typeof (Interop.RayTracingShaderGroupCreateInfoNv));
+			Initialize ();
+		}
+
+		internal RayTracingShaderGroupCreateInfoNv (NativePointer pointer)
+		{
+			native = pointer;
+			Initialize ();
+		}
+
+
+		internal void Initialize ()
+		{
+			m->SType = StructureType.RayTracingShaderGroupCreateInfoNv;
+		}
+
+	}
+
+	unsafe public partial class RayTracingPipelineCreateInfoNv : MarshalledObject
+	{
+		public PipelineCreateFlags Flags {
+			get { return m->Flags; }
+			set { m->Flags = value; }
+		}
+
+		public UInt32 StageCount {
+			get { return m->StageCount; }
+			set { m->StageCount = value; }
+		}
+
+		NativeReference refStages;
+		public PipelineShaderStageCreateInfo[] Stages {
+			get {
+				if (m->StageCount == 0)
+					return null;
+				var values = new PipelineShaderStageCreateInfo [m->StageCount];
+				unsafe
+				{
+					Interop.PipelineShaderStageCreateInfo* ptr = (Interop.PipelineShaderStageCreateInfo*)m->Stages;
+					for (int i = 0; i < values.Length; i++) {
+						values [i] = new PipelineShaderStageCreateInfo ();
+						*values [i].m = ptr [i];
+					}
+				}
+				return values;
+			}
+
+			set {
+				if (value == null) {
+					m->StageCount = 0;
+					m->Stages = IntPtr.Zero;
+					return;
+				}
+				m->StageCount = (uint)value.Length;
+				refStages = new NativeReference ((int)(sizeof(Interop.PipelineShaderStageCreateInfo)*value.Length));
+				m->Stages = refStages.Handle;
+				unsafe
+				{
+					Interop.PipelineShaderStageCreateInfo* ptr = (Interop.PipelineShaderStageCreateInfo*)m->Stages;
+					for (int i = 0; i < value.Length; i++)
+						ptr [i] = *value [i].m;
+				}
+			}
+		}
+
+		public UInt32 GroupCount {
+			get { return m->GroupCount; }
+			set { m->GroupCount = value; }
+		}
+
+		NativeReference refGroups;
+		public RayTracingShaderGroupCreateInfoNv[] Groups {
+			get {
+				if (m->GroupCount == 0)
+					return null;
+				var values = new RayTracingShaderGroupCreateInfoNv [m->GroupCount];
+				unsafe
+				{
+					Interop.RayTracingShaderGroupCreateInfoNv* ptr = (Interop.RayTracingShaderGroupCreateInfoNv*)m->Groups;
+					for (int i = 0; i < values.Length; i++) {
+						values [i] = new RayTracingShaderGroupCreateInfoNv ();
+						*values [i].m = ptr [i];
+					}
+				}
+				return values;
+			}
+
+			set {
+				if (value == null) {
+					m->GroupCount = 0;
+					m->Groups = IntPtr.Zero;
+					return;
+				}
+				m->GroupCount = (uint)value.Length;
+				refGroups = new NativeReference ((int)(sizeof(Interop.RayTracingShaderGroupCreateInfoNv)*value.Length));
+				m->Groups = refGroups.Handle;
+				unsafe
+				{
+					Interop.RayTracingShaderGroupCreateInfoNv* ptr = (Interop.RayTracingShaderGroupCreateInfoNv*)m->Groups;
+					for (int i = 0; i < value.Length; i++)
+						ptr [i] = *value [i].m;
+				}
+			}
+		}
+
+		public UInt32 MaxRecursionDepth {
+			get { return m->MaxRecursionDepth; }
+			set { m->MaxRecursionDepth = value; }
+		}
+
+		PipelineLayout lLayout;
+		public PipelineLayout Layout {
+			get { return lLayout; }
+			set { lLayout = value; m->Layout = value != null ? (UInt64)value.m : default(UInt64); }
+		}
+
+		Pipeline lBasePipelineHandle;
+		public Pipeline BasePipelineHandle {
+			get { return lBasePipelineHandle; }
+			set { lBasePipelineHandle = value; m->BasePipelineHandle = value != null ? (UInt64)value.m : default(UInt64); }
+		}
+
+		public Int32 BasePipelineIndex {
+			get { return m->BasePipelineIndex; }
+			set { m->BasePipelineIndex = value; }
+		}
+
+		internal Interop.RayTracingPipelineCreateInfoNv* m {
+			get {
+				return (Interop.RayTracingPipelineCreateInfoNv*)native.Handle;
+			}
+		}
+
+		public RayTracingPipelineCreateInfoNv ()
+		{
+			native = Interop.Structure.Allocate (typeof (Interop.RayTracingPipelineCreateInfoNv));
+			Initialize ();
+		}
+
+		internal RayTracingPipelineCreateInfoNv (NativePointer pointer)
+		{
+			native = pointer;
+			Initialize ();
+		}
+
+		override public void Dispose (bool disposing)
+		{
+			base.Dispose (disposing);
+			if (!disposing)
+				return;
+			refStages.Dispose ();
+			refStages = null;
+			refGroups.Dispose ();
+			refGroups = null;
+		}
+
+		internal void Initialize ()
+		{
+			m->SType = StructureType.RayTracingPipelineCreateInfoNv;
+		}
+
+	}
+
+	unsafe public partial class GeometryTrianglesNv : MarshalledObject
+	{
+		Buffer lVertexData;
+		public Buffer VertexData {
+			get { return lVertexData; }
+			set { lVertexData = value; m->VertexData = value != null ? (UInt64)value.m : default(UInt64); }
+		}
+
+		public DeviceSize VertexOffset {
+			get { return m->VertexOffset; }
+			set { m->VertexOffset = value; }
+		}
+
+		public UInt32 VertexCount {
+			get { return m->VertexCount; }
+			set { m->VertexCount = value; }
+		}
+
+		public DeviceSize VertexStride {
+			get { return m->VertexStride; }
+			set { m->VertexStride = value; }
+		}
+
+		public Format VertexFormat {
+			get { return m->VertexFormat; }
+			set { m->VertexFormat = value; }
+		}
+
+		Buffer lIndexData;
+		public Buffer IndexData {
+			get { return lIndexData; }
+			set { lIndexData = value; m->IndexData = value != null ? (UInt64)value.m : default(UInt64); }
+		}
+
+		public DeviceSize IndexOffset {
+			get { return m->IndexOffset; }
+			set { m->IndexOffset = value; }
+		}
+
+		public UInt32 IndexCount {
+			get { return m->IndexCount; }
+			set { m->IndexCount = value; }
+		}
+
+		public IndexType IndexType {
+			get { return m->IndexType; }
+			set { m->IndexType = value; }
+		}
+
+		Buffer lTransformData;
+		public Buffer TransformData {
+			get { return lTransformData; }
+			set { lTransformData = value; m->TransformData = value != null ? (UInt64)value.m : default(UInt64); }
+		}
+
+		public DeviceSize TransformOffset {
+			get { return m->TransformOffset; }
+			set { m->TransformOffset = value; }
+		}
+
+		internal Interop.GeometryTrianglesNv* m {
+			get {
+				return (Interop.GeometryTrianglesNv*)native.Handle;
+			}
+		}
+
+		public GeometryTrianglesNv ()
+		{
+			native = Interop.Structure.Allocate (typeof (Interop.GeometryTrianglesNv));
+			Initialize ();
+		}
+
+		internal GeometryTrianglesNv (NativePointer pointer)
+		{
+			native = pointer;
+			Initialize ();
+		}
+
+
+		internal void Initialize ()
+		{
+			m->SType = StructureType.GeometryTrianglesNv;
+		}
+
+	}
+
+	unsafe public partial class GeometryAABBNv : MarshalledObject
+	{
+		Buffer lAabbData;
+		public Buffer AabbData {
+			get { return lAabbData; }
+			set { lAabbData = value; m->AabbData = value != null ? (UInt64)value.m : default(UInt64); }
+		}
+
+		public UInt32 NumAabbs {
+			get { return m->NumAabbs; }
+			set { m->NumAabbs = value; }
+		}
+
+		public UInt32 Stride {
+			get { return m->Stride; }
+			set { m->Stride = value; }
+		}
+
+		public DeviceSize Offset {
+			get { return m->Offset; }
+			set { m->Offset = value; }
+		}
+
+		internal Interop.GeometryAABBNv* m {
+			get {
+				return (Interop.GeometryAABBNv*)native.Handle;
+			}
+		}
+
+		public GeometryAABBNv ()
+		{
+			native = Interop.Structure.Allocate (typeof (Interop.GeometryAABBNv));
+			Initialize ();
+		}
+
+		internal GeometryAABBNv (NativePointer pointer)
+		{
+			native = pointer;
+			Initialize ();
+		}
+
+
+		internal void Initialize ()
+		{
+			m->SType = StructureType.GeometryAABBNv;
+		}
+
+	}
+
+	unsafe public partial class GeometryDataNv : MarshalledObject
+	{
+		GeometryTrianglesNv lTriangles;
+		public GeometryTrianglesNv Triangles {
+			get { return lTriangles; }
+			set { lTriangles = value; m->Triangles = value != null ? *value.m : default(Interop.GeometryTrianglesNv); }
+		}
+
+		GeometryAABBNv lAabbs;
+		public GeometryAABBNv Aabbs {
+			get { return lAabbs; }
+			set { lAabbs = value; m->Aabbs = value != null ? *value.m : default(Interop.GeometryAABBNv); }
+		}
+
+		internal Interop.GeometryDataNv* m {
+			get {
+				return (Interop.GeometryDataNv*)native.Handle;
+			}
+		}
+
+		public GeometryDataNv ()
+		{
+			native = Interop.Structure.Allocate (typeof (Interop.GeometryDataNv));
+			Initialize ();
+		}
+
+		internal GeometryDataNv (NativePointer pointer)
+		{
+			native = pointer;
+			Initialize ();
+		}
+
+
+		internal void Initialize ()
+		{
+			lTriangles = new GeometryTrianglesNv (new NativePointer (native.Reference, (IntPtr)(&m->Triangles)));
+			lAabbs = new GeometryAABBNv (new NativePointer (native.Reference, (IntPtr)(&m->Aabbs)));
+		}
+
+	}
+
+	unsafe public partial class GeometryNv : MarshalledObject
+	{
+		public GeometryTypeNv GeometryType {
+			get { return m->GeometryType; }
+			set { m->GeometryType = value; }
+		}
+
+		GeometryDataNv lGeometry;
+		public GeometryDataNv Geometry {
+			get { return lGeometry; }
+			set { lGeometry = value; m->Geometry = value != null ? *value.m : default(Interop.GeometryDataNv); }
+		}
+
+		public GeometryFlagsNv Flags {
+			get { return m->Flags; }
+			set { m->Flags = value; }
+		}
+
+		internal Interop.GeometryNv* m {
+			get {
+				return (Interop.GeometryNv*)native.Handle;
+			}
+		}
+
+		public GeometryNv ()
+		{
+			native = Interop.Structure.Allocate (typeof (Interop.GeometryNv));
+			Initialize ();
+		}
+
+		internal GeometryNv (NativePointer pointer)
+		{
+			native = pointer;
+			Initialize ();
+		}
+
+
+		internal void Initialize ()
+		{
+			m->SType = StructureType.GeometryNv;
+			lGeometry = new GeometryDataNv (new NativePointer (native.Reference, (IntPtr)(&m->Geometry)));
+		}
+
+	}
+
+	unsafe public partial class AccelerationStructureInfoNv : MarshalledObject
+	{
+		public AccelerationStructureTypeNv Type {
+			get { return m->Type; }
+			set { m->Type = value; }
+		}
+
+		public BuildAccelerationStructureFlagsNv Flags {
+			get { return m->Flags; }
+			set { m->Flags = value; }
+		}
+
+		public UInt32 InstanceCount {
+			get { return m->InstanceCount; }
+			set { m->InstanceCount = value; }
+		}
+
+		public UInt32 GeometryCount {
+			get { return m->GeometryCount; }
+			set { m->GeometryCount = value; }
+		}
+
+		NativeReference refGeometries;
+		public GeometryNv[] Geometries {
+			get {
+				if (m->GeometryCount == 0)
+					return null;
+				var values = new GeometryNv [m->GeometryCount];
+				unsafe
+				{
+					Interop.GeometryNv* ptr = (Interop.GeometryNv*)m->Geometries;
+					for (int i = 0; i < values.Length; i++) {
+						values [i] = new GeometryNv ();
+						*values [i].m = ptr [i];
+					}
+				}
+				return values;
+			}
+
+			set {
+				if (value == null) {
+					m->GeometryCount = 0;
+					m->Geometries = IntPtr.Zero;
+					return;
+				}
+				m->GeometryCount = (uint)value.Length;
+				refGeometries = new NativeReference ((int)(sizeof(Interop.GeometryNv)*value.Length));
+				m->Geometries = refGeometries.Handle;
+				unsafe
+				{
+					Interop.GeometryNv* ptr = (Interop.GeometryNv*)m->Geometries;
+					for (int i = 0; i < value.Length; i++)
+						ptr [i] = *value [i].m;
+				}
+			}
+		}
+
+		internal Interop.AccelerationStructureInfoNv* m {
+			get {
+				return (Interop.AccelerationStructureInfoNv*)native.Handle;
+			}
+		}
+
+		public AccelerationStructureInfoNv ()
+		{
+			native = Interop.Structure.Allocate (typeof (Interop.AccelerationStructureInfoNv));
+			Initialize ();
+		}
+
+		internal AccelerationStructureInfoNv (NativePointer pointer)
+		{
+			native = pointer;
+			Initialize ();
+		}
+
+		override public void Dispose (bool disposing)
+		{
+			base.Dispose (disposing);
+			if (!disposing)
+				return;
+			refGeometries.Dispose ();
+			refGeometries = null;
+		}
+
+		internal void Initialize ()
+		{
+			m->SType = StructureType.AccelerationStructureInfoNv;
+		}
+
+	}
+
+	unsafe public partial class AccelerationStructureCreateInfoNv : MarshalledObject
+	{
+		public DeviceSize CompactedSize {
+			get { return m->CompactedSize; }
+			set { m->CompactedSize = value; }
+		}
+
+		AccelerationStructureInfoNv lInfo;
+		public AccelerationStructureInfoNv Info {
+			get { return lInfo; }
+			set { lInfo = value; m->Info = value != null ? *value.m : default(Interop.AccelerationStructureInfoNv); }
+		}
+
+		internal Interop.AccelerationStructureCreateInfoNv* m {
+			get {
+				return (Interop.AccelerationStructureCreateInfoNv*)native.Handle;
+			}
+		}
+
+		public AccelerationStructureCreateInfoNv ()
+		{
+			native = Interop.Structure.Allocate (typeof (Interop.AccelerationStructureCreateInfoNv));
+			Initialize ();
+		}
+
+		internal AccelerationStructureCreateInfoNv (NativePointer pointer)
+		{
+			native = pointer;
+			Initialize ();
+		}
+
+
+		internal void Initialize ()
+		{
+			m->SType = StructureType.AccelerationStructureCreateInfoNv;
+			lInfo = new AccelerationStructureInfoNv (new NativePointer (native.Reference, (IntPtr)(&m->Info)));
+		}
+
+	}
+
+	unsafe public partial class BindAccelerationStructureMemoryInfoNv : MarshalledObject
+	{
+		AccelerationStructureNv lAccelerationStructure;
+		public AccelerationStructureNv AccelerationStructure {
+			get { return lAccelerationStructure; }
+			set { lAccelerationStructure = value; m->AccelerationStructure = value != null ? (UInt64)value.m : default(UInt64); }
+		}
+
+		DeviceMemory lMemory;
+		public DeviceMemory Memory {
+			get { return lMemory; }
+			set { lMemory = value; m->Memory = value != null ? (UInt64)value.m : default(UInt64); }
+		}
+
+		public DeviceSize MemoryOffset {
+			get { return m->MemoryOffset; }
+			set { m->MemoryOffset = value; }
+		}
+
+		public UInt32 DeviceIndexCount {
+			get { return m->DeviceIndexCount; }
+			set { m->DeviceIndexCount = value; }
+		}
+
+		NativeReference refDeviceIndices;
+		public UInt32[] DeviceIndices {
+			get {
+				if (m->DeviceIndexCount == 0)
+					return null;
+				var values = new UInt32 [m->DeviceIndexCount];
+				unsafe
+				{
+					UInt32* ptr = (UInt32*)m->DeviceIndices;
+					for (int i = 0; i < values.Length; i++) 
+						values [i] = ptr [i];
+				}
+				return values;
+			}
+
+			set {
+				if (value == null) {
+					m->DeviceIndexCount = 0;
+					m->DeviceIndices = IntPtr.Zero;
+					return;
+				}
+				m->DeviceIndexCount = (uint)value.Length;
+				refDeviceIndices = new NativeReference ((int)(sizeof(UInt32)*value.Length));
+				m->DeviceIndices = refDeviceIndices.Handle;
+				unsafe
+				{
+					UInt32* ptr = (UInt32*)m->DeviceIndices;
+					for (int i = 0; i < value.Length; i++)
+						ptr [i] = value [i];
+				}
+			}
+		}
+
+		internal Interop.BindAccelerationStructureMemoryInfoNv* m {
+			get {
+				return (Interop.BindAccelerationStructureMemoryInfoNv*)native.Handle;
+			}
+		}
+
+		public BindAccelerationStructureMemoryInfoNv ()
+		{
+			native = Interop.Structure.Allocate (typeof (Interop.BindAccelerationStructureMemoryInfoNv));
+			Initialize ();
+		}
+
+		internal BindAccelerationStructureMemoryInfoNv (NativePointer pointer)
+		{
+			native = pointer;
+			Initialize ();
+		}
+
+		override public void Dispose (bool disposing)
+		{
+			base.Dispose (disposing);
+			if (!disposing)
+				return;
+			refDeviceIndices.Dispose ();
+			refDeviceIndices = null;
+		}
+
+		internal void Initialize ()
+		{
+			m->SType = StructureType.BindAccelerationStructureMemoryInfoNv;
+		}
+
+	}
+
+	unsafe public partial class WriteDescriptorSetAccelerationStructureNv : MarshalledObject
+	{
+		public UInt32 AccelerationStructureCount {
+			get { return m->AccelerationStructureCount; }
+			set { m->AccelerationStructureCount = value; }
+		}
+
+		NativeReference refAccelerationStructures;
+		public AccelerationStructureNv[] AccelerationStructures {
+			get {
+				if (m->AccelerationStructureCount == 0)
+					return null;
+				var values = new AccelerationStructureNv [m->AccelerationStructureCount];
+				unsafe
+				{
+					UInt64* ptr = (UInt64*)m->AccelerationStructures;
+					for (int i = 0; i < values.Length; i++) {
+						values [i] = new AccelerationStructureNv ();
+						values [i].m = ptr [i];
+					}
+				}
+				return values;
+			}
+
+			set {
+				if (value == null) {
+					m->AccelerationStructureCount = 0;
+					m->AccelerationStructures = IntPtr.Zero;
+					return;
+				}
+				m->AccelerationStructureCount = (uint)value.Length;
+				refAccelerationStructures = new NativeReference ((int)(sizeof(UInt64)*value.Length));
+				m->AccelerationStructures = refAccelerationStructures.Handle;
+				unsafe
+				{
+					UInt64* ptr = (UInt64*)m->AccelerationStructures;
+					for (int i = 0; i < value.Length; i++)
+						ptr [i] = value [i].m;
+				}
+			}
+		}
+
+		internal Interop.WriteDescriptorSetAccelerationStructureNv* m {
+			get {
+				return (Interop.WriteDescriptorSetAccelerationStructureNv*)native.Handle;
+			}
+		}
+
+		public WriteDescriptorSetAccelerationStructureNv ()
+		{
+			native = Interop.Structure.Allocate (typeof (Interop.WriteDescriptorSetAccelerationStructureNv));
+			Initialize ();
+		}
+
+		internal WriteDescriptorSetAccelerationStructureNv (NativePointer pointer)
+		{
+			native = pointer;
+			Initialize ();
+		}
+
+		override public void Dispose (bool disposing)
+		{
+			base.Dispose (disposing);
+			if (!disposing)
+				return;
+			refAccelerationStructures.Dispose ();
+			refAccelerationStructures = null;
+		}
+
+		internal void Initialize ()
+		{
+			m->SType = StructureType.WriteDescriptorSetAccelerationStructureNv;
+		}
+
+	}
+
+	unsafe public partial class AccelerationStructureMemoryRequirementsInfoNv : MarshalledObject
+	{
+		public AccelerationStructureMemoryRequirementsTypeNv Type {
+			get { return m->Type; }
+			set { m->Type = value; }
+		}
+
+		AccelerationStructureNv lAccelerationStructure;
+		public AccelerationStructureNv AccelerationStructure {
+			get { return lAccelerationStructure; }
+			set { lAccelerationStructure = value; m->AccelerationStructure = value != null ? (UInt64)value.m : default(UInt64); }
+		}
+
+		internal Interop.AccelerationStructureMemoryRequirementsInfoNv* m {
+			get {
+				return (Interop.AccelerationStructureMemoryRequirementsInfoNv*)native.Handle;
+			}
+		}
+
+		public AccelerationStructureMemoryRequirementsInfoNv ()
+		{
+			native = Interop.Structure.Allocate (typeof (Interop.AccelerationStructureMemoryRequirementsInfoNv));
+			Initialize ();
+		}
+
+		internal AccelerationStructureMemoryRequirementsInfoNv (NativePointer pointer)
+		{
+			native = pointer;
+			Initialize ();
+		}
+
+
+		internal void Initialize ()
+		{
+			m->SType = StructureType.AccelerationStructureMemoryRequirementsInfoNv;
+		}
+
+	}
+
+	unsafe public partial class PhysicalDeviceRayTracingPropertiesNv : MarshalledObject
+	{
+		public UInt32 ShaderGroupHandleSize {
+			get { return m->ShaderGroupHandleSize; }
+			set { m->ShaderGroupHandleSize = value; }
+		}
+
+		public UInt32 MaxRecursionDepth {
+			get { return m->MaxRecursionDepth; }
+			set { m->MaxRecursionDepth = value; }
+		}
+
+		public UInt32 MaxShaderGroupStride {
+			get { return m->MaxShaderGroupStride; }
+			set { m->MaxShaderGroupStride = value; }
+		}
+
+		public UInt32 ShaderGroupBaseAlignment {
+			get { return m->ShaderGroupBaseAlignment; }
+			set { m->ShaderGroupBaseAlignment = value; }
+		}
+
+		public UInt64 MaxGeometryCount {
+			get { return m->MaxGeometryCount; }
+			set { m->MaxGeometryCount = value; }
+		}
+
+		public UInt64 MaxInstanceCount {
+			get { return m->MaxInstanceCount; }
+			set { m->MaxInstanceCount = value; }
+		}
+
+		public UInt64 MaxTriangleCount {
+			get { return m->MaxTriangleCount; }
+			set { m->MaxTriangleCount = value; }
+		}
+
+		public UInt32 MaxDescriptorSetAccelerationStructures {
+			get { return m->MaxDescriptorSetAccelerationStructures; }
+			set { m->MaxDescriptorSetAccelerationStructures = value; }
+		}
+
+		internal Interop.PhysicalDeviceRayTracingPropertiesNv* m {
+			get {
+				return (Interop.PhysicalDeviceRayTracingPropertiesNv*)native.Handle;
+			}
+		}
+
+		public PhysicalDeviceRayTracingPropertiesNv ()
+		{
+			native = Interop.Structure.Allocate (typeof (Interop.PhysicalDeviceRayTracingPropertiesNv));
+			Initialize ();
+		}
+
+		internal PhysicalDeviceRayTracingPropertiesNv (NativePointer pointer)
+		{
+			native = pointer;
+			Initialize ();
+		}
+
+
+		internal void Initialize ()
+		{
+			m->SType = StructureType.PhysicalDeviceRayTracingPropertiesNv;
+		}
+
+	}
+
+	unsafe public partial class DrmFormatModifierPropertiesListExt : MarshalledObject
+	{
+		public UInt32 DrmFormatModifierCount {
+			get { return m->DrmFormatModifierCount; }
+			set { m->DrmFormatModifierCount = value; }
+		}
+
+		NativeReference refDrmFormatModifierProperties;
+		public DrmFormatModifierPropertiesExt[] DrmFormatModifierProperties {
+			get {
+				if (m->DrmFormatModifierCount == 0)
+					return null;
+				var values = new DrmFormatModifierPropertiesExt [m->DrmFormatModifierCount];
+				unsafe
+				{
+					DrmFormatModifierPropertiesExt* ptr = (DrmFormatModifierPropertiesExt*)m->DrmFormatModifierProperties;
+					for (int i = 0; i < values.Length; i++) 
+						values [i] = ptr [i];
+				}
+				return values;
+			}
+
+			set {
+				if (value == null) {
+					m->DrmFormatModifierCount = 0;
+					m->DrmFormatModifierProperties = IntPtr.Zero;
+					return;
+				}
+				m->DrmFormatModifierCount = (uint)value.Length;
+				refDrmFormatModifierProperties = new NativeReference ((int)(sizeof(DrmFormatModifierPropertiesExt)*value.Length));
+				m->DrmFormatModifierProperties = refDrmFormatModifierProperties.Handle;
+				unsafe
+				{
+					DrmFormatModifierPropertiesExt* ptr = (DrmFormatModifierPropertiesExt*)m->DrmFormatModifierProperties;
+					for (int i = 0; i < value.Length; i++)
+						ptr [i] = value [i];
+				}
+			}
+		}
+
+		internal Interop.DrmFormatModifierPropertiesListExt* m {
+			get {
+				return (Interop.DrmFormatModifierPropertiesListExt*)native.Handle;
+			}
+		}
+
+		public DrmFormatModifierPropertiesListExt ()
+		{
+			native = Interop.Structure.Allocate (typeof (Interop.DrmFormatModifierPropertiesListExt));
+			Initialize ();
+		}
+
+		internal DrmFormatModifierPropertiesListExt (NativePointer pointer)
+		{
+			native = pointer;
+			Initialize ();
+		}
+
+		override public void Dispose (bool disposing)
+		{
+			base.Dispose (disposing);
+			if (!disposing)
+				return;
+			refDrmFormatModifierProperties.Dispose ();
+			refDrmFormatModifierProperties = null;
+		}
+
+		internal void Initialize ()
+		{
+			m->SType = StructureType.DrmFormatModifierPropertiesListExt;
+		}
+
+	}
+
+	unsafe public partial struct DrmFormatModifierPropertiesExt
+	{
+		public UInt64 DrmFormatModifier;
+		public UInt32 DrmFormatModifierPlaneCount;
+		public FormatFeatureFlags DrmFormatModifierTilingFeatures;
+	}
+
+	unsafe public partial class PhysicalDeviceImageDrmFormatModifierInfoExt : MarshalledObject
+	{
+		public UInt64 DrmFormatModifier {
+			get { return m->DrmFormatModifier; }
+			set { m->DrmFormatModifier = value; }
+		}
+
+		public SharingMode SharingMode {
+			get { return m->SharingMode; }
+			set { m->SharingMode = value; }
+		}
+
+		public UInt32 QueueFamilyIndexCount {
+			get { return m->QueueFamilyIndexCount; }
+			set { m->QueueFamilyIndexCount = value; }
+		}
+
+		NativeReference refQueueFamilyIndices;
+		public UInt32[] QueueFamilyIndices {
+			get {
+				if (m->QueueFamilyIndexCount == 0)
+					return null;
+				var values = new UInt32 [m->QueueFamilyIndexCount];
+				unsafe
+				{
+					UInt32* ptr = (UInt32*)m->QueueFamilyIndices;
+					for (int i = 0; i < values.Length; i++) 
+						values [i] = ptr [i];
+				}
+				return values;
+			}
+
+			set {
+				if (value == null) {
+					m->QueueFamilyIndexCount = 0;
+					m->QueueFamilyIndices = IntPtr.Zero;
+					return;
+				}
+				m->QueueFamilyIndexCount = (uint)value.Length;
+				refQueueFamilyIndices = new NativeReference ((int)(sizeof(UInt32)*value.Length));
+				m->QueueFamilyIndices = refQueueFamilyIndices.Handle;
+				unsafe
+				{
+					UInt32* ptr = (UInt32*)m->QueueFamilyIndices;
+					for (int i = 0; i < value.Length; i++)
+						ptr [i] = value [i];
+				}
+			}
+		}
+
+		internal Interop.PhysicalDeviceImageDrmFormatModifierInfoExt* m {
+			get {
+				return (Interop.PhysicalDeviceImageDrmFormatModifierInfoExt*)native.Handle;
+			}
+		}
+
+		public PhysicalDeviceImageDrmFormatModifierInfoExt ()
+		{
+			native = Interop.Structure.Allocate (typeof (Interop.PhysicalDeviceImageDrmFormatModifierInfoExt));
+			Initialize ();
+		}
+
+		internal PhysicalDeviceImageDrmFormatModifierInfoExt (NativePointer pointer)
+		{
+			native = pointer;
+			Initialize ();
+		}
+
+		override public void Dispose (bool disposing)
+		{
+			base.Dispose (disposing);
+			if (!disposing)
+				return;
+			refQueueFamilyIndices.Dispose ();
+			refQueueFamilyIndices = null;
+		}
+
+		internal void Initialize ()
+		{
+			m->SType = StructureType.PhysicalDeviceImageDrmFormatModifierInfoExt;
+		}
+
+	}
+
+	unsafe public partial class ImageDrmFormatModifierListCreateInfoExt : MarshalledObject
+	{
+		public UInt32 DrmFormatModifierCount {
+			get { return m->DrmFormatModifierCount; }
+			set { m->DrmFormatModifierCount = value; }
+		}
+
+		NativeReference refDrmFormatModifiers;
+		public UInt64[] DrmFormatModifiers {
+			get {
+				if (m->DrmFormatModifierCount == 0)
+					return null;
+				var values = new UInt64 [m->DrmFormatModifierCount];
+				unsafe
+				{
+					UInt64* ptr = (UInt64*)m->DrmFormatModifiers;
+					for (int i = 0; i < values.Length; i++) 
+						values [i] = ptr [i];
+				}
+				return values;
+			}
+
+			set {
+				if (value == null) {
+					m->DrmFormatModifierCount = 0;
+					m->DrmFormatModifiers = IntPtr.Zero;
+					return;
+				}
+				m->DrmFormatModifierCount = (uint)value.Length;
+				refDrmFormatModifiers = new NativeReference ((int)(sizeof(UInt64)*value.Length));
+				m->DrmFormatModifiers = refDrmFormatModifiers.Handle;
+				unsafe
+				{
+					UInt64* ptr = (UInt64*)m->DrmFormatModifiers;
+					for (int i = 0; i < value.Length; i++)
+						ptr [i] = value [i];
+				}
+			}
+		}
+
+		internal Interop.ImageDrmFormatModifierListCreateInfoExt* m {
+			get {
+				return (Interop.ImageDrmFormatModifierListCreateInfoExt*)native.Handle;
+			}
+		}
+
+		public ImageDrmFormatModifierListCreateInfoExt ()
+		{
+			native = Interop.Structure.Allocate (typeof (Interop.ImageDrmFormatModifierListCreateInfoExt));
+			Initialize ();
+		}
+
+		internal ImageDrmFormatModifierListCreateInfoExt (NativePointer pointer)
+		{
+			native = pointer;
+			Initialize ();
+		}
+
+		override public void Dispose (bool disposing)
+		{
+			base.Dispose (disposing);
+			if (!disposing)
+				return;
+			refDrmFormatModifiers.Dispose ();
+			refDrmFormatModifiers = null;
+		}
+
+		internal void Initialize ()
+		{
+			m->SType = StructureType.ImageDrmFormatModifierListCreateInfoExt;
+		}
+
+	}
+
+	unsafe public partial class ImageDrmFormatModifierExplicitCreateInfoExt : MarshalledObject
+	{
+		public UInt64 DrmFormatModifier {
+			get { return m->DrmFormatModifier; }
+			set { m->DrmFormatModifier = value; }
+		}
+
+		public UInt32 DrmFormatModifierPlaneCount {
+			get { return m->DrmFormatModifierPlaneCount; }
+			set { m->DrmFormatModifierPlaneCount = value; }
+		}
+
+		NativeReference refPlaneLayouts;
+		public SubresourceLayout[] PlaneLayouts {
+			get {
+				if (m->DrmFormatModifierPlaneCount == 0)
+					return null;
+				var values = new SubresourceLayout [m->DrmFormatModifierPlaneCount];
+				unsafe
+				{
+					SubresourceLayout* ptr = (SubresourceLayout*)m->PlaneLayouts;
+					for (int i = 0; i < values.Length; i++) 
+						values [i] = ptr [i];
+				}
+				return values;
+			}
+
+			set {
+				if (value == null) {
+					m->DrmFormatModifierPlaneCount = 0;
+					m->PlaneLayouts = IntPtr.Zero;
+					return;
+				}
+				m->DrmFormatModifierPlaneCount = (uint)value.Length;
+				refPlaneLayouts = new NativeReference ((int)(sizeof(SubresourceLayout)*value.Length));
+				m->PlaneLayouts = refPlaneLayouts.Handle;
+				unsafe
+				{
+					SubresourceLayout* ptr = (SubresourceLayout*)m->PlaneLayouts;
+					for (int i = 0; i < value.Length; i++)
+						ptr [i] = value [i];
+				}
+			}
+		}
+
+		internal Interop.ImageDrmFormatModifierExplicitCreateInfoExt* m {
+			get {
+				return (Interop.ImageDrmFormatModifierExplicitCreateInfoExt*)native.Handle;
+			}
+		}
+
+		public ImageDrmFormatModifierExplicitCreateInfoExt ()
+		{
+			native = Interop.Structure.Allocate (typeof (Interop.ImageDrmFormatModifierExplicitCreateInfoExt));
+			Initialize ();
+		}
+
+		internal ImageDrmFormatModifierExplicitCreateInfoExt (NativePointer pointer)
+		{
+			native = pointer;
+			Initialize ();
+		}
+
+		override public void Dispose (bool disposing)
+		{
+			base.Dispose (disposing);
+			if (!disposing)
+				return;
+			refPlaneLayouts.Dispose ();
+			refPlaneLayouts = null;
+		}
+
+		internal void Initialize ()
+		{
+			m->SType = StructureType.ImageDrmFormatModifierExplicitCreateInfoExt;
+		}
+
+	}
+
+	unsafe public partial class ImageDrmFormatModifierPropertiesExt : MarshalledObject
+	{
+		public UInt64 DrmFormatModifier {
+			get { return m->DrmFormatModifier; }
+			set { m->DrmFormatModifier = value; }
+		}
+
+		internal Interop.ImageDrmFormatModifierPropertiesExt* m {
+			get {
+				return (Interop.ImageDrmFormatModifierPropertiesExt*)native.Handle;
+			}
+		}
+
+		public ImageDrmFormatModifierPropertiesExt ()
+		{
+			native = Interop.Structure.Allocate (typeof (Interop.ImageDrmFormatModifierPropertiesExt));
+			Initialize ();
+		}
+
+		internal ImageDrmFormatModifierPropertiesExt (NativePointer pointer)
+		{
+			native = pointer;
+			Initialize ();
+		}
+
+
+		internal void Initialize ()
+		{
+			m->SType = StructureType.ImageDrmFormatModifierPropertiesExt;
+		}
+
+	}
+
+	unsafe public partial class ImageStencilUsageCreateInfoExt : MarshalledObject
+	{
+		public ImageUsageFlags StencilUsage {
+			get { return m->StencilUsage; }
+			set { m->StencilUsage = value; }
+		}
+
+		internal Interop.ImageStencilUsageCreateInfoExt* m {
+			get {
+				return (Interop.ImageStencilUsageCreateInfoExt*)native.Handle;
+			}
+		}
+
+		public ImageStencilUsageCreateInfoExt ()
+		{
+			native = Interop.Structure.Allocate (typeof (Interop.ImageStencilUsageCreateInfoExt));
+			Initialize ();
+		}
+
+		internal ImageStencilUsageCreateInfoExt (NativePointer pointer)
+		{
+			native = pointer;
+			Initialize ();
+		}
+
+
+		internal void Initialize ()
+		{
+			m->SType = StructureType.ImageStencilUsageCreateInfoExt;
+		}
+
+	}
+
+	unsafe public partial class DeviceMemoryOverallocationCreateInfoAmd : MarshalledObject
+	{
+		public MemoryOverallocationBehaviorAmd OverallocationBehavior {
+			get { return m->OverallocationBehavior; }
+			set { m->OverallocationBehavior = value; }
+		}
+
+		internal Interop.DeviceMemoryOverallocationCreateInfoAmd* m {
+			get {
+				return (Interop.DeviceMemoryOverallocationCreateInfoAmd*)native.Handle;
+			}
+		}
+
+		public DeviceMemoryOverallocationCreateInfoAmd ()
+		{
+			native = Interop.Structure.Allocate (typeof (Interop.DeviceMemoryOverallocationCreateInfoAmd));
+			Initialize ();
+		}
+
+		internal DeviceMemoryOverallocationCreateInfoAmd (NativePointer pointer)
+		{
+			native = pointer;
+			Initialize ();
+		}
+
+
+		internal void Initialize ()
+		{
+			m->SType = StructureType.DeviceMemoryOverallocationCreateInfoAmd;
+		}
+
+	}
+
+	unsafe public partial class PhysicalDeviceFragmentDensityMapFeaturesExt : MarshalledObject
+	{
+		public bool FragmentDensityMap {
+			get { return m->FragmentDensityMap; }
+			set { m->FragmentDensityMap = value; }
+		}
+
+		public bool FragmentDensityMapDynamic {
+			get { return m->FragmentDensityMapDynamic; }
+			set { m->FragmentDensityMapDynamic = value; }
+		}
+
+		public bool FragmentDensityMapNonSubsampledImages {
+			get { return m->FragmentDensityMapNonSubsampledImages; }
+			set { m->FragmentDensityMapNonSubsampledImages = value; }
+		}
+
+		internal Interop.PhysicalDeviceFragmentDensityMapFeaturesExt* m {
+			get {
+				return (Interop.PhysicalDeviceFragmentDensityMapFeaturesExt*)native.Handle;
+			}
+		}
+
+		public PhysicalDeviceFragmentDensityMapFeaturesExt ()
+		{
+			native = Interop.Structure.Allocate (typeof (Interop.PhysicalDeviceFragmentDensityMapFeaturesExt));
+			Initialize ();
+		}
+
+		internal PhysicalDeviceFragmentDensityMapFeaturesExt (NativePointer pointer)
+		{
+			native = pointer;
+			Initialize ();
+		}
+
+
+		internal void Initialize ()
+		{
+			m->SType = StructureType.PhysicalDeviceFragmentDensityMapFeaturesExt;
+		}
+
+	}
+
+	unsafe public partial class PhysicalDeviceFragmentDensityMapPropertiesExt : MarshalledObject
+	{
+		public Extent2D MinFragmentDensityTexelSize {
+			get { return m->MinFragmentDensityTexelSize; }
+			set { m->MinFragmentDensityTexelSize = value; }
+		}
+
+		public Extent2D MaxFragmentDensityTexelSize {
+			get { return m->MaxFragmentDensityTexelSize; }
+			set { m->MaxFragmentDensityTexelSize = value; }
+		}
+
+		public bool FragmentDensityInvocations {
+			get { return m->FragmentDensityInvocations; }
+			set { m->FragmentDensityInvocations = value; }
+		}
+
+		internal Interop.PhysicalDeviceFragmentDensityMapPropertiesExt* m {
+			get {
+				return (Interop.PhysicalDeviceFragmentDensityMapPropertiesExt*)native.Handle;
+			}
+		}
+
+		public PhysicalDeviceFragmentDensityMapPropertiesExt ()
+		{
+			native = Interop.Structure.Allocate (typeof (Interop.PhysicalDeviceFragmentDensityMapPropertiesExt));
+			Initialize ();
+		}
+
+		internal PhysicalDeviceFragmentDensityMapPropertiesExt (NativePointer pointer)
+		{
+			native = pointer;
+			Initialize ();
+		}
+
+
+		internal void Initialize ()
+		{
+			m->SType = StructureType.PhysicalDeviceFragmentDensityMapPropertiesExt;
+		}
+
+	}
+
+	unsafe public partial class RenderPassFragmentDensityMapCreateInfoExt : MarshalledObject
+	{
+		public AttachmentReference FragmentDensityMapAttachment {
+			get { return m->FragmentDensityMapAttachment; }
+			set { m->FragmentDensityMapAttachment = value; }
+		}
+
+		internal Interop.RenderPassFragmentDensityMapCreateInfoExt* m {
+			get {
+				return (Interop.RenderPassFragmentDensityMapCreateInfoExt*)native.Handle;
+			}
+		}
+
+		public RenderPassFragmentDensityMapCreateInfoExt ()
+		{
+			native = Interop.Structure.Allocate (typeof (Interop.RenderPassFragmentDensityMapCreateInfoExt));
+			Initialize ();
+		}
+
+		internal RenderPassFragmentDensityMapCreateInfoExt (NativePointer pointer)
+		{
+			native = pointer;
+			Initialize ();
+		}
+
+
+		internal void Initialize ()
+		{
+			m->SType = StructureType.RenderPassFragmentDensityMapCreateInfoExt;
+		}
+
+	}
+
+	unsafe public partial class PhysicalDeviceScalarBlockLayoutFeaturesExt : MarshalledObject
+	{
+		public bool ScalarBlockLayout {
+			get { return m->ScalarBlockLayout; }
+			set { m->ScalarBlockLayout = value; }
+		}
+
+		internal Interop.PhysicalDeviceScalarBlockLayoutFeaturesExt* m {
+			get {
+				return (Interop.PhysicalDeviceScalarBlockLayoutFeaturesExt*)native.Handle;
+			}
+		}
+
+		public PhysicalDeviceScalarBlockLayoutFeaturesExt ()
+		{
+			native = Interop.Structure.Allocate (typeof (Interop.PhysicalDeviceScalarBlockLayoutFeaturesExt));
+			Initialize ();
+		}
+
+		internal PhysicalDeviceScalarBlockLayoutFeaturesExt (NativePointer pointer)
+		{
+			native = pointer;
+			Initialize ();
+		}
+
+
+		internal void Initialize ()
+		{
+			m->SType = StructureType.PhysicalDeviceScalarBlockLayoutFeaturesExt;
+		}
+
+	}
+
+	unsafe public partial class SurfaceProtectedCapabilitiesKhr : MarshalledObject
+	{
+		public bool SupportsProtected {
+			get { return m->SupportsProtected; }
+			set { m->SupportsProtected = value; }
+		}
+
+		internal Interop.SurfaceProtectedCapabilitiesKhr* m {
+			get {
+				return (Interop.SurfaceProtectedCapabilitiesKhr*)native.Handle;
+			}
+		}
+
+		public SurfaceProtectedCapabilitiesKhr ()
+		{
+			native = Interop.Structure.Allocate (typeof (Interop.SurfaceProtectedCapabilitiesKhr));
+			Initialize ();
+		}
+
+		internal SurfaceProtectedCapabilitiesKhr (NativePointer pointer)
+		{
+			native = pointer;
+			Initialize ();
+		}
+
+
+		internal void Initialize ()
+		{
+			m->SType = StructureType.SurfaceProtectedCapabilitiesKhr;
+		}
+
+	}
+
+	unsafe public partial class PhysicalDeviceUniformBufferStandardLayoutFeaturesKhr : MarshalledObject
+	{
+		public bool UniformBufferStandardLayout {
+			get { return m->UniformBufferStandardLayout; }
+			set { m->UniformBufferStandardLayout = value; }
+		}
+
+		internal Interop.PhysicalDeviceUniformBufferStandardLayoutFeaturesKhr* m {
+			get {
+				return (Interop.PhysicalDeviceUniformBufferStandardLayoutFeaturesKhr*)native.Handle;
+			}
+		}
+
+		public PhysicalDeviceUniformBufferStandardLayoutFeaturesKhr ()
+		{
+			native = Interop.Structure.Allocate (typeof (Interop.PhysicalDeviceUniformBufferStandardLayoutFeaturesKhr));
+			Initialize ();
+		}
+
+		internal PhysicalDeviceUniformBufferStandardLayoutFeaturesKhr (NativePointer pointer)
+		{
+			native = pointer;
+			Initialize ();
+		}
+
+
+		internal void Initialize ()
+		{
+			m->SType = StructureType.PhysicalDeviceUniformBufferStandardLayoutFeaturesKhr;
+		}
+
+	}
+
+	unsafe public partial class PhysicalDeviceDepthClipEnableFeaturesExt : MarshalledObject
+	{
+		public bool DepthClipEnable {
+			get { return m->DepthClipEnable; }
+			set { m->DepthClipEnable = value; }
+		}
+
+		internal Interop.PhysicalDeviceDepthClipEnableFeaturesExt* m {
+			get {
+				return (Interop.PhysicalDeviceDepthClipEnableFeaturesExt*)native.Handle;
+			}
+		}
+
+		public PhysicalDeviceDepthClipEnableFeaturesExt ()
+		{
+			native = Interop.Structure.Allocate (typeof (Interop.PhysicalDeviceDepthClipEnableFeaturesExt));
+			Initialize ();
+		}
+
+		internal PhysicalDeviceDepthClipEnableFeaturesExt (NativePointer pointer)
+		{
+			native = pointer;
+			Initialize ();
+		}
+
+
+		internal void Initialize ()
+		{
+			m->SType = StructureType.PhysicalDeviceDepthClipEnableFeaturesExt;
+		}
+
+	}
+
+	unsafe public partial class PipelineRasterizationDepthClipStateCreateInfoExt : MarshalledObject
+	{
+		public UInt32 Flags {
+			get { return m->Flags; }
+			set { m->Flags = value; }
+		}
+
+		public bool DepthClipEnable {
+			get { return m->DepthClipEnable; }
+			set { m->DepthClipEnable = value; }
+		}
+
+		internal Interop.PipelineRasterizationDepthClipStateCreateInfoExt* m {
+			get {
+				return (Interop.PipelineRasterizationDepthClipStateCreateInfoExt*)native.Handle;
+			}
+		}
+
+		public PipelineRasterizationDepthClipStateCreateInfoExt ()
+		{
+			native = Interop.Structure.Allocate (typeof (Interop.PipelineRasterizationDepthClipStateCreateInfoExt));
+			Initialize ();
+		}
+
+		internal PipelineRasterizationDepthClipStateCreateInfoExt (NativePointer pointer)
+		{
+			native = pointer;
+			Initialize ();
+		}
+
+
+		internal void Initialize ()
+		{
+			m->SType = StructureType.PipelineRasterizationDepthClipStateCreateInfoExt;
+		}
+
+	}
+
+	unsafe public partial class PhysicalDeviceMemoryPriorityFeaturesExt : MarshalledObject
+	{
+		public bool MemoryPriority {
+			get { return m->MemoryPriority; }
+			set { m->MemoryPriority = value; }
+		}
+
+		internal Interop.PhysicalDeviceMemoryPriorityFeaturesExt* m {
+			get {
+				return (Interop.PhysicalDeviceMemoryPriorityFeaturesExt*)native.Handle;
+			}
+		}
+
+		public PhysicalDeviceMemoryPriorityFeaturesExt ()
+		{
+			native = Interop.Structure.Allocate (typeof (Interop.PhysicalDeviceMemoryPriorityFeaturesExt));
+			Initialize ();
+		}
+
+		internal PhysicalDeviceMemoryPriorityFeaturesExt (NativePointer pointer)
+		{
+			native = pointer;
+			Initialize ();
+		}
+
+
+		internal void Initialize ()
+		{
+			m->SType = StructureType.PhysicalDeviceMemoryPriorityFeaturesExt;
+		}
+
+	}
+
+	unsafe public partial class MemoryPriorityAllocateInfoExt : MarshalledObject
+	{
+		public float Priority {
+			get { return m->Priority; }
+			set { m->Priority = value; }
+		}
+
+		internal Interop.MemoryPriorityAllocateInfoExt* m {
+			get {
+				return (Interop.MemoryPriorityAllocateInfoExt*)native.Handle;
+			}
+		}
+
+		public MemoryPriorityAllocateInfoExt ()
+		{
+			native = Interop.Structure.Allocate (typeof (Interop.MemoryPriorityAllocateInfoExt));
+			Initialize ();
+		}
+
+		internal MemoryPriorityAllocateInfoExt (NativePointer pointer)
+		{
+			native = pointer;
+			Initialize ();
+		}
+
+
+		internal void Initialize ()
+		{
+			m->SType = StructureType.MemoryPriorityAllocateInfoExt;
+		}
+
+	}
+
+	unsafe public partial class PhysicalDeviceBufferDeviceAddressFeaturesExt : MarshalledObject
+	{
+		public bool BufferDeviceAddress {
+			get { return m->BufferDeviceAddress; }
+			set { m->BufferDeviceAddress = value; }
+		}
+
+		public bool BufferDeviceAddressCaptureReplay {
+			get { return m->BufferDeviceAddressCaptureReplay; }
+			set { m->BufferDeviceAddressCaptureReplay = value; }
+		}
+
+		public bool BufferDeviceAddressMultiDevice {
+			get { return m->BufferDeviceAddressMultiDevice; }
+			set { m->BufferDeviceAddressMultiDevice = value; }
+		}
+
+		internal Interop.PhysicalDeviceBufferDeviceAddressFeaturesExt* m {
+			get {
+				return (Interop.PhysicalDeviceBufferDeviceAddressFeaturesExt*)native.Handle;
+			}
+		}
+
+		public PhysicalDeviceBufferDeviceAddressFeaturesExt ()
+		{
+			native = Interop.Structure.Allocate (typeof (Interop.PhysicalDeviceBufferDeviceAddressFeaturesExt));
+			Initialize ();
+		}
+
+		internal PhysicalDeviceBufferDeviceAddressFeaturesExt (NativePointer pointer)
+		{
+			native = pointer;
+			Initialize ();
+		}
+
+
+		internal void Initialize ()
+		{
+			m->SType = StructureType.PhysicalDeviceBufferDeviceAddressFeaturesExt;
+		}
+
+	}
+
+	unsafe public partial class PhysicalDeviceBufferAddressFeaturesExt : PhysicalDeviceBufferDeviceAddressFeaturesExt
+	{
+		public PhysicalDeviceBufferAddressFeaturesExt () : base () {
+		}
+
+		internal PhysicalDeviceBufferAddressFeaturesExt (NativePointer pointer) : base (pointer) {
+		}
+
+	}
+
+	unsafe public partial class BufferDeviceAddressInfoExt : MarshalledObject
+	{
+		Buffer lBuffer;
+		public Buffer Buffer {
+			get { return lBuffer; }
+			set { lBuffer = value; m->Buffer = value != null ? (UInt64)value.m : default(UInt64); }
+		}
+
+		internal Interop.BufferDeviceAddressInfoExt* m {
+			get {
+				return (Interop.BufferDeviceAddressInfoExt*)native.Handle;
+			}
+		}
+
+		public BufferDeviceAddressInfoExt ()
+		{
+			native = Interop.Structure.Allocate (typeof (Interop.BufferDeviceAddressInfoExt));
+			Initialize ();
+		}
+
+		internal BufferDeviceAddressInfoExt (NativePointer pointer)
+		{
+			native = pointer;
+			Initialize ();
+		}
+
+
+		internal void Initialize ()
+		{
+			m->SType = StructureType.BufferDeviceAddressInfoExt;
+		}
+
+	}
+
+	unsafe public partial class BufferDeviceAddressCreateInfoExt : MarshalledObject
+	{
+		public DeviceAddress DeviceAddress {
+			get { return m->DeviceAddress; }
+			set { m->DeviceAddress = value; }
+		}
+
+		internal Interop.BufferDeviceAddressCreateInfoExt* m {
+			get {
+				return (Interop.BufferDeviceAddressCreateInfoExt*)native.Handle;
+			}
+		}
+
+		public BufferDeviceAddressCreateInfoExt ()
+		{
+			native = Interop.Structure.Allocate (typeof (Interop.BufferDeviceAddressCreateInfoExt));
+			Initialize ();
+		}
+
+		internal BufferDeviceAddressCreateInfoExt (NativePointer pointer)
+		{
+			native = pointer;
+			Initialize ();
+		}
+
+
+		internal void Initialize ()
+		{
+			m->SType = StructureType.BufferDeviceAddressCreateInfoExt;
+		}
+
+	}
+
+	unsafe public partial class PhysicalDeviceImageViewImageFormatInfoExt : MarshalledObject
+	{
+		public ImageViewType ImageViewType {
+			get { return m->ImageViewType; }
+			set { m->ImageViewType = value; }
+		}
+
+		internal Interop.PhysicalDeviceImageViewImageFormatInfoExt* m {
+			get {
+				return (Interop.PhysicalDeviceImageViewImageFormatInfoExt*)native.Handle;
+			}
+		}
+
+		public PhysicalDeviceImageViewImageFormatInfoExt ()
+		{
+			native = Interop.Structure.Allocate (typeof (Interop.PhysicalDeviceImageViewImageFormatInfoExt));
+			Initialize ();
+		}
+
+		internal PhysicalDeviceImageViewImageFormatInfoExt (NativePointer pointer)
+		{
+			native = pointer;
+			Initialize ();
+		}
+
+
+		internal void Initialize ()
+		{
+			m->SType = StructureType.PhysicalDeviceImageViewImageFormatInfoExt;
+		}
+
+	}
+
+	unsafe public partial class FilterCubicImageViewImageFormatPropertiesExt : MarshalledObject
+	{
+		public bool FilterCubic {
+			get { return m->FilterCubic; }
+			set { m->FilterCubic = value; }
+		}
+
+		public bool FilterCubicMinmax {
+			get { return m->FilterCubicMinmax; }
+			set { m->FilterCubicMinmax = value; }
+		}
+
+		internal Interop.FilterCubicImageViewImageFormatPropertiesExt* m {
+			get {
+				return (Interop.FilterCubicImageViewImageFormatPropertiesExt*)native.Handle;
+			}
+		}
+
+		public FilterCubicImageViewImageFormatPropertiesExt ()
+		{
+			native = Interop.Structure.Allocate (typeof (Interop.FilterCubicImageViewImageFormatPropertiesExt));
+			Initialize ();
+		}
+
+		internal FilterCubicImageViewImageFormatPropertiesExt (NativePointer pointer)
+		{
+			native = pointer;
+			Initialize ();
+		}
+
+
+		internal void Initialize ()
+		{
+			m->SType = StructureType.FilterCubicImageViewImageFormatPropertiesExt;
+		}
+
+	}
+
+	unsafe public partial class PhysicalDeviceCooperativeMatrixFeaturesNv : MarshalledObject
+	{
+		public bool CooperativeMatrix {
+			get { return m->CooperativeMatrix; }
+			set { m->CooperativeMatrix = value; }
+		}
+
+		public bool CooperativeMatrixRobustBufferAccess {
+			get { return m->CooperativeMatrixRobustBufferAccess; }
+			set { m->CooperativeMatrixRobustBufferAccess = value; }
+		}
+
+		internal Interop.PhysicalDeviceCooperativeMatrixFeaturesNv* m {
+			get {
+				return (Interop.PhysicalDeviceCooperativeMatrixFeaturesNv*)native.Handle;
+			}
+		}
+
+		public PhysicalDeviceCooperativeMatrixFeaturesNv ()
+		{
+			native = Interop.Structure.Allocate (typeof (Interop.PhysicalDeviceCooperativeMatrixFeaturesNv));
+			Initialize ();
+		}
+
+		internal PhysicalDeviceCooperativeMatrixFeaturesNv (NativePointer pointer)
+		{
+			native = pointer;
+			Initialize ();
+		}
+
+
+		internal void Initialize ()
+		{
+			m->SType = StructureType.PhysicalDeviceCooperativeMatrixFeaturesNv;
+		}
+
+	}
+
+	unsafe public partial class PhysicalDeviceCooperativeMatrixPropertiesNv : MarshalledObject
+	{
+		public ShaderStageFlags CooperativeMatrixSupportedStages {
+			get { return m->CooperativeMatrixSupportedStages; }
+			set { m->CooperativeMatrixSupportedStages = value; }
+		}
+
+		internal Interop.PhysicalDeviceCooperativeMatrixPropertiesNv* m {
+			get {
+				return (Interop.PhysicalDeviceCooperativeMatrixPropertiesNv*)native.Handle;
+			}
+		}
+
+		public PhysicalDeviceCooperativeMatrixPropertiesNv ()
+		{
+			native = Interop.Structure.Allocate (typeof (Interop.PhysicalDeviceCooperativeMatrixPropertiesNv));
+			Initialize ();
+		}
+
+		internal PhysicalDeviceCooperativeMatrixPropertiesNv (NativePointer pointer)
+		{
+			native = pointer;
+			Initialize ();
+		}
+
+
+		internal void Initialize ()
+		{
+			m->SType = StructureType.PhysicalDeviceCooperativeMatrixPropertiesNv;
+		}
+
+	}
+
+	unsafe public partial class CooperativeMatrixPropertiesNv : MarshalledObject
+	{
+		public UInt32 Msize {
+			get { return m->Msize; }
+			set { m->Msize = value; }
+		}
+
+		public UInt32 Nsize {
+			get { return m->Nsize; }
+			set { m->Nsize = value; }
+		}
+
+		public UInt32 Ksize {
+			get { return m->Ksize; }
+			set { m->Ksize = value; }
+		}
+
+		public ComponentTypeNv Atype {
+			get { return m->Atype; }
+			set { m->Atype = value; }
+		}
+
+		public ComponentTypeNv Btype {
+			get { return m->Btype; }
+			set { m->Btype = value; }
+		}
+
+		public ComponentTypeNv Ctype {
+			get { return m->Ctype; }
+			set { m->Ctype = value; }
+		}
+
+		public ComponentTypeNv Dtype {
+			get { return m->Dtype; }
+			set { m->Dtype = value; }
+		}
+
+		public ScopeNv Scope {
+			get { return m->Scope; }
+			set { m->Scope = value; }
+		}
+
+		internal Interop.CooperativeMatrixPropertiesNv* m {
+			get {
+				return (Interop.CooperativeMatrixPropertiesNv*)native.Handle;
+			}
+		}
+
+		public CooperativeMatrixPropertiesNv ()
+		{
+			native = Interop.Structure.Allocate (typeof (Interop.CooperativeMatrixPropertiesNv));
+			Initialize ();
+		}
+
+		internal CooperativeMatrixPropertiesNv (NativePointer pointer)
+		{
+			native = pointer;
+			Initialize ();
+		}
+
+
+		internal void Initialize ()
+		{
+			m->SType = StructureType.CooperativeMatrixPropertiesNv;
+		}
+
+	}
+
+	unsafe public partial class PhysicalDeviceYcbcrImageArraysFeaturesExt : MarshalledObject
+	{
+		public bool YcbcrImageArrays {
+			get { return m->YcbcrImageArrays; }
+			set { m->YcbcrImageArrays = value; }
+		}
+
+		internal Interop.PhysicalDeviceYcbcrImageArraysFeaturesExt* m {
+			get {
+				return (Interop.PhysicalDeviceYcbcrImageArraysFeaturesExt*)native.Handle;
+			}
+		}
+
+		public PhysicalDeviceYcbcrImageArraysFeaturesExt ()
+		{
+			native = Interop.Structure.Allocate (typeof (Interop.PhysicalDeviceYcbcrImageArraysFeaturesExt));
+			Initialize ();
+		}
+
+		internal PhysicalDeviceYcbcrImageArraysFeaturesExt (NativePointer pointer)
+		{
+			native = pointer;
+			Initialize ();
+		}
+
+
+		internal void Initialize ()
+		{
+			m->SType = StructureType.PhysicalDeviceYcbcrImageArraysFeaturesExt;
+		}
+
+	}
+
+	unsafe public partial class ImageViewHandleInfoNvx : MarshalledObject
+	{
+		ImageView lImageView;
+		public ImageView ImageView {
+			get { return lImageView; }
+			set { lImageView = value; m->ImageView = value != null ? (UInt64)value.m : default(UInt64); }
+		}
+
+		public DescriptorType DescriptorType {
+			get { return m->DescriptorType; }
+			set { m->DescriptorType = value; }
+		}
+
+		Sampler lSampler;
+		public Sampler Sampler {
+			get { return lSampler; }
+			set { lSampler = value; m->Sampler = value != null ? (UInt64)value.m : default(UInt64); }
+		}
+
+		internal Interop.ImageViewHandleInfoNvx* m {
+			get {
+				return (Interop.ImageViewHandleInfoNvx*)native.Handle;
+			}
+		}
+
+		public ImageViewHandleInfoNvx ()
+		{
+			native = Interop.Structure.Allocate (typeof (Interop.ImageViewHandleInfoNvx));
+			Initialize ();
+		}
+
+		internal ImageViewHandleInfoNvx (NativePointer pointer)
+		{
+			native = pointer;
+			Initialize ();
+		}
+
+
+		internal void Initialize ()
+		{
+			m->SType = StructureType.ImageViewHandleInfoNvx;
+		}
+
+	}
+
+	unsafe public partial class PresentFrameTokenGGP : MarshalledObject
+	{
+		public int FrameToken {
+			get { return m->FrameToken; }
+			set { m->FrameToken = value; }
+		}
+
+		internal Interop.PresentFrameTokenGGP* m {
+			get {
+				return (Interop.PresentFrameTokenGGP*)native.Handle;
+			}
+		}
+
+		public PresentFrameTokenGGP ()
+		{
+			native = Interop.Structure.Allocate (typeof (Interop.PresentFrameTokenGGP));
+			Initialize ();
+		}
+
+		internal PresentFrameTokenGGP (NativePointer pointer)
+		{
+			native = pointer;
+			Initialize ();
+		}
+
+
+		internal void Initialize ()
+		{
+			m->SType = StructureType.PresentFrameTokenGGP;
+		}
+
+	}
+
+	unsafe public partial struct PipelineCreationFeedbackExt
+	{
+		public PipelineCreationFeedbackFlagsExt Flags;
+		public UInt64 Duration;
+	}
+
+	unsafe public partial class PipelineCreationFeedbackCreateInfoExt : MarshalledObject
+	{
+		public PipelineCreationFeedbackExt PipelineCreationFeedback {
+			get { return (PipelineCreationFeedbackExt)Interop.Structure.MarshalPointerToObject (m->PipelineCreationFeedback, typeof (PipelineCreationFeedbackExt)); }
+			set { m->PipelineCreationFeedback = Interop.Structure.MarshalObjectToPointer (m->PipelineCreationFeedback, value); }
+		}
+
+		public UInt32 PipelineStageCreationFeedbackCount {
+			get { return m->PipelineStageCreationFeedbackCount; }
+			set { m->PipelineStageCreationFeedbackCount = value; }
+		}
+
+		NativeReference refPipelineStageCreationFeedbacks;
+		public PipelineCreationFeedbackExt[] PipelineStageCreationFeedbacks {
+			get {
+				if (m->PipelineStageCreationFeedbackCount == 0)
+					return null;
+				var values = new PipelineCreationFeedbackExt [m->PipelineStageCreationFeedbackCount];
+				unsafe
+				{
+					PipelineCreationFeedbackExt* ptr = (PipelineCreationFeedbackExt*)m->PipelineStageCreationFeedbacks;
+					for (int i = 0; i < values.Length; i++) 
+						values [i] = ptr [i];
+				}
+				return values;
+			}
+
+			set {
+				if (value == null) {
+					m->PipelineStageCreationFeedbackCount = 0;
+					m->PipelineStageCreationFeedbacks = IntPtr.Zero;
+					return;
+				}
+				m->PipelineStageCreationFeedbackCount = (uint)value.Length;
+				refPipelineStageCreationFeedbacks = new NativeReference ((int)(sizeof(PipelineCreationFeedbackExt)*value.Length));
+				m->PipelineStageCreationFeedbacks = refPipelineStageCreationFeedbacks.Handle;
+				unsafe
+				{
+					PipelineCreationFeedbackExt* ptr = (PipelineCreationFeedbackExt*)m->PipelineStageCreationFeedbacks;
+					for (int i = 0; i < value.Length; i++)
+						ptr [i] = value [i];
+				}
+			}
+		}
+
+		internal Interop.PipelineCreationFeedbackCreateInfoExt* m {
+			get {
+				return (Interop.PipelineCreationFeedbackCreateInfoExt*)native.Handle;
+			}
+		}
+
+		public PipelineCreationFeedbackCreateInfoExt ()
+		{
+			native = Interop.Structure.Allocate (typeof (Interop.PipelineCreationFeedbackCreateInfoExt));
+			Initialize ();
+		}
+
+		internal PipelineCreationFeedbackCreateInfoExt (NativePointer pointer)
+		{
+			native = pointer;
+			Initialize ();
+		}
+
+		override public void Dispose (bool disposing)
+		{
+			base.Dispose (disposing);
+			if (!disposing)
+				return;
+			refPipelineStageCreationFeedbacks.Dispose ();
+			refPipelineStageCreationFeedbacks = null;
+		}
+
+		internal void Initialize ()
+		{
+			m->SType = StructureType.PipelineCreationFeedbackCreateInfoExt;
+		}
+
+	}
+
+	unsafe public partial class SurfaceFullScreenExclusiveInfoExt : MarshalledObject
+	{
+		public FullScreenExclusiveExt FullScreenExclusive {
+			get { return m->FullScreenExclusive; }
+			set { m->FullScreenExclusive = value; }
+		}
+
+		internal Interop.SurfaceFullScreenExclusiveInfoExt* m {
+			get {
+				return (Interop.SurfaceFullScreenExclusiveInfoExt*)native.Handle;
+			}
+		}
+
+		public SurfaceFullScreenExclusiveInfoExt ()
+		{
+			native = Interop.Structure.Allocate (typeof (Interop.SurfaceFullScreenExclusiveInfoExt));
+			Initialize ();
+		}
+
+		internal SurfaceFullScreenExclusiveInfoExt (NativePointer pointer)
+		{
+			native = pointer;
+			Initialize ();
+		}
+
+
+		internal void Initialize ()
+		{
+			m->SType = StructureType.SurfaceFullScreenExclusiveInfoExt;
+		}
+
+	}
+
+	unsafe public partial class SurfaceFullScreenExclusiveWin32InfoExt : MarshalledObject
+	{
+		public IntPtr Hmonitor {
+			get { return m->Hmonitor; }
+			set { m->Hmonitor = value; }
+		}
+
+		internal Interop.SurfaceFullScreenExclusiveWin32InfoExt* m {
+			get {
+				return (Interop.SurfaceFullScreenExclusiveWin32InfoExt*)native.Handle;
+			}
+		}
+
+		public SurfaceFullScreenExclusiveWin32InfoExt ()
+		{
+			native = Interop.Structure.Allocate (typeof (Interop.SurfaceFullScreenExclusiveWin32InfoExt));
+			Initialize ();
+		}
+
+		internal SurfaceFullScreenExclusiveWin32InfoExt (NativePointer pointer)
+		{
+			native = pointer;
+			Initialize ();
+		}
+
+
+		internal void Initialize ()
+		{
+			m->SType = StructureType.SurfaceFullScreenExclusiveWin32InfoExt;
+		}
+
+	}
+
+	unsafe public partial class SurfaceCapabilitiesFullScreenExclusiveExt : MarshalledObject
+	{
+		public bool FullScreenExclusiveSupported {
+			get { return m->FullScreenExclusiveSupported; }
+			set { m->FullScreenExclusiveSupported = value; }
+		}
+
+		internal Interop.SurfaceCapabilitiesFullScreenExclusiveExt* m {
+			get {
+				return (Interop.SurfaceCapabilitiesFullScreenExclusiveExt*)native.Handle;
+			}
+		}
+
+		public SurfaceCapabilitiesFullScreenExclusiveExt ()
+		{
+			native = Interop.Structure.Allocate (typeof (Interop.SurfaceCapabilitiesFullScreenExclusiveExt));
+			Initialize ();
+		}
+
+		internal SurfaceCapabilitiesFullScreenExclusiveExt (NativePointer pointer)
+		{
+			native = pointer;
+			Initialize ();
+		}
+
+
+		internal void Initialize ()
+		{
+			m->SType = StructureType.SurfaceCapabilitiesFullScreenExclusiveExt;
+		}
+
+	}
+
+	unsafe public partial class HeadlessSurfaceCreateInfoExt : MarshalledObject
+	{
+		public UInt32 Flags {
+			get { return m->Flags; }
+			set { m->Flags = value; }
+		}
+
+		internal Interop.HeadlessSurfaceCreateInfoExt* m {
+			get {
+				return (Interop.HeadlessSurfaceCreateInfoExt*)native.Handle;
+			}
+		}
+
+		public HeadlessSurfaceCreateInfoExt ()
+		{
+			native = Interop.Structure.Allocate (typeof (Interop.HeadlessSurfaceCreateInfoExt));
+			Initialize ();
+		}
+
+		internal HeadlessSurfaceCreateInfoExt (NativePointer pointer)
+		{
+			native = pointer;
+			Initialize ();
+		}
+
+
+		internal void Initialize ()
+		{
+			m->SType = StructureType.HeadlessSurfaceCreateInfoExt;
+		}
+
+	}
+
+	unsafe public partial class PhysicalDeviceCoverageReductionModeFeaturesNv : MarshalledObject
+	{
+		public bool CoverageReductionMode {
+			get { return m->CoverageReductionMode; }
+			set { m->CoverageReductionMode = value; }
+		}
+
+		internal Interop.PhysicalDeviceCoverageReductionModeFeaturesNv* m {
+			get {
+				return (Interop.PhysicalDeviceCoverageReductionModeFeaturesNv*)native.Handle;
+			}
+		}
+
+		public PhysicalDeviceCoverageReductionModeFeaturesNv ()
+		{
+			native = Interop.Structure.Allocate (typeof (Interop.PhysicalDeviceCoverageReductionModeFeaturesNv));
+			Initialize ();
+		}
+
+		internal PhysicalDeviceCoverageReductionModeFeaturesNv (NativePointer pointer)
+		{
+			native = pointer;
+			Initialize ();
+		}
+
+
+		internal void Initialize ()
+		{
+			m->SType = StructureType.PhysicalDeviceCoverageReductionModeFeaturesNv;
+		}
+
+	}
+
+	unsafe public partial class PipelineCoverageReductionStateCreateInfoNv : MarshalledObject
+	{
+		public UInt32 Flags {
+			get { return m->Flags; }
+			set { m->Flags = value; }
+		}
+
+		public CoverageReductionModeNv CoverageReductionMode {
+			get { return m->CoverageReductionMode; }
+			set { m->CoverageReductionMode = value; }
+		}
+
+		internal Interop.PipelineCoverageReductionStateCreateInfoNv* m {
+			get {
+				return (Interop.PipelineCoverageReductionStateCreateInfoNv*)native.Handle;
+			}
+		}
+
+		public PipelineCoverageReductionStateCreateInfoNv ()
+		{
+			native = Interop.Structure.Allocate (typeof (Interop.PipelineCoverageReductionStateCreateInfoNv));
+			Initialize ();
+		}
+
+		internal PipelineCoverageReductionStateCreateInfoNv (NativePointer pointer)
+		{
+			native = pointer;
+			Initialize ();
+		}
+
+
+		internal void Initialize ()
+		{
+			m->SType = StructureType.PipelineCoverageReductionStateCreateInfoNv;
+		}
+
+	}
+
+	unsafe public partial class FramebufferMixedSamplesCombinationNv : MarshalledObject
+	{
+		public CoverageReductionModeNv CoverageReductionMode {
+			get { return m->CoverageReductionMode; }
+			set { m->CoverageReductionMode = value; }
+		}
+
+		public SampleCountFlags RasterizationSamples {
+			get { return m->RasterizationSamples; }
+			set { m->RasterizationSamples = value; }
+		}
+
+		public SampleCountFlags DepthStencilSamples {
+			get { return m->DepthStencilSamples; }
+			set { m->DepthStencilSamples = value; }
+		}
+
+		public SampleCountFlags ColorSamples {
+			get { return m->ColorSamples; }
+			set { m->ColorSamples = value; }
+		}
+
+		internal Interop.FramebufferMixedSamplesCombinationNv* m {
+			get {
+				return (Interop.FramebufferMixedSamplesCombinationNv*)native.Handle;
+			}
+		}
+
+		public FramebufferMixedSamplesCombinationNv ()
+		{
+			native = Interop.Structure.Allocate (typeof (Interop.FramebufferMixedSamplesCombinationNv));
+			Initialize ();
+		}
+
+		internal FramebufferMixedSamplesCombinationNv (NativePointer pointer)
+		{
+			native = pointer;
+			Initialize ();
+		}
+
+
+		internal void Initialize ()
+		{
+			m->SType = StructureType.FramebufferMixedSamplesCombinationNv;
+		}
+
+	}
+
+	unsafe public partial class PhysicalDeviceShaderIntegerFunctions2Intel : MarshalledObject
+	{
+		public bool ShaderIntegerFunctions2 {
+			get { return m->ShaderIntegerFunctions2; }
+			set { m->ShaderIntegerFunctions2 = value; }
+		}
+
+		internal Interop.PhysicalDeviceShaderIntegerFunctions2Intel* m {
+			get {
+				return (Interop.PhysicalDeviceShaderIntegerFunctions2Intel*)native.Handle;
+			}
+		}
+
+		public PhysicalDeviceShaderIntegerFunctions2Intel ()
+		{
+			native = Interop.Structure.Allocate (typeof (Interop.PhysicalDeviceShaderIntegerFunctions2Intel));
+			Initialize ();
+		}
+
+		internal PhysicalDeviceShaderIntegerFunctions2Intel (NativePointer pointer)
+		{
+			native = pointer;
+			Initialize ();
+		}
+
+
+		internal void Initialize ()
+		{
+			m->SType = StructureType.PhysicalDeviceShaderIntegerFunctions2FeaturesIntel;
+		}
+
+	}
+
+	unsafe public partial class PerformanceValueIntel : MarshalledObject
+	{
+		public PerformanceValueTypeIntel Type {
+			get { return m->Type; }
+			set { m->Type = value; }
+		}
+
+		PerformanceValueDataIntel lData;
+		public PerformanceValueDataIntel Data {
+			get { return lData; }
+			set { lData = value; m->Data = value != null ? *value.m : default(Interop.PerformanceValueDataIntel); }
+		}
+
+		internal Interop.PerformanceValueIntel* m {
+			get {
+				return (Interop.PerformanceValueIntel*)native.Handle;
+			}
+		}
+
+		public PerformanceValueIntel ()
+		{
+			native = Interop.Structure.Allocate (typeof (Interop.PerformanceValueIntel));
+			Initialize ();
+		}
+
+		internal PerformanceValueIntel (NativePointer pointer)
+		{
+			native = pointer;
+			Initialize ();
+		}
+
+
+		internal void Initialize ()
+		{
+			lData = new PerformanceValueDataIntel (new NativePointer (native.Reference, (IntPtr)(&m->Data)));
+		}
+
+	}
+
+	unsafe public partial class InitializePerformanceApiInfoIntel : MarshalledObject
+	{
+		public IntPtr UserData {
+			get { return m->UserData; }
+			set { m->UserData = value; }
+		}
+
+		internal Interop.InitializePerformanceApiInfoIntel* m {
+			get {
+				return (Interop.InitializePerformanceApiInfoIntel*)native.Handle;
+			}
+		}
+
+		public InitializePerformanceApiInfoIntel ()
+		{
+			native = Interop.Structure.Allocate (typeof (Interop.InitializePerformanceApiInfoIntel));
+			Initialize ();
+		}
+
+		internal InitializePerformanceApiInfoIntel (NativePointer pointer)
+		{
+			native = pointer;
+			Initialize ();
+		}
+
+
+		internal void Initialize ()
+		{
+			m->SType = StructureType.InitializePerformanceApiInfoIntel;
+		}
+
+	}
+
+	unsafe public partial class QueryPoolCreateInfoIntel : MarshalledObject
+	{
+		public QueryPoolSamplingModeIntel PerformanceCountersSampling {
+			get { return m->PerformanceCountersSampling; }
+			set { m->PerformanceCountersSampling = value; }
+		}
+
+		internal Interop.QueryPoolCreateInfoIntel* m {
+			get {
+				return (Interop.QueryPoolCreateInfoIntel*)native.Handle;
+			}
+		}
+
+		public QueryPoolCreateInfoIntel ()
+		{
+			native = Interop.Structure.Allocate (typeof (Interop.QueryPoolCreateInfoIntel));
+			Initialize ();
+		}
+
+		internal QueryPoolCreateInfoIntel (NativePointer pointer)
+		{
+			native = pointer;
+			Initialize ();
+		}
+
+
+		internal void Initialize ()
+		{
+			m->SType = StructureType.QueryPoolCreateInfoIntel;
+		}
+
+	}
+
+	unsafe public partial class PerformanceMarkerInfoIntel : MarshalledObject
+	{
+		public UInt64 Marker {
+			get { return m->Marker; }
+			set { m->Marker = value; }
+		}
+
+		internal Interop.PerformanceMarkerInfoIntel* m {
+			get {
+				return (Interop.PerformanceMarkerInfoIntel*)native.Handle;
+			}
+		}
+
+		public PerformanceMarkerInfoIntel ()
+		{
+			native = Interop.Structure.Allocate (typeof (Interop.PerformanceMarkerInfoIntel));
+			Initialize ();
+		}
+
+		internal PerformanceMarkerInfoIntel (NativePointer pointer)
+		{
+			native = pointer;
+			Initialize ();
+		}
+
+
+		internal void Initialize ()
+		{
+			m->SType = StructureType.PerformanceMarkerInfoIntel;
+		}
+
+	}
+
+	unsafe public partial class PerformanceStreamMarkerInfoIntel : MarshalledObject
+	{
+		public UInt32 Marker {
+			get { return m->Marker; }
+			set { m->Marker = value; }
+		}
+
+		internal Interop.PerformanceStreamMarkerInfoIntel* m {
+			get {
+				return (Interop.PerformanceStreamMarkerInfoIntel*)native.Handle;
+			}
+		}
+
+		public PerformanceStreamMarkerInfoIntel ()
+		{
+			native = Interop.Structure.Allocate (typeof (Interop.PerformanceStreamMarkerInfoIntel));
+			Initialize ();
+		}
+
+		internal PerformanceStreamMarkerInfoIntel (NativePointer pointer)
+		{
+			native = pointer;
+			Initialize ();
+		}
+
+
+		internal void Initialize ()
+		{
+			m->SType = StructureType.PerformanceStreamMarkerInfoIntel;
+		}
+
+	}
+
+	unsafe public partial class PerformanceOverrideInfoIntel : MarshalledObject
+	{
+		public PerformanceOverrideTypeIntel Type {
+			get { return m->Type; }
+			set { m->Type = value; }
+		}
+
+		public bool Enable {
+			get { return m->Enable; }
+			set { m->Enable = value; }
+		}
+
+		public UInt64 Parameter {
+			get { return m->Parameter; }
+			set { m->Parameter = value; }
+		}
+
+		internal Interop.PerformanceOverrideInfoIntel* m {
+			get {
+				return (Interop.PerformanceOverrideInfoIntel*)native.Handle;
+			}
+		}
+
+		public PerformanceOverrideInfoIntel ()
+		{
+			native = Interop.Structure.Allocate (typeof (Interop.PerformanceOverrideInfoIntel));
+			Initialize ();
+		}
+
+		internal PerformanceOverrideInfoIntel (NativePointer pointer)
+		{
+			native = pointer;
+			Initialize ();
+		}
+
+
+		internal void Initialize ()
+		{
+			m->SType = StructureType.PerformanceOverrideInfoIntel;
+		}
+
+	}
+
+	unsafe public partial class PerformanceConfigurationAcquireInfoIntel : MarshalledObject
+	{
+		public PerformanceConfigurationTypeIntel Type {
+			get { return m->Type; }
+			set { m->Type = value; }
+		}
+
+		internal Interop.PerformanceConfigurationAcquireInfoIntel* m {
+			get {
+				return (Interop.PerformanceConfigurationAcquireInfoIntel*)native.Handle;
+			}
+		}
+
+		public PerformanceConfigurationAcquireInfoIntel ()
+		{
+			native = Interop.Structure.Allocate (typeof (Interop.PerformanceConfigurationAcquireInfoIntel));
+			Initialize ();
+		}
+
+		internal PerformanceConfigurationAcquireInfoIntel (NativePointer pointer)
+		{
+			native = pointer;
+			Initialize ();
+		}
+
+
+		internal void Initialize ()
+		{
+			m->SType = StructureType.PerformanceConfigurationAcquireInfoIntel;
+		}
+
+	}
+
+	unsafe public partial class PhysicalDeviceShaderSMBuiltinsPropertiesNv : MarshalledObject
+	{
+		public UInt32 ShaderSmcount {
+			get { return m->ShaderSmcount; }
+			set { m->ShaderSmcount = value; }
+		}
+
+		public UInt32 ShaderWarpsPerSm {
+			get { return m->ShaderWarpsPerSm; }
+			set { m->ShaderWarpsPerSm = value; }
+		}
+
+		internal Interop.PhysicalDeviceShaderSMBuiltinsPropertiesNv* m {
+			get {
+				return (Interop.PhysicalDeviceShaderSMBuiltinsPropertiesNv*)native.Handle;
+			}
+		}
+
+		public PhysicalDeviceShaderSMBuiltinsPropertiesNv ()
+		{
+			native = Interop.Structure.Allocate (typeof (Interop.PhysicalDeviceShaderSMBuiltinsPropertiesNv));
+			Initialize ();
+		}
+
+		internal PhysicalDeviceShaderSMBuiltinsPropertiesNv (NativePointer pointer)
+		{
+			native = pointer;
+			Initialize ();
+		}
+
+
+		internal void Initialize ()
+		{
+			m->SType = StructureType.PhysicalDeviceShaderSMBuiltinsPropertiesNv;
+		}
+
+	}
+
+	unsafe public partial class PhysicalDeviceShaderSMBuiltinsFeaturesNv : MarshalledObject
+	{
+		public bool ShaderSmbuiltins {
+			get { return m->ShaderSmbuiltins; }
+			set { m->ShaderSmbuiltins = value; }
+		}
+
+		internal Interop.PhysicalDeviceShaderSMBuiltinsFeaturesNv* m {
+			get {
+				return (Interop.PhysicalDeviceShaderSMBuiltinsFeaturesNv*)native.Handle;
+			}
+		}
+
+		public PhysicalDeviceShaderSMBuiltinsFeaturesNv ()
+		{
+			native = Interop.Structure.Allocate (typeof (Interop.PhysicalDeviceShaderSMBuiltinsFeaturesNv));
+			Initialize ();
+		}
+
+		internal PhysicalDeviceShaderSMBuiltinsFeaturesNv (NativePointer pointer)
+		{
+			native = pointer;
+			Initialize ();
+		}
+
+
+		internal void Initialize ()
+		{
+			m->SType = StructureType.PhysicalDeviceShaderSMBuiltinsFeaturesNv;
+		}
+
+	}
+
+	unsafe public partial class PhysicalDeviceFragmentShaderInterlockFeaturesExt : MarshalledObject
+	{
+		public bool FragmentShaderSampleInterlock {
+			get { return m->FragmentShaderSampleInterlock; }
+			set { m->FragmentShaderSampleInterlock = value; }
+		}
+
+		public bool FragmentShaderPixelInterlock {
+			get { return m->FragmentShaderPixelInterlock; }
+			set { m->FragmentShaderPixelInterlock = value; }
+		}
+
+		public bool FragmentShaderShadingRateInterlock {
+			get { return m->FragmentShaderShadingRateInterlock; }
+			set { m->FragmentShaderShadingRateInterlock = value; }
+		}
+
+		internal Interop.PhysicalDeviceFragmentShaderInterlockFeaturesExt* m {
+			get {
+				return (Interop.PhysicalDeviceFragmentShaderInterlockFeaturesExt*)native.Handle;
+			}
+		}
+
+		public PhysicalDeviceFragmentShaderInterlockFeaturesExt ()
+		{
+			native = Interop.Structure.Allocate (typeof (Interop.PhysicalDeviceFragmentShaderInterlockFeaturesExt));
+			Initialize ();
+		}
+
+		internal PhysicalDeviceFragmentShaderInterlockFeaturesExt (NativePointer pointer)
+		{
+			native = pointer;
+			Initialize ();
+		}
+
+
+		internal void Initialize ()
+		{
+			m->SType = StructureType.PhysicalDeviceFragmentShaderInterlockFeaturesExt;
 		}
 
 	}

--- a/src/Vulkan/Unions.cs
+++ b/src/Vulkan/Unions.cs
@@ -68,8 +68,8 @@ namespace Vulkan
 					m->Uint32 [i] = 0;
 			}
 		}
-		internal Interop.ClearColorValue* m {
 
+		internal Interop.ClearColorValue* m {
 			get {
 				return (Interop.ClearColorValue*)native.Handle;
 			}
@@ -99,8 +99,8 @@ namespace Vulkan
 			get { return m->DepthStencil; }
 			set { m->DepthStencil = value; }
 		}
-		internal Interop.ClearValue* m {
 
+		internal Interop.ClearValue* m {
 			get {
 				return (Interop.ClearValue*)native.Handle;
 			}
@@ -122,6 +122,51 @@ namespace Vulkan
 		internal void Initialize ()
 		{
 			lColor = new ClearColorValue (new NativePointer (native.Reference, (IntPtr)(&m->Color)));
+		}
+
+	}
+
+	unsafe public partial class PerformanceValueDataIntel : MarshalledObject
+	{
+		public UInt32 Value32 {
+			get { return m->Value32; }
+			set { m->Value32 = value; }
+		}
+
+		public UInt64 Value64 {
+			get { return m->Value64; }
+			set { m->Value64 = value; }
+		}
+
+		public float ValueFloat {
+			get { return m->ValueFloat; }
+			set { m->ValueFloat = value; }
+		}
+
+		public bool ValueBool {
+			get { return m->ValueBool; }
+			set { m->ValueBool = value; }
+		}
+
+		public string ValueString {
+			get { return Marshal.PtrToStringAnsi (m->ValueString); }
+			set { m->ValueString = Marshal.StringToHGlobalAnsi (value); }
+		}
+
+		internal Interop.PerformanceValueDataIntel* m {
+			get {
+				return (Interop.PerformanceValueDataIntel*)native.Handle;
+			}
+		}
+
+		public PerformanceValueDataIntel ()
+		{
+			native = Interop.Structure.Allocate (typeof (Interop.PerformanceValueDataIntel));
+		}
+
+		internal PerformanceValueDataIntel (NativePointer pointer)
+		{
+			native = pointer;
 		}
 
 	}

--- a/src/Vulkan/Vulkan.csproj
+++ b/src/Vulkan/Vulkan.csproj
@@ -74,7 +74,7 @@
     </Task>
   </UsingTask>
   <Target Name="DownloadSpecification" Condition="'$(OS)' == 'Windows_NT'">
-    <DownloadURL URL="https://raw.githubusercontent.com/KhronosGroup/Vulkan-Docs/1.0/src/spec/vk.xml" OutputFile="$(OutputPath)\vk.xml" />
+    <DownloadURL URL="https://raw.githubusercontent.com/KhronosGroup/Vulkan-Headers/master/registry/vk.xml" OutputFile="$(OutputPath)\vk.xml" />
   </Target>
   <Target Name="BuildGeneratedSource" DependsOnTargets="DownloadSpecification" Inputs="$(OutputPath)\vk.xml;$(OutputPath)\Generator.exe" Outputs="Vulkan\Enums.cs">
     <MakeDir Directories="$(OutputPath)" />

--- a/tools/Generator/Generator.cs
+++ b/tools/Generator/Generator.cs
@@ -2160,6 +2160,8 @@ namespace VulkanSharp.Generator
 			"vkCreateIOSSurfaceMVK",
 			// TODO: support fixed array of Handles
 			"vkEnumeratePhysicalDeviceGroupsKHX",
+            "vkEnumeratePhysicalDeviceGroups",
+            "vkEnumeratePhysicalDeviceGroupsKHR",
         };
 
 		HashSet<string> delegateUnmanagedCommands = new HashSet<string> {

--- a/tools/Generator/Generator.cs
+++ b/tools/Generator/Generator.cs
@@ -803,11 +803,17 @@ namespace VulkanSharp.Generator
 			if (csMemberType.StartsWith ("PFN_"))
 				csMemberType = "IntPtr";
 
-			if (csMemberType == "SampleMask")
+            if (csMemberType == "CAMetalLayer" || csMemberType == "AHardwareBuffer")
+                csMemberType = "IntPtr";
+
+            if (csMemberType == "SampleMask")
 				csMemberType = "UInt32";
 
 			if (csMemberType == "Bool32" && !isInterop && needsMarshalling)
 				csMemberType = "bool";
+
+            if (csMemberType == "DeviceSize" || csMemberType == "DeviceAddress")
+				csMemberType = "UInt64";
 
             bool needsCharCast = false;
 			if (csMemberType == "char") {

--- a/tools/Generator/Generator.cs
+++ b/tools/Generator/Generator.cs
@@ -809,7 +809,10 @@ namespace VulkanSharp.Generator
 			if (csMemberType == "Bool32" && !isInterop && needsMarshalling)
 				csMemberType = "bool";
 
-			bool needsCharCast = false;
+            if (csMemberType == "DeviceSize" || csMemberType == "DeviceAddress")
+				csMemberType = "UInt64";
+
+            bool needsCharCast = false;
 			if (csMemberType == "char") {
 				if (isInterop || !needsMarshalling)
 					csMemberType = "byte";
@@ -958,7 +961,7 @@ namespace VulkanSharp.Generator
                     GenerateMembers (originalElement, WriteMember);
                     WriteLine ();
                     // generate the implicit conversions
-                    IndentWriteLine ("{0} static implicit operator {1} ({2} that) {{", isInterop ? "internal" : "public", csName, acsName);
+                    IndentWriteLine ("public static implicit operator {0} ({1} that) {{", csName, acsName);
                     IndentLevel++;
                     IndentWriteLine ("return new {0} {{", csName);
                     IndentLevel++;
@@ -970,7 +973,7 @@ namespace VulkanSharp.Generator
                     IndentLevel--;
                     IndentWriteLine ("}");
                     WriteLine ();
-                    IndentWriteLine ("{0} static implicit operator {1} ({2} that) {{", isInterop ? "internal" : "public", acsName, csName);
+                    IndentWriteLine ("public static implicit operator {0} ({1} that) {{", acsName, csName);
                     IndentLevel++;
                     IndentWriteLine ("return new {0} {{", acsName);
                     IndentLevel++;

--- a/tools/Generator/Generator.cs
+++ b/tools/Generator/Generator.cs
@@ -2011,6 +2011,9 @@ namespace VulkanSharp.Generator
 
 			bool written = false;
 			foreach (var command in specTree.Elements ("commands").Elements ("command")) {
+                if (command.Attribute ("alias") != null)
+                    continue;
+
 				if (handlesCommands.Contains (ReadName (command.Element ("proto"))))
 					continue;
 

--- a/tools/Generator/Generator.cs
+++ b/tools/Generator/Generator.cs
@@ -972,7 +972,8 @@ namespace VulkanSharp.Generator
 
 				if (info.needsMarshalling) {
 					var needsInitialize = hasSType || initializeMembers.Count > 0;
-					IndentWriteLine ("internal {0}.{1}* m {{\n", InteropNamespace, csName);
+					WriteLine ();
+					IndentWriteLine ("internal {0}.{1}* m {{", InteropNamespace, csName);
 					IndentLevel++;
 					IndentWriteLine ("get {");
 					IndentLevel++;

--- a/tools/Generator/Generator.cs
+++ b/tools/Generator/Generator.cs
@@ -2190,7 +2190,7 @@ namespace VulkanSharp.Generator
                         continue;
 
                     if (ReadName (command.Element ("proto")) == alias.Value) {
-                        commandElement = command;
+                        commandElement = new XElement(command);
                         break;
                     }
 			    }
@@ -2200,6 +2200,9 @@ namespace VulkanSharp.Generator
 
                     return false;
                 }
+            
+                // clone the node in all but name
+                commandElement.Element ("proto").Element ("name").Value = function;
 
                 IndentWriteLine ("[Obsolete (\"{0} is deprecated, please use {1} instead.\")]", function, alias.Value);
             }

--- a/tools/Generator/Generator.cs
+++ b/tools/Generator/Generator.cs
@@ -1950,22 +1950,21 @@ namespace VulkanSharp.Generator
 			IndentWrite ("{0}{1}{2}{3} (", hasResult ? "result = " : "", (ignoredParameters.Count == 0 && csType != "void") ? "return " : "", delegateUnmanagedCommands.Contains (function) ? "" : string.Format ("{0}.NativeMethods.", InteropNamespace), function);
 			WriteCommandParameters (commandElement, useArrayParameters, null, null, dataParam, isForHandle && !isExtension, true, paramsDict, isExtension);
 			WriteLine (");");
-
-			if (fixedCount > 0) {
-				foreach (var param in paramsDict) {
-					if (param.Value.isFixed) {
-						IndentLevel--;
-						IndentWriteLine ("}");
-					}
-				}
-			}
-
 			if (arrayParamCount > 0)
 				foreach (var param in paramsDict) {
 					var info = param.Value;
 					if (info.len != null && firstOutParam != info && !info.isOut)
 						IndentWriteLine ("Marshal.FreeHGlobal (array{0});", info.csName);
 				}
+
+			if (fixedCount > 0)
+				foreach (var param in paramsDict) {
+					if (param.Value.isFixed) {
+						IndentLevel--;
+						IndentWriteLine ("}");
+					}
+				}
+
 			CommandHandleResult (hasResult);
 			if (firstOutParam != null && !createArray) {
 				WriteLine ();

--- a/tools/Generator/Generator.cs
+++ b/tools/Generator/Generator.cs
@@ -1922,17 +1922,18 @@ namespace VulkanSharp.Generator
 		bool WriteUnmanagedCommand (XElement commandElement)
 		{
             var alias = commandElement.Attribute ("alias");
+			string function = alias == null ? ReadName (commandElement.Element ("proto")) : ReadName (commandElement);
+
+			// todo: extensions support
+			if (requiredCommands != null) {
+				if (!requiredCommands.Contains (function))
+					return false;
+			} else if (disabledUnmanagedCommands.Contains (function))
+				return false;
+
             if (alias == null) {
-			    string function = ReadName (commandElement.Element ("proto"));
 			    string type = commandElement.Element ("proto").Element ("type").Value;
 			    string csType = GetTypeCsName (type);
-
-			    // todo: extensions support
-			    if (requiredCommands != null) {
-				    if (!requiredCommands.Contains (function))
-					    return false;
-			    } else if (disabledUnmanagedCommands.Contains (function))
-				    return false;
 
 			    // todo: function pointers
 			    if (csType.StartsWith ("PFN_"))
@@ -1947,8 +1948,6 @@ namespace VulkanSharp.Generator
 			    WriteUnmanagedCommandParameters (commandElement);
 			    WriteLine (");");
             } else {
-                string function = ReadName(commandElement);
-
                 IndentWrite("[Obsolete(\"{0} is deprecated, please use {1} instead.\", true)]", function, alias.Value);
                 if (delegateUnmanagedCommands.Contains(function))
                     IndentWrite("private unsafe delegate void {0} ();", function);

--- a/tools/Generator/Generator.cs
+++ b/tools/Generator/Generator.cs
@@ -2177,18 +2177,18 @@ namespace VulkanSharp.Generator
 
 			foreach (var element in extensions) {
 				string enumName = GetTypeCsName (element.Attribute ("extends").Value, "enum");
+				string entryName = element.Attribute ("name").Value;
+
                 var alias = element.Attribute ("alias");
-                if (alias == null) {
-				    var info = new EnumExtensionInfo { name = element.Attribute ("name").Value, value = EnumExtensionValue (element, number, ref enumName) };
-                    if (!enumExtensions.ContainsKey (enumName))
-                        enumExtensions [enumName] = new List<EnumExtensionInfo> ();
+                var info = (alias == null)
+                    ? new EnumExtensionInfo { name = entryName, value = EnumExtensionValue (element, number, ref enumName) }
+                    : new EnumExtensionInfo { name = entryName, alias = alias.Value };
+
+                // add this enum only if it is unique
+				if (!enumExtensions.ContainsKey (enumName))
+					enumExtensions [enumName] = new List<EnumExtensionInfo> ();
+                if (enumExtensions [enumName].Find ((e) => e.name == entryName) == null)
                     enumExtensions [enumName].Add (info);
-                } else {
-				    var info = new EnumExtensionInfo { name = element.Attribute ("name").Value, alias = alias.Value };
-				    if (!enumExtensions.ContainsKey (enumName))
-					    enumExtensions [enumName] = new List<EnumExtensionInfo> ();
-				    enumExtensions [enumName].Add (info);
-                }
             }
 		}
 

--- a/tools/Generator/Generator.cs
+++ b/tools/Generator/Generator.cs
@@ -1182,7 +1182,8 @@ namespace VulkanSharp.Generator
 
 				if (info.needsMarshalling) {
 					var needsInitialize = hasSType != null || initializeMembers.Count > 0;
-					IndentWriteLine ("internal {0}.{1}* m {{\n", InteropNamespace, csName);
+					WriteLine ();
+					IndentWriteLine ("internal {0}.{1}* m {{", InteropNamespace, csName);
 					IndentLevel++;
 					IndentWriteLine ("get {");
 					IndentLevel++;

--- a/tools/Generator/Generator.cs
+++ b/tools/Generator/Generator.cs
@@ -809,9 +809,6 @@ namespace VulkanSharp.Generator
 			if (csMemberType == "Bool32" && !isInterop && needsMarshalling)
 				csMemberType = "bool";
 
-            if (csMemberType == "DeviceSize" || csMemberType == "DeviceAddress")
-				csMemberType = "UInt64";
-
             bool needsCharCast = false;
 			if (csMemberType == "char") {
 				if (isInterop || !needsMarshalling)
@@ -1182,8 +1179,7 @@ namespace VulkanSharp.Generator
 
 				if (info.needsMarshalling) {
 					var needsInitialize = hasSType || initializeMembers.Count > 0;
-					WriteLine ();
-					IndentWriteLine ("internal {0}.{1}* m {{", InteropNamespace, csName);
+					IndentWriteLine ("internal {0}.{1}* m {{\n", InteropNamespace, csName);
 					IndentLevel++;
 					IndentWriteLine ("get {");
 					IndentLevel++;

--- a/tools/Generator/Generator.cs
+++ b/tools/Generator/Generator.cs
@@ -1925,7 +1925,7 @@ namespace VulkanSharp.Generator
 			if (arrayParamCount > 0)
 				foreach (var param in paramsDict) {
 					var info = param.Value;
-					if (info.len != null && firstOutParam != info) {
+					if (info.len != null && firstOutParam != info && !info.isOut) {
 						IndentWriteLine ("var array{0} = {0} == null ? IntPtr.Zero : Marshal.AllocHGlobal ({0}.Length*sizeof ({1}));", info.csName, GetParamArrayType (info));
 						IndentWriteLine ("var len{0} = {0} == null ? 0 : {0}.Length;", info.csName);
 						IndentWriteLine ("if ({0} != null)", info.csName);
@@ -1963,7 +1963,7 @@ namespace VulkanSharp.Generator
 			if (arrayParamCount > 0)
 				foreach (var param in paramsDict) {
 					var info = param.Value;
-					if (info.len != null && firstOutParam != info)
+					if (info.len != null && firstOutParam != info && !info.isOut)
 						IndentWriteLine ("Marshal.FreeHGlobal (array{0});", info.csName);
 				}
 			CommandHandleResult (hasResult);
@@ -2160,7 +2160,7 @@ namespace VulkanSharp.Generator
 			"vkCreateIOSSurfaceMVK",
 			// TODO: support fixed array of Handles
 			"vkEnumeratePhysicalDeviceGroupsKHX",
-		};
+        };
 
 		HashSet<string> delegateUnmanagedCommands = new HashSet<string> {
 			"vkCreateDebugReportCallbackEXT",

--- a/tools/Generator/Generator.cs
+++ b/tools/Generator/Generator.cs
@@ -809,9 +809,6 @@ namespace VulkanSharp.Generator
 			if (csMemberType == "Bool32" && !isInterop && needsMarshalling)
 				csMemberType = "bool";
 
-            if (csMemberType == "DeviceSize" || csMemberType == "DeviceAddress")
-				csMemberType = "UInt64";
-
             bool needsCharCast = false;
 			if (csMemberType == "char") {
 				if (isInterop || !needsMarshalling)
@@ -1031,7 +1028,8 @@ namespace VulkanSharp.Generator
             "PhysicalDeviceGroupProperties",
 			// NativeBufferAndroid uses disabled extension
 			"NativeBufferAndroid",
-		};
+            "ImportAndroidHardwareBufferInfoAndroid",
+        };
 
 		void WriteStructureInitializeMethod (List<StructMemberInfo> members, string csName, string hasSType)
 		{
@@ -1669,7 +1667,11 @@ namespace VulkanSharp.Generator
 			"CreateGraphicsPipelines",
 			"CreateComputePipelines",
 			"CreateSharedSwapchainsKHR",
-		};
+            "CreateRayTracingPipelinesNV",
+            "CmdEndTransformFeedbackEXT",
+            "CmdBeginTransformFeedbackEXT",
+            "CmdBindTransformFeedbackBuffersEXT",
+        };
 		HashSet<string> notLengthTypes = new HashSet<string> {
 			"RROutput",
 		};
@@ -2160,7 +2162,10 @@ namespace VulkanSharp.Generator
             "vkEnumeratePhysicalDeviceGroupsKHR",
             // TODO: resolve issues converting to/from `MemoryRequirements2Khr`
             "vkGetAccelerationStructureMemoryRequirementsNV",
-            // TODO: pointer to pointer (`
+            // TODO: pointer to pointer
+            // also, just disable android extensions
+            "vkGetMemoryAndroidHardwareBufferANDROID",
+            "vkGetAndroidHardwareBufferPropertiesANDROID",
         };
 
 		HashSet<string> delegateUnmanagedCommands = new HashSet<string> {

--- a/tools/Generator/Generator.cs
+++ b/tools/Generator/Generator.cs
@@ -130,9 +130,16 @@ namespace VulkanSharp.Generator
 				prefix = prefix.Substring (0, prefix.Length - 5);
 				suffix = "Bit" + suffix;
 			}
-
+            
 			if (fName.StartsWith (prefix, StringComparison.OrdinalIgnoreCase))
-				fName = fName.Substring (prefix.Length);
+                fName = fName.Substring (prefix.Length);
+
+			if (value.StartsWith (prefix, StringComparison.OrdinalIgnoreCase))
+                value = value.Substring (prefix.Length);
+
+            // likely a typo not relevant to C#, e.g. CAPABILITIES_2 <> CAPABILITIES2
+            if (fName == value)
+                return;
 
 			if (!char.IsLetter (fName [0])) {
 				switch (csEnumName) {
@@ -178,11 +185,12 @@ namespace VulkanSharp.Generator
 		{
             var valueAttr = e.Attribute ("value");
             var aliasAttr = e.Attribute ("alias");
+
             string value;
             if (valueAttr != null)
                 value = valueAttr.Value;
             else if (aliasAttr != null)
-				value = aliasAttr.Value;
+				value = TranslateCName (aliasAttr.Value);
             else
 				value = FormatFlagValue (Convert.ToInt32 (e.Attribute ("bitpos").Value));
 
@@ -197,7 +205,7 @@ namespace VulkanSharp.Generator
                 if (info.alias == null)
 				    WriteEnumField (info.name, info.value.ToString (), csEnumName);
                 else
-                    WriteEnumField (info.name, info.alias, csEnumName);
+                    WriteEnumField (info.name, TranslateCName (info.alias), csEnumName);
             }
 		}
 

--- a/tools/Generator/Generator.cs
+++ b/tools/Generator/Generator.cs
@@ -2130,6 +2130,10 @@ namespace VulkanSharp.Generator
 
 		string EnumExtensionValue (XElement element, int number, ref string csEnumName)
 		{
+			var extnumberAttribute = element.Attribute ("extnumber");
+            if (extnumberAttribute != null)
+                number = Int32.Parse (extnumberAttribute.Value);
+
 			var offsetAttribute = element.Attribute ("offset");
 			if (offsetAttribute != null) {
 				int direction = 1;
@@ -2157,7 +2161,10 @@ namespace VulkanSharp.Generator
 		void LearnExtension (XElement extensionElement)
 		{
 			var extensions = from e in extensionElement.Elements ("require").Elements ("enum") where e.Attribute ("extends") != null select e;
-			int number = Int32.Parse (extensionElement.Attribute ("number").Value);
+
+            int number = 0;
+            Int32.TryParse (extensionElement.Attribute ("number").Value, out number);
+
 			foreach (var element in extensions) {
 				string enumName = GetTypeCsName (element.Attribute ("extends").Value, "enum");
                 var alias = element.Attribute ("alias");

--- a/tools/Generator/Generator.cs
+++ b/tools/Generator/Generator.cs
@@ -176,8 +176,8 @@ namespace VulkanSharp.Generator
 
 		void WriteEnumField (XElement e, string csEnumName)
 		{
-            var valueAttr = e.Attribute("value");
-            var aliasAttr = e.Attribute("alias");
+            var valueAttr = e.Attribute ("value");
+            var aliasAttr = e.Attribute ("alias");
             string value;
             if (valueAttr != null)
                 value = valueAttr.Value;
@@ -1981,29 +1981,29 @@ namespace VulkanSharp.Generator
 			    }
 
                 if (commandElement == null) {
-                    Console.WriteLine("warning: could not find prototype for alias {0}", function);
+                    Console.WriteLine ("warning: could not find prototype for alias {0}", function);
 
                     return false;
                 }
 
-                IndentWriteLine("[Obsolete(\"{0} is deprecated, please use {1} instead.\")]", function, alias.Value);
+                IndentWriteLine ("[Obsolete (\"{0} is deprecated, please use {1} instead.\")]", function, alias.Value);
             }
 
-            string type = commandElement.Element("proto").Element("type").Value;
-            string csType = GetTypeCsName(type);
+            string type = commandElement.Element ("proto").Element ("type").Value;
+            string csType = GetTypeCsName (type);
 
             // todo: function pointers
-            if (csType.StartsWith("PFN_"))
+            if (csType.StartsWith ("PFN_"))
                 csType = "IntPtr";
 
-            if (delegateUnmanagedCommands.Contains(function))
-                IndentWrite("internal unsafe delegate {0} {1} (", csType, function);
+            if (delegateUnmanagedCommands.Contains (function))
+                IndentWrite ("internal unsafe delegate {0} {1} (", csType, function);
             else
             {
-                IndentWriteLine("[DllImport (VulkanLibrary, CallingConvention = CallingConvention.Winapi)]");
-                IndentWrite("internal static unsafe extern {0} {1} (", csType, function);
+                IndentWriteLine ("[DllImport (VulkanLibrary, CallingConvention = CallingConvention.Winapi)]");
+                IndentWrite ("internal static unsafe extern {0} {1} (", csType, function);
             }
-            WriteUnmanagedCommandParameters(commandElement);
+            WriteUnmanagedCommandParameters (commandElement);
             WriteLine(");");
 
             return true;
@@ -2187,7 +2187,7 @@ namespace VulkanSharp.Generator
 				"VK_NV_external_memory_win32",
 				"VK_NV_win32_keyed_mutex",
 			} );
-			GeneratePlatformExtension("iOS", "VK_MVK_ios_surface");
+			GeneratePlatformExtension ("iOS", "VK_MVK_ios_surface");
 		}
 
 		void WriteTypes (XmlDocument doc, XmlElement types, string elementName, TypeInfo[] typeInfo)

--- a/tools/Generator/Generator.cs
+++ b/tools/Generator/Generator.cs
@@ -163,10 +163,16 @@ namespace VulkanSharp.Generator
 			if (suffix != null) {
 				if (fName.EndsWith (suffix))
 					fName = fName.Substring (0, fName.Length - suffix.Length);
-				else if (isExtensionField && fName.EndsWith (suffix + extension))
-					fName = fName.Substring (0, fName.Length - suffix.Length - extension.Length) + extension;
-			}
-			IndentWriteLine ("{0} = {1},", fName, value);
+				else if (isExtensionField) {
+                    if (fName.EndsWith (suffix + extension))
+					    fName = fName.Substring (0, fName.Length - suffix.Length - extension.Length) + extension;
+                    if (value.EndsWith (suffix + extension))
+                        value = value.Substring (0, value.Length - suffix.Length - extension.Length) + extension;
+                }
+                if (value.EndsWith (suffix))
+                    value = value.Substring (0, value.Length - suffix.Length);
+            }
+            IndentWriteLine ("{0} = {1},", fName, value);
 
 			currentEnumInfo.members [fName] = name;
 		}

--- a/tools/Generator/Generator.cs
+++ b/tools/Generator/Generator.cs
@@ -2184,10 +2184,15 @@ namespace VulkanSharp.Generator
 
 		void LearnExtensions ()
 		{
-			var elements = from e in specTree.Elements ("extensions").Elements ("extension") where e.Attribute ("supported").Value != "disabled" select e;
+			var extensions = from e in specTree.Elements ("extensions").Elements ("extension") where e.Attribute ("supported").Value != "disabled" select e;
 
-			foreach (var element in elements)
-				LearnExtension (element);
+			foreach (var extension in extensions)
+				LearnExtension (extension);
+
+			var features = specTree.Elements ("feature");
+
+			foreach (var feature in features)
+				LearnExtension (feature);
 		}
 
 		void PrepareExtensionSets (string[] extensionNames)

--- a/tools/Generator/Generator.cs
+++ b/tools/Generator/Generator.cs
@@ -1026,9 +1026,11 @@ namespace VulkanSharp.Generator
 			"PhysicalDeviceGroupPropertiesKhx",
             "PhysicalDeviceGroupPropertiesKhr",
             "PhysicalDeviceGroupProperties",
+            "PhysicalDeviceMemoryBudgetPropertiesExt",
 			// NativeBufferAndroid uses disabled extension
 			"NativeBufferAndroid",
             "ImportAndroidHardwareBufferInfoAndroid",
+            "MetalSurfaceCreateInfoExt",
         };
 
 		void WriteStructureInitializeMethod (List<StructMemberInfo> members, string csName, string hasSType)
@@ -2166,6 +2168,8 @@ namespace VulkanSharp.Generator
             // also, just disable android extensions
             "vkGetMemoryAndroidHardwareBufferANDROID",
             "vkGetAndroidHardwareBufferPropertiesANDROID",
+            // disable metal surface creation
+            "vkCreateMetalSurfaceEXT",
         };
 
 		HashSet<string> delegateUnmanagedCommands = new HashSet<string> {

--- a/tools/Generator/Generator.cs
+++ b/tools/Generator/Generator.cs
@@ -893,6 +893,8 @@ namespace VulkanSharp.Generator
 			"ExportFenceWin32HandleInfoKhr",
 			// TODO: support fixed array of Handles
 			"PhysicalDeviceGroupPropertiesKhx",
+            "PhysicalDeviceGroupPropertiesKhr",
+            "PhysicalDeviceGroupProperties",
 			// NativeBufferAndroid uses disabled extension
 			"NativeBufferAndroid",
 		};

--- a/tools/Generator/Generator.cs
+++ b/tools/Generator/Generator.cs
@@ -134,6 +134,10 @@ namespace VulkanSharp.Generator
 			if (fName.StartsWith (prefix, StringComparison.OrdinalIgnoreCase))
                 fName = fName.Substring (prefix.Length);
 
+            // some enum entires now start with numbers, don't let them
+			if (fName[0] >= '0' && fName[0] <= '9')
+                fName = "_" + fName;
+
 			if (value.StartsWith (prefix, StringComparison.OrdinalIgnoreCase))
                 value = value.Substring (prefix.Length);
 

--- a/tools/Generator/Generator.cs
+++ b/tools/Generator/Generator.cs
@@ -803,9 +803,6 @@ namespace VulkanSharp.Generator
 			if (csMemberType.StartsWith ("PFN_"))
 				csMemberType = "IntPtr";
 
-            if (csMemberType == "CAMetalLayer" || csMemberType == "AHardwareBuffer")
-                csMemberType = "IntPtr";
-
             if (csMemberType == "SampleMask")
 				csMemberType = "UInt32";
 
@@ -1778,7 +1775,7 @@ namespace VulkanSharp.Generator
 			if (hasResult)
 				csType = "void";
 
-			ParamInfo firstOutParam = null;
+            ParamInfo firstOutParam = null;
 			ParamInfo intParam = null;
 			string outLen = null;
 			ParamInfo dataParam = null;
@@ -2161,6 +2158,9 @@ namespace VulkanSharp.Generator
 			"vkEnumeratePhysicalDeviceGroupsKHX",
             "vkEnumeratePhysicalDeviceGroups",
             "vkEnumeratePhysicalDeviceGroupsKHR",
+            // TODO: resolve issues converting to/from `MemoryRequirements2Khr`
+            "vkGetAccelerationStructureMemoryRequirementsNV",
+            // TODO: pointer to pointer (`
         };
 
 		HashSet<string> delegateUnmanagedCommands = new HashSet<string> {

--- a/tools/Generator/Generator.cs
+++ b/tools/Generator/Generator.cs
@@ -1948,13 +1948,13 @@ namespace VulkanSharp.Generator
 			    WriteUnmanagedCommandParameters (commandElement);
 			    WriteLine (");");
             } else {
-                IndentWrite("[Obsolete(\"{0} is deprecated, please use {1} instead.\", true)]", function, alias.Value);
-                if (delegateUnmanagedCommands.Contains(function))
-                    IndentWrite("private unsafe delegate void {0} ();", function);
+                IndentWriteLine ("[Obsolete(\"{0} is deprecated, please use {1} instead.\", true)]", function, alias.Value);
+                if (delegateUnmanagedCommands.Contains (function))
+                    IndentWriteLine ("private unsafe delegate void {0} ();", function);
                 else
                 {
-                    IndentWriteLine("[DllImport (VulkanLibrary, CallingConvention = CallingConvention.Winapi)]");
-                    IndentWrite("private static unsafe extern void {0} ();", function);
+                    IndentWriteLine ("[DllImport (VulkanLibrary, CallingConvention = CallingConvention.Winapi)]");
+                    IndentWriteLine ("private static unsafe extern void {0} ();", function);
                 }
             }
 

--- a/tools/Generator/GeneratorBase.cs
+++ b/tools/Generator/GeneratorBase.cs
@@ -91,6 +91,10 @@ namespace VulkanSharp.Generator
 			{ "SECURITY_ATTRIBUTES", "SecurityAttributes" },
 			{ "Display", "IntPtr" },  // this is now broken, as Handles use DisplayKHR instead of it
 			{ "RROutput", "UInt32" },
+			{ "HMONITOR", "IntPtr" },
+            // according to: https://github.com/KhronosGroup/Vulkan-Docs/blob/ad46c7dc688fe973ac7299b651403be5f562db8e/tests/ggp_c/vulkan_types.h
+            { "GgpStreamDescriptor", "int" },
+            { "GgpFrameToken", "int" },
 		};
 
 		protected static Dictionary<string, string> extensions = new Dictionary<string, string> {

--- a/tools/Generator/GeneratorBase.cs
+++ b/tools/Generator/GeneratorBase.cs
@@ -8,29 +8,34 @@ namespace VulkanSharp.Generator
 	public class GeneratorBase
 	{
 		static Dictionary<string, string> specialParts = new Dictionary<string, string> {
-			{ "AMD", "Amd" },
-			{ "API", "Api" },
-			{ "EXT", "Ext" },
-			{ "ID", "ID" },
-			{ "IOS", "IOS" },
-			{ "KHR", "Khr" },
-			{ "KHX", "Khx" },
-			{ "LOD", "LOD" },
-			{ "1D", "1D" },
-			{ "2D", "2D" },
-			{ "3D", "3D" },
-			{ "MACOS", "MacOS" },
-			{ "NV", "Nv" },
-			{ "NVX", "Nvx" },
-			{ "NN", "Nn" },
-		};
+            { "AMD", "Amd" },
+            { "API", "Api" },
+            { "EXT", "Ext" },
+            { "ID", "ID" },
+            { "IOS", "IOS" },
+            { "KHR", "Khr" },
+            { "KHX", "Khx" },
+            { "LOD", "LOD" },
+            { "1D", "1D" },
+            { "2D", "2D" },
+            { "3D", "3D" },
+            { "MACOS", "MacOS" },
+            { "NV", "Nv" },
+            { "NVX", "Nvx" },
+            { "NN", "Nn" },
+            { "ASTC", "ASTC" },
+            { "PCI", "PCI" },
+            { "AABB", "AABB" },
+            { "GGP", "GGP" },
+            { "SM", "SM" },
+        };
 
 		protected string TranslateCName (string name)
 		{
 			StringWriter sw = new StringWriter ();
 			bool first = true;
 
-			foreach (var part in name.Split ('_')) {
+            foreach (var part in name.Split ('_')) {
 				if (first) {
 					first = false;
 					if (name.StartsWith ("VK", StringComparison.OrdinalIgnoreCase))
@@ -109,9 +114,10 @@ namespace VulkanSharp.Generator
 			{ "NV", "Nv" },
 			{ "NVX", "Nvx" },
 			{ "NN", "Nn" },
+			{ "INTEL", "Intel" },
 		};
 
-		protected string GetTypeCsName (string name, string typeName = "type")
+        protected string GetTypeCsName (string name, string typeName = "type")
 		{
 			if (typesTranslation.ContainsKey (name))
 				return typesTranslation [name];

--- a/tools/Generator/GeneratorBase.cs
+++ b/tools/Generator/GeneratorBase.cs
@@ -141,9 +141,6 @@ namespace VulkanSharp.Generator
 				if (csName.EndsWith (ext.Key))
 					csName = csName.Substring (0, csName.Length - ext.Value.Length) + ext.Value;
 
-            if (csName == "CAMetalLayer" || csName == "AHardwareBuffer")
-                csName = "IntPtr";
-
             return csName;
 		}
 

--- a/tools/Generator/GeneratorBase.cs
+++ b/tools/Generator/GeneratorBase.cs
@@ -72,8 +72,9 @@ namespace VulkanSharp.Generator
 			{ "size_t", "UIntPtr" },
 			{ "xcb_connection_t", "IntPtr" },
 			{ "xcb_window_t", "IntPtr" },
-			{ "xcb_visualid_t", "Int32" },
-		};
+            { "xcb_visualid_t", "Int32" },
+            { "zx_handle_t", "UInt32" },
+        };
 
 		HashSet<string> knownTypes = new HashSet<string> {
 			"void",

--- a/tools/Generator/GeneratorBase.cs
+++ b/tools/Generator/GeneratorBase.cs
@@ -141,7 +141,10 @@ namespace VulkanSharp.Generator
 				if (csName.EndsWith (ext.Key))
 					csName = csName.Substring (0, csName.Length - ext.Value.Length) + ext.Value;
 
-			return csName;
+            if (csName == "CAMetalLayer" || csName == "AHardwareBuffer")
+                csName = "IntPtr";
+
+            return csName;
 		}
 
 		protected string GetEnumCsName (string name, bool bitmask)


### PR DESCRIPTION
Major additions:

1. `alias` attributes are parsed to generate new versions of commands/structs/enums pointing at the old versions.  Usually when an extension has been moved in to the main spec.  Also deprecates the old version.  Commands will give a warning, structs are implicitly converted, enums reference each other.

Examples:

```cs
public void CmdSetDeviceMask (UInt32 deviceMask)
{
	unsafe {
		Interop.NativeMethods.vkCmdSetDeviceMask (this.m, deviceMask);
	}
}

[Obsolete ("CmdSetDeviceMaskKHR is deprecated, please use CmdSetDeviceMask instead.")]
public void CmdSetDeviceMaskKHR (UInt32 deviceMask)
{
	unsafe {
		Interop.NativeMethods.vkCmdSetDeviceMaskKHR (this.m, deviceMask);
	}
}
```

```cs
public enum StructureType : int
{
	...
	PhysicalDeviceBufferDeviceAddressFeaturesExt = 1000244000,
	PhysicalDeviceBufferAddressFeaturesExt = PhysicalDeviceBufferDeviceAddressFeaturesExt,
	...
}
```

```cs
unsafe public partial class PhysicalDeviceFeatures2Khr : PhysicalDeviceFeatures2
{
	public PhysicalDeviceFeatures2Khr () : base () {
	}

	internal PhysicalDeviceFeatures2Khr (NativePointer pointer) : base (pointer) {
	}
}
```

2. `feature` tags are now parsed in much the same way as `extension` tags.

3. `extnumber` attributes are optionally used for determining enum values.

4. Added a few more basic types: `zx_handle_t`, `DeviceAddress`, `HMONITOR`, `GgpStreamDescriptor`, and `GgpFrameToken`.

5. Recognise the `INTEL` vendor suffix.

6. Currently just disables several android- and metal-specific extensions, as they couldn't be generated correctly.

7. Also disables a few commands that needed pointers to pointers, and fixed pointer arrays (was already listed as `TODO` in the generator before I touched anything, so this isn't actually a change).

8. Now pulls the latest `vk.xml` file from the Vulkan docs, not just pinned to 1.0.